### PR TITLE
feat(bzlmod): prepare upstream module for downstream consumption

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
-# Attic Cache - Bazel Configuration
-# =================================
+# Attic IaC - Bazel Configuration
+# ================================
 
 # Build settings
 build --jobs=auto
@@ -12,7 +12,7 @@ build --incompatible_enable_cc_toolchain_resolution
 common --enable_bzlmod
 
 # Disk cache for local builds
-build --disk_cache=~/.cache/bazel/attic-cache
+build --disk_cache=~/.cache/bazel/attic-iac
 
 # =============================================================================
 # Nix Integration
@@ -29,8 +29,19 @@ build --experimental_remote_cache_async
 # Guard against concurrent changes during builds
 build --experimental_guard_against_concurrent_changes
 
-# Remote cache (to be configured with Attic/S3)
-# build --remote_cache=grpc://cache.example.com:9092
+# =============================================================================
+# Remote Cache Configuration
+# =============================================================================
+# Downstream modules should define their own remote cache endpoints.
+# Example configs:
+#   build:ci-internal --remote_cache=grpc://bazel-cache.example.local:9092
+#   build:remote --remote_cache=grpcs://bazel-cache.example.com:443
+
+# Read-only: For builds that should only read from cache
+build:cache-readonly --remote_upload_local_results=false
+
+# Disable remote cache (for debugging)
+build:no-remote-cache --remote_cache=
 
 # Test settings
 test --test_output=errors
@@ -53,6 +64,10 @@ build:ci --disk_cache=
 build:ci --color=yes
 build:ci --curses=no
 test:ci --test_output=all
+
+# CI with remote cache (configure remote cache endpoint separately)
+# Usage: bazel build --config=ci-cached //...
+build:ci-cached --config=ci
 
 # Platform-specific settings (containers built via Nix, not rules_oci)
 # build:linux --platforms=@platforms//os:linux

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-# Attic Cache - Root BUILD file
+# Attic IaC - Root BUILD file
 
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
@@ -7,8 +7,9 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 # Package visibility
 package(default_visibility = ["//visibility:public"])
 
-# Export Kubernetes manifests for validation
+# Export files needed by sub-packages and downstream modules
 exports_files([
+    "MODULE.bazel",
     "flake.nix",
     "flake.lock",
 ])
@@ -28,12 +29,6 @@ filegroup(
     ] + glob(["nix/**/*.nix"]),
 )
 
-# Filegroup for GitLab CI configuration
-filegroup(
-    name = "gitlab_ci",
-    srcs = glob([".gitlab-ci.yml", ".gitlab/ci/**/*.yml"]),
-)
-
 # Filegroup for OpenTofu configuration
 filegroup(
     name = "tofu_files",
@@ -44,7 +39,6 @@ filegroup(
 pkg_tar(
     name = "deployment_bundle",
     srcs = [
-        ":gitlab_ci",
         ":k8s_manifests",
         ":nix_files",
     ],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,11 +1,14 @@
-"""Attic Cache - Bazel Module Configuration
+"""Attic IaC - Bazel Module Configuration
 
-Bazel is used for validation and artifact bundling.
-Nix handles all binary builds and container images.
+Generic infrastructure-as-code modules, SvelteKit app, and build rules.
+Bazel handles validation, artifact bundling, and toolchain management.
+Nix handles binary builds and container images via rules_nixpkgs.
+
+This module can be consumed by downstream Bazel modules via bazel_dep().
 """
 
 module(
-    name = "attic-cache",
+    name = "attic-iac",
     version = "0.1.0",
 )
 


### PR DESCRIPTION
## Summary

- Module renamed from `attic-cache` to `attic-iac` in MODULE.bazel for clarity as a shared upstream infrastructure module
- MODULE.bazel added to `exports_files` so downstream modules can reference it via `bazel_dep(name = "attic-iac")`
- Bates-specific remote cache URLs removed from `.bazelrc` (these move to the private overlay)
- `gitlab_ci` filegroup removed from BUILD.bazel (CI/CD config moves to the private overlay repo)
- Enables downstream modules to consume via `bazel_dep(name = "attic-iac")`

## Test plan

- [ ] Verify `bazel build //...` succeeds in the upstream repo with no Bates-specific references
- [ ] Verify a downstream MODULE.bazel can declare `bazel_dep(name = "attic-iac", ...)` and resolve targets
- [ ] Confirm `.bazelrc` contains no institution-specific remote cache URLs
- [ ] Confirm `exports_files` includes MODULE.bazel for downstream visibility

