### PR TITLE
feat(bzlmod): rename module to attic-iac for downstream consumption

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-# Attic Cache - Bazel Configuration
+# Attic IaC - Bazel Configuration
 # =================================
 
 # Build settings
@@ -12,7 +12,7 @@ build --incompatible_enable_cc_toolchain_resolution
 common --enable_bzlmod
 
 # Disk cache for local builds
-build --disk_cache=~/.cache/bazel/attic-cache
+build --disk_cache=~/.cache/bazel/attic-iac
 
 # =============================================================================
 # Nix Integration

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-# Attic Cache - Root BUILD file
+# Attic IaC - Root BUILD file
 
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 
 # Export Kubernetes manifests for validation
 exports_files([
+    "MODULE.bazel",
     "flake.nix",
     "flake.lock",
 ])
@@ -28,12 +29,6 @@ filegroup(
     ] + glob(["nix/**/*.nix"]),
 )
 
-# Filegroup for GitLab CI configuration
-filegroup(
-    name = "gitlab_ci",
-    srcs = glob([".gitlab-ci.yml", ".gitlab/ci/**/*.yml"]),
-)
-
 # Filegroup for OpenTofu configuration
 filegroup(
     name = "tofu_files",
@@ -44,7 +39,6 @@ filegroup(
 pkg_tar(
     name = "deployment_bundle",
     srcs = [
-        ":gitlab_ci",
         ":k8s_manifests",
         ":nix_files",
     ],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,11 +1,11 @@
-"""Attic Cache - Bazel Module Configuration
+"""Attic IaC - Bazel Module Configuration
 
 Bazel is used for validation and artifact bundling.
 Nix handles all binary builds and container images.
 """
 
 module(
-    name = "attic-cache",
+    name = "attic-iac",
     version = "0.1.0",
 )
 


### PR DESCRIPTION
## Summary
- Rename Bazel module from `attic-cache` to `attic-iac` so downstream private overlays can `bazel_dep(name = "attic-iac")`
- Add `MODULE.bazel` to `exports_files` for overlay repository rule path resolution
- Remove `gitlab_ci` filegroup from root BUILD (CI config belongs in org-specific overlays)
- Update `.bazelrc` disk cache path to match new module name

## Context
This prepares the upstream module for consumption by private overlay repos via Bzlmod's `local_path_override` / `git_override`. The overlay repo (`attic-cache-bates`) layers org-specific configs on top.

## Test plan
- [ ] `bazel build //...` succeeds standalone
- [ ] `bazel mod graph` resolves correctly
- [ ] Private overlay resolves `@attic-iac//...` via `local_path_override`
- [ ] No org-specific references remain in upstream