### PR TITLE
fix(app): fix container build for pnpm workspace structure

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,50 @@
+name: Build Runner Dashboard Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "app/**"
+      - "config/**"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "package.json"
+      - ".npmrc"
+      - "app/Dockerfile"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and Push to GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: app/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jesssullivan/runner-dashboard:latest
+            ghcr.io/jesssullivan/runner-dashboard:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/Jesssullivan/attic-iac
+            org.opencontainers.image.description=Runner Dashboard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   create-release:
@@ -60,25 +61,29 @@ jobs:
           prerelease: false
 
   build-container:
-    name: Build Runner Dashboard Container
+    name: Build and Push Runner Dashboard Container
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build container
-        run: |
-          cd app
-          docker build -t attic-runner-dashboard:${{ github.ref_name }} .
-
-      - name: Save container
-        run: |
-          docker save attic-runner-dashboard:${{ github.ref_name }} | gzip > runner-dashboard-${{ github.ref_name }}.tar.gz
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
-          name: runner-dashboard-container
-          path: runner-dashboard-${{ github.ref_name }}.tar.gz
+          context: .
+          file: app/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jesssullivan/runner-dashboard:${{ github.ref_name }}
+            ghcr.io/jesssullivan/runner-dashboard:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,30 +1,33 @@
 FROM node:22-alpine AS builder
-
-WORKDIR /app
+WORKDIR /workspace
 RUN corepack enable pnpm
 
-COPY package.json pnpm-lock.yaml ./
+# Workspace root files (lockfile, workspace config)
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml .npmrc ./
+COPY app/package.json app/
+
 RUN pnpm install --frozen-lockfile
 
-COPY . .
+# App source + config for prebuild
+COPY app/ app/
+COPY config/ config/
+
+WORKDIR /workspace/app
 RUN pnpm build
 RUN pnpm prune --prod
 
+# --- Production ---
 FROM node:22-alpine
-
 WORKDIR /app
 RUN apk add --no-cache ca-certificates
 
-COPY --from=builder /app/build build/
-COPY --from=builder /app/node_modules node_modules/
-COPY --from=builder /app/package.json .
+COPY --from=builder /workspace/app/build build/
+COPY --from=builder /workspace/app/node_modules node_modules/
+COPY --from=builder /workspace/app/package.json .
 
-ENV NODE_ENV=production
-ENV PORT=3000
+ENV NODE_ENV=production PORT=3000
 EXPOSE 3000
-
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:3000/api/health || exit 1
-
 USER node
 CMD ["node", "build/index.js"]

--- a/app/scripts/generate-environments.ts
+++ b/app/scripts/generate-environments.ts
@@ -6,7 +6,7 @@
  * that the runner dashboard can import for environment-specific settings.
  */
 
-import { readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, copyFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { parse } from 'yaml';
@@ -66,8 +66,19 @@ function generateLabel(cluster: OrganizationConfig['clusters'][0]): string {
 
 async function main() {
 	try {
-		// Read organization.yaml from parent directory
+		// Read organization.yaml from parent directory, fall back to example
 		const orgConfigPath = resolve(__dirname, '../../config/organization.yaml');
+		const exampleConfigPath = resolve(__dirname, '../../config/organization.example.yaml');
+
+		if (!existsSync(orgConfigPath)) {
+			if (existsSync(exampleConfigPath)) {
+				console.log(`organization.yaml not found, using example config`);
+				copyFileSync(exampleConfigPath, orgConfigPath);
+			} else {
+				throw new Error('Neither organization.yaml nor organization.example.yaml found');
+			}
+		}
+
 		console.log(`Reading organization config from: ${orgConfigPath}`);
 
 		const orgConfigYaml = readFileSync(orgConfigPath, 'utf-8');


### PR DESCRIPTION
## Summary
- Rewrite `app/Dockerfile` to build from repo root context (fixes broken `COPY pnpm-lock.yaml`)
- Prebuild script (`generate-environments.ts`) falls back to example config when `organization.yaml` is missing
- New `build-image.yml` workflow builds and pushes to GHCR on main branch pushes
- `release.yml` updated to push versioned + latest tags to GHCR instead of saving artifacts
- Nix `runnerDashboard` derivation source filter now includes workspace root files

## Context
All three container build paths (Dockerfile, Nix, GitHub Actions) were broken because the pnpm workspace lockfile lives at the repo root, not in `app/`. This caused `pnpm install --frozen-lockfile` to fail in every CI context.

## Test plan
- [ ] GitHub Actions `build-image.yml` workflow runs successfully on merge
- [ ] GHCR image `ghcr.io/jesssullivan/runner-dashboard:latest` is pushed
- [ ] `release.yml` build-container job pushes versioned tag on next release