### PR TITLE
feat: GHCR auth, runtime config, and rules_img containers

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -69,7 +69,7 @@ test:ci --test_output=all
 # Usage: bazel build --config=ci-cached //...
 build:ci-cached --config=ci
 
-# Platform-specific settings (containers built via Nix, not rules_oci)
+# Platform-specific settings (containers built via rules_img (OCI) and Nix (nix2container))
 # build:linux --platforms=@platforms//os:linux
 # build:macos --platforms=@platforms//os:macos
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,6 +60,24 @@ node.toolchain(
 )
 
 # =============================================================================
+# Container Image Rules (rules_img)
+# =============================================================================
+# OCI container image building: layer creation, manifest assembly, and push.
+# Used alongside Nix container builds (nix2container) for the Dashboard image.
+
+bazel_dep(name = "rules_img", version = "0.3.4")
+
+img = use_extension("@rules_img//img:extensions.bzl", "img")
+img.pull(
+    name = "node22_alpine",
+    registry = "docker.io",
+    repository = "library/node",
+    tag = "22-alpine",
+    platforms = ["linux/amd64"],
+)
+use_repo(img, "node22_alpine")
+
+# =============================================================================
 # rules_nixpkgs - Nix Toolchain Integration
 # =============================================================================
 # Provides reproducible toolchains from Nix for Bazel builds.
@@ -123,10 +141,13 @@ use_repo(nix_pkg, "kubectl", "tofu", "yq")
 # =============================================================================
 #
 # This module supports both IaC validation and the Runner Dashboard app.
-# Binary builds (Attic server, containers) are handled by Nix:
+# Binary builds (Attic server) are handled by Nix:
 #   - nix build .#attic
 #   - nix build .#container
-#   - nix build .#runner-dashboard
+#
+# Container images can be built via rules_img (OCI) or Nix (nix2container):
+#   - bazel build //app:image     (rules_img)
+#   - bazel run //app:push        (push to GHCR)
 #   - nix build .#runner-dashboard-image
 #
 # Bazel focuses on:
@@ -135,6 +156,7 @@ use_repo(nix_pkg, "kubectl", "tofu", "yq")
 # 3. Bundling deployment artifacts (//:deployment_bundle)
 # 4. Running configuration tests (//tests:*)
 # 5. Building the Runner Dashboard SvelteKit app (//app:build)
+# 6. Building OCI container images (//app:image)
 #
 # Remote caching via bazel-remote (when deployed):
 #   bazel build --config=ci-cached //...

--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_run_binary", "js_run_devserver")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@rules_img//img:defs.bzl", "image_layer", "image_manifest", "image_push")
 
 # Link all npm packages into this workspace
 npm_link_all_packages(name = "node_modules")
@@ -32,6 +33,51 @@ js_run_binary(
     tool = ":node_modules/vite/bin/vite.js",
     visibility = ["//visibility:public"],
 )
+
+# =============================================================================
+# Container Image (OCI via rules_img)
+# =============================================================================
+
+# App layer: built SvelteKit output
+image_layer(
+    name = "app_layer",
+    srcs = {
+        "/app/build": ":build",
+        "/app/package.json": "package.json",
+    },
+)
+
+# Production image
+image_manifest(
+    name = "image",
+    base = "@node22_alpine",
+    layers = [":app_layer"],
+    entrypoint = ["/usr/local/bin/node"],
+    cmd = ["/app/build/index.js"],
+    env = {
+        "NODE_ENV": "production",
+        "PORT": "3000",
+    },
+    ports = ["3000/tcp"],
+    workdir = "/app",
+    user = "1000",
+    labels = {
+        "org.opencontainers.image.source": "https://github.com/Jesssullivan/attic-iac",
+    },
+)
+
+# Push to GHCR (run with: bazel run //app:push)
+image_push(
+    name = "push",
+    image = ":image",
+    registry = "ghcr.io",
+    repository = "jesssullivan/runner-dashboard",
+    tag = "latest",
+)
+
+# =============================================================================
+# Development
+# =============================================================================
 
 # Development server
 js_run_devserver(

--- a/app/src/lib/server/config.ts
+++ b/app/src/lib/server/config.ts
@@ -1,0 +1,19 @@
+import { readFileSync, existsSync } from 'fs';
+import { env } from '$env/dynamic/private';
+import type { EnvironmentConfig } from '$lib/types/environment';
+import fallbackConfig from '$lib/config/environments.json';
+
+let cachedEnvironments: EnvironmentConfig[] | null = null;
+
+export function getEnvironments(): EnvironmentConfig[] {
+	if (cachedEnvironments) return cachedEnvironments;
+
+	const configPath = env.ENVIRONMENTS_CONFIG_PATH || '';
+	if (configPath && existsSync(configPath)) {
+		const raw = readFileSync(configPath, 'utf-8');
+		cachedEnvironments = JSON.parse(raw);
+	} else {
+		cachedEnvironments = fallbackConfig as EnvironmentConfig[];
+	}
+	return cachedEnvironments!;
+}

--- a/app/src/lib/stores/environment.ts
+++ b/app/src/lib/stores/environment.ts
@@ -1,25 +1,39 @@
-import type { Environment } from "$lib/types";
-import environmentsConfig from "$lib/config/environments.json";
+import type { EnvironmentConfig } from "$lib/types";
+import { buildEnvironmentLookups } from "$lib/types/environment";
 
-let currentEnv = $state<Environment>("dev");
+let configs = $state<EnvironmentConfig[]>([]);
+let currentEnv = $state<string>("dev");
 
-export function getEnvironment(): Environment {
-  return currentEnv;
+export function initEnvironments(envConfigs: EnvironmentConfig[]) {
+	configs = envConfigs;
+	if (envConfigs.length > 0 && !envConfigs.some((e) => e.name === currentEnv)) {
+		currentEnv = envConfigs[0].name;
+	}
 }
 
-export function setEnvironment(env: Environment) {
-  currentEnv = env;
+export function getEnvironment(): string {
+	return currentEnv;
+}
+
+export function setEnvironment(env: string) {
+	currentEnv = env;
 }
 
 export const environment = {
-  get current() {
-    return currentEnv;
-  },
-  set current(env: Environment) {
-    currentEnv = env;
-  },
-  get domain() {
-    const config = environmentsConfig.find(e => e.name === currentEnv);
-    return config?.domain ?? '';
-  },
+	get current() {
+		return currentEnv;
+	},
+	set current(env: string) {
+		currentEnv = env;
+	},
+	get domain() {
+		const config = configs.find((e) => e.name === currentEnv);
+		return config?.domain ?? "";
+	},
+	get configs() {
+		return configs;
+	},
+	get lookups() {
+		return buildEnvironmentLookups(configs);
+	},
 };

--- a/app/src/lib/types/environment.ts
+++ b/app/src/lib/types/environment.ts
@@ -1,9 +1,3 @@
-// Generated environment configuration
-// This file loads environment configs from the generated environments.json
-// which is created from config/organization.yaml during the prebuild step
-
-import environmentsJson from '../config/environments.json';
-
 // Environment configuration interface
 export interface EnvironmentConfig {
 	name: string;
@@ -16,32 +10,19 @@ export interface EnvironmentConfig {
 	context: string;
 }
 
-// Load environments from generated JSON
-const environments = environmentsJson as EnvironmentConfig[];
-
-// Export environment names as const array
-export const ENVIRONMENTS = environments.map((env) => env.name) as string[];
-export type Environment = (typeof ENVIRONMENTS)[number];
-
-// Generate lookup records from the environment configs
-export const ENV_LABELS: Record<string, string> = Object.fromEntries(
-	environments.map((env) => [env.name, env.label])
-);
-
-export const ENV_DOMAINS: Record<string, string> = Object.fromEntries(
-	environments.map((env) => [env.name, env.domain])
-);
-
-export const ENVIRONMENT_CONFIGS: Record<string, EnvironmentConfig> = Object.fromEntries(
-	environments.map((env) => [env.name, env])
-);
-
-// Helper function to get environment config by name
-export function getEnvironmentConfig(name: string): EnvironmentConfig | undefined {
-	return ENVIRONMENT_CONFIGS[name];
+// Build lookup records from environment config array
+export function buildEnvironmentLookups(configs: EnvironmentConfig[]) {
+	const names = configs.map((env) => env.name);
+	const labels: Record<string, string> = Object.fromEntries(
+		configs.map((env) => [env.name, env.label])
+	);
+	const domains: Record<string, string> = Object.fromEntries(
+		configs.map((env) => [env.name, env.domain])
+	);
+	const byName: Record<string, EnvironmentConfig> = Object.fromEntries(
+		configs.map((env) => [env.name, env])
+	);
+	return { names, labels, domains, byName };
 }
 
-// Helper function to check if an environment name is valid
-export function isValidEnvironment(name: string): name is Environment {
-	return ENVIRONMENTS.includes(name);
-}
+export type Environment = string;

--- a/app/src/routes/+layout.server.ts
+++ b/app/src/routes/+layout.server.ts
@@ -1,7 +1,9 @@
 import type { LayoutServerLoad } from "./$types";
+import { getEnvironments } from "$lib/server/config";
 
 export const load: LayoutServerLoad = async ({ locals }) => {
   return {
     user: locals.user ?? null,
+    environments: getEnvironments(),
   };
 };

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -3,8 +3,15 @@
 	import type { Snippet } from 'svelte';
 	import Sidebar from '$lib/components/nav/Sidebar.svelte';
 	import Breadcrumb from '$lib/components/nav/Breadcrumb.svelte';
+	import { initEnvironments } from '$lib/stores/environment';
 
-	let { children }: { children: Snippet } = $props();
+	let { data, children }: { data: any; children: Snippet } = $props();
+
+	$effect(() => {
+		if (data.environments) {
+			initEnvironments(data.environments);
+		}
+	});
 </script>
 
 <div class="h-full flex">

--- a/tofu/modules/runner-dashboard/variables.tf
+++ b/tofu/modules/runner-dashboard/variables.tf
@@ -258,3 +258,36 @@ variable "node_selector" {
   type        = map(string)
   default     = {}
 }
+
+# =============================================================================
+# Container Registry Authentication
+# =============================================================================
+
+variable "image_pull_secret_name" {
+  description = "Name of imagePullSecret for private container registry (auto-created when ghcr_token is set)"
+  type        = string
+  default     = ""
+}
+
+variable "ghcr_token" {
+  description = "GitHub PAT with read:packages scope for GHCR pull"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "ghcr_username" {
+  description = "GitHub username for GHCR auth"
+  type        = string
+  default     = ""
+}
+
+# =============================================================================
+# Runtime Environment Configuration
+# =============================================================================
+
+variable "environments_config" {
+  description = "JSON content for environments.json ConfigMap (empty = use build-time default)"
+  type        = string
+  default     = ""
+}

--- a/tofu/stacks/runner-dashboard/main.tf
+++ b/tofu/stacks/runner-dashboard/main.tf
@@ -83,6 +83,14 @@ module "runner_dashboard" {
 
   # Additional env vars
   environment_variables = var.environment_variables
+
+  # Container registry auth
+  image_pull_secret_name = var.image_pull_secret_name
+  ghcr_token             = var.ghcr_token
+  ghcr_username          = var.ghcr_username
+
+  # Runtime environment config
+  environments_config = var.environments_config
 }
 
 # =============================================================================

--- a/tofu/stacks/runner-dashboard/variables.tf
+++ b/tofu/stacks/runner-dashboard/variables.tf
@@ -205,3 +205,36 @@ variable "enable_prometheus_scrape" {
   type        = bool
   default     = true
 }
+
+# =============================================================================
+# Container Registry Authentication
+# =============================================================================
+
+variable "image_pull_secret_name" {
+  description = "Name of imagePullSecret for private container registry"
+  type        = string
+  default     = ""
+}
+
+variable "ghcr_token" {
+  description = "GitHub PAT with read:packages scope for GHCR pull"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "ghcr_username" {
+  description = "GitHub username for GHCR auth"
+  type        = string
+  default     = ""
+}
+
+# =============================================================================
+# Runtime Environment Configuration
+# =============================================================================
+
+variable "environments_config" {
+  description = "JSON content for environments.json ConfigMap (empty = use build-time default)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Add `imagePullSecrets` support for private GHCR registry (auto-creates `dockerconfigjson` secret from `ghcr_token` + `ghcr_username` variables)
- Add runtime environments ConfigMap: overlays provide org-specific `environments.json` mounted into pod, SvelteKit reads at server startup via `$env/dynamic/private`
- Refactor environment store to initialize from server layout data instead of static build-time import
- Add `rules_img` v0.3.4 for OCI container builds (`image_layer`, `image_manifest`, `image_push` targets in `app/BUILD.bazel`)

## Changes

### Track 1: GHCR Authenticated Pull
- `tofu/modules/runner-dashboard/variables.tf`: Add `image_pull_secret_name`, `ghcr_token`, `ghcr_username`
- `tofu/modules/runner-dashboard/main.tf`: Add `kubernetes_secret.ghcr_auth` (dockerconfigjson), `image_pull_secrets` in deployment spec
- Stack pass-through in `tofu/stacks/runner-dashboard/`

### Track 2: Runtime Environment Config
- New `app/src/lib/server/config.ts`: Reads from ConfigMap file path or falls back to build-time JSON
- `app/src/routes/+layout.server.ts`: Exposes environments in server load data
- `app/src/lib/stores/environment.ts`: Initializes from layout data
- `tofu/modules/runner-dashboard/main.tf`: Conditional ConfigMap + volume mount

### Track 3: rules_img Container Builds
- `MODULE.bazel`: Add `rules_img` v0.3.4 + `node22_alpine` base image pull
- `app/BUILD.bazel`: Add `image_layer`, `image_manifest`, `image_push` targets
- `.bazelrc`: Update container build comment

## Test plan
- [x] `pnpm check`: 0 errors, 5 warnings (same as before)
- [x] `pnpm test`: 78 tests pass (9 files)
- [x] `tofu validate` on runner-dashboard module: success
- [ ] `bazel build //app:image` (requires rules_img fetch)
- [ ] Overlay pipeline green after merge