### PR TITLE
feat: GloriousFlywheel documentation overhaul and docs site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,11 @@
-name: Deploy to GitHub Pages
+name: Deploy Docs
 
 on:
   push:
     branches: [main]
+    paths:
+      - docs/**
+      - docs-site/**
   workflow_dispatch:
 
 permissions:
@@ -15,43 +18,39 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm --filter glorious-flywheel-docs build
+        env:
+          DOCS_BASE_PATH: /attic-iac
+
+      - uses: actions/configure-pages@v4
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-site/build
+
   deploy:
+    needs: build
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
-      - name: Create index
-        run: |
-          cat > index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <meta charset="utf-8">
-            <title>Attic IaC Documentation</title>
-          </head>
-          <body>
-            <h1>Attic IaC Documentation</h1>
-            <p>LLM-optimized documentation (no human-readable formatting).</p>
-            <ul>
-              <li><a href="llms.txt">llms.txt</a> - Plain text documentation</li>
-              <li><a href="llms.md">llms.md</a> - Markdown documentation</li>
-            </ul>
-          </body>
-          </html>
-          EOF
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: "."
-
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -99,8 +99,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,7 @@
+config:
+  line-length: false
+  single-h1: false
+  no-bare-urls: false
+  blanks-around-fences: false
+  no-trailing-punctuation: false
+  fenced-code-language: false

--- a/README.md
+++ b/README.md
@@ -1,395 +1,128 @@
-# Attic Cache - Self-Hosted Nix Binary Cache Infrastructure
+# GloriousFlywheel (attic-iac)
 
-Self-hosted [Attic](https://github.com/zhaofengli/attic) Nix binary cache with auto-scaled GitLab runner fleet and GitOps management dashboard. Deploy to any Kubernetes cluster using OpenTofu and the GitLab Kubernetes Agent.
+Self-deploying infrastructure that builds, caches, and monitors itself.
 
-**Features**:
-
-- Attic binary cache with S3/MinIO storage
-- Auto-scaled GitLab runners (Docker, Nix, DinD, Rocky)
-- Real-time monitoring dashboard with drift detection
-- GitLab OAuth authentication
-- CloudNativePG for HA PostgreSQL
-- Horizontal Pod Autoscaling (HPA) for all services
-- Optional Bazel remote cache
-- Prometheus ServiceMonitor integration
-
-## Quick Start
-
-**Prerequisites**: Kubernetes 1.24+, kubectl, OpenTofu, GitLab with Kubernetes Agent
-
-```bash
-# 1. Configure your organization
-cp config/organization.example.yaml config/organization.yaml
-# Edit with your GitLab group, cluster contexts, domains
-
-# 2. Set up secrets
-cp .env.example .env
-# Add TF_HTTP_PASSWORD (GitLab PAT)
-
-# 3. Deploy
-just tofu-plan attic
-just tofu-apply attic
-
-# 4. Verify
-curl https://attic-cache.{your-domain}/nix-cache-info
+```mermaid
+graph LR
+    R[Runners] -->|"tofu apply"| R
+    R -->|deploy| AC[Attic Cache]
+    AC -->|accelerates| NB[Nix Builds]
+    NB -->|"executed by"| R
+    R -->|deploy| D[Dashboard]
+    D -->|monitors| R
+    AC -->|"caches its own derivations"| AC
+    RB[RenovateBot] -->|"version bump PRs"| PIPE[CI Pipeline]
+    PIPE -->|"executed by"| R
 ```
 
-See **[Quick Start Guide](docs/quick-start.md)** for detailed setup instructions.
+## What is this?
+
+A set of OpenTofu modules, Nix packages, and a SvelteKit monitoring dashboard that
+form a recursive infrastructure system. GitLab runners deploy themselves, the Nix
+binary cache caches its own derivations, and RenovateBot keeps dependencies current --
+all running on infrastructure managed by this code.
 
 ## Architecture
 
-```
-                      GitLab CI/CD
-  validate ──> build ──> deploy ──> verify
-     │            │
-     │ (parallel) │ needs: [] (greedy)
-     │            │
-     │            ├── nix build → Attic push ─┐
-     │            └── bazel build ─────────────┤ Cache flywheel
-     │                                         │
-     │            ┌────────────────────────────┘
-     │            ▼
-     │     ┌─────────────┐
-     │     │ Attic Cache  │  ← subsequent builds pull from here
-     │     │  (cluster)   │    60+ min → <5 min
-     │     └─────────────┘
-     │
-     └──── GitLab Kubernetes Agent
-            ┌──────────────┼──────────────┐
-            │              │              │
-            ▼              ▼              ▼
-     ┌────────────┐ ┌────────────┐ ┌────────────┐
-     │    dev     │ │  staging   │ │    prod    │
-     │  (review)  │ │  (staging) │ │(production)│
-     │  *.dev.    │ │ *.staging. │ │   *.prod.  │
-     │example.com │ │example.com │ │example.com │
-     └────────────┘ └────────────┘ └────────────┘
+Two-module Bzlmod architecture: a public upstream repository (this one) and private
+overlay repositories that add organization-specific configuration.
+
+```mermaid
+graph TD
+    subgraph upstream["attic-iac (upstream)"]
+        M[MODULE.bazel] --> TOFU[tofu/modules/]
+        M --> APP[app/]
+        M --> DOCS[docs-site/]
+    end
+    subgraph overlay["Organization Overlay"]
+        BM[MODULE.bazel] -->|"bazel_dep + local_path_override"| M
+        BM --> EXT[build/extensions.bzl]
+        EXT -->|"symlink merge"| MERGED["@attic_merged"]
+    end
 ```
 
-**Example Cluster Configuration** (customize in `config/organization.yaml`):
+## Components
 
-| Cluster | Purpose    | GitLab Agent Context    | Ingress Domain      |
-| ------- | ---------- | ----------------------- | ------------------- |
-| dev     | Dev/review | `myorg/k8s/agents:dev`  | `*.dev.example.com` |
-| prod    | Production | `myorg/k8s/agents:prod` | `*.example.com`     |
+- **Attic binary cache** -- S3/MinIO storage, CloudNativePG PostgreSQL, automatic GC
+- **GitLab runners** -- 5 types (docker, dind, rocky8, rocky9, nix) with HPA autoscaling
+- **Runner dashboard** -- SvelteKit 5 + Skeleton v4 monitoring UI with drift detection
+- **Documentation site** -- SvelteKit + mdsvex + Mermaid, deployed to GitHub/GitLab Pages
 
-## Cache Flywheel
+## Quick Start
 
-This infrastructure implements an incremental cache warming pattern that dramatically reduces CI build times:
-
-```
-Pipeline N (cold, no cache):
-  nix build .#package           ← 60+ min (compile everything from scratch)
-  attic push main result        ← push full closure to cache
-
-Pipeline N+1 (warm, watch-store active):
-  watch-store running in background
-  nix build .#package           ← <5 min (derivations pulled from cache)
-  each derivation pushed AS IT'S BUILT
-
-Pipeline N+2 (fails at minute 10):
-  watch-store running
-  nix build .#package           ← fails partway through
-  but 10 minutes of derivations are ALREADY cached
-  next pipeline picks up where this one left off
-```
-
-**How it works:**
-
-1. **Greedy builds** (`needs: []`) - Build jobs start immediately, parallel with validation
-2. **Substituter pull** - Nix configured with Attic as trusted substituter
-3. **Incremental push** - `attic watch-store` runs in background, pushing each store path as it's built
-4. **Bootstrap** - Attic client fetched from cache if available, skipped if not
-5. **Final push** - Belt-and-suspenders full closure push after build completes
-6. **Non-blocking** - All cache operations are best-effort, never fail builds
-
-See [docs/greedy-build-pattern.md](docs/greedy-build-pattern.md) for implementation details.
-
-## OpenTofu Modules
-
-15 reusable infrastructure modules for Kubernetes deployments:
-
-| Module                              | Purpose                                                     |
-| ----------------------------------- | ----------------------------------------------------------- |
-| `hpa-deployment`                    | HPA-enabled Kubernetes deployments                          |
-| `cnpg-operator` / `postgresql-cnpg` | CloudNativePG operator and PostgreSQL clusters              |
-| `minio-operator` / `minio-tenant`   | MinIO operator and S3-compatible storage                    |
-| `gitlab-runner`                     | Self-hosted GitLab Runner on K8s (HPA, PDB, ServiceMonitor) |
-| `gitlab-user-runner`                | Automated runner token lifecycle via GitLab API             |
-| `gitlab-agent-rbac`                 | RBAC for GitLab Agent ci_access impersonation               |
-| `runner-security`                   | NetworkPolicy, ResourceQuota, LimitRange                    |
-| `runner-dashboard`                  | SvelteKit GitOps dashboard deployment                       |
-| `bazel-cache`                       | Bazel remote cache with S3/MinIO backend                    |
-| `dns-record`                        | DNS record management                                       |
-
-## Infrastructure Stacks
-
-Three deployable stacks for complete infrastructure:
-
-### 1. Attic Cache (`tofu/stacks/attic/`)
-
-Deploys the complete Attic binary cache infrastructure:
-
-- **Attic API** - Stateless API server (HPA: 1-10 replicas)
-- **PostgreSQL** - CloudNativePG cluster (1 or 3 instances)
-- **Storage** - MinIO distributed or external S3
-- **Ingress** - TLS-enabled ingress with cert-manager
-- **Optional**: Bazel remote cache, cache warming CronJob
-
-**Deploy**:
+Prerequisites: Nix with flakes, kubectl, direnv
 
 ```bash
-cd tofu/stacks/attic
-ENV=dev just tofu-plan
-ENV=dev just tofu-apply
+# Enter development shell
+direnv allow
+
+# Configure your organization
+cp config/organization.example.yaml config/organization.yaml
+
+# Set up secrets
+cp .env.example .env
+# Add TF_HTTP_PASSWORD (GitLab PAT)
+
+# Deploy
+just tofu-plan attic
+just tofu-apply attic
 ```
 
-### 2. GitLab Runners (`tofu/stacks/bates-ils-runners/`)
-
-_Note: Rename to `gitlab-runners` for generic deployments_
-
-Auto-scaled runner fleet with 5 runner types:
-
-| Runner   | Image            | Isolation        | Privileged | HPA Range |
-| -------- | ---------------- | ---------------- | ---------- | --------- |
-| `docker` | `ubuntu-22.04`   | Shared namespace | No         | 1-20      |
-| `dind`   | `docker:dind`    | Shared namespace | Yes        | 1-10      |
-| `nix`    | Custom Nix image | Shared namespace | No         | 1-10      |
-| `rocky8` | `rockylinux:8`   | Per-job pods     | No         | 1-10      |
-| `rocky9` | `rockylinux:9`   | Per-job pods     | No         | 1-10      |
-
-**Features**:
-
-- HPA based on CPU/memory utilization
-- PodDisruptionBudget for graceful scaling
-- Prometheus ServiceMonitors
-- Resource quotas and limits
-- Network policies (optional)
-
-### 3. Runner Dashboard (`tofu/stacks/runner-dashboard/`)
-
-SvelteKit web application for runner management:
-
-**Features**:
-
-- Real-time runner status and metrics
-- GitLab OAuth authentication
-- Drift detection (tfvars vs Kubernetes state)
-- GitOps workflow (create MRs for config changes)
-- Server-Sent Events for live updates
-- Chart.js visualizations
-
-**Access**: `https://runner-dashboard.{your-domain}`
-
-## CI/CD Pipeline
-
-GitLab CI/CD pipeline with 4 stages:
-
-```yaml
-stages:
-  - validate # Lint, format, security scans
-  - build # Nix builds, Bazel builds, Docker images
-  - deploy # Deploy to review/staging/production
-  - verify # Health checks, smoke tests
-```
-
-**Environment mapping**:
-
-- **Review** (beehive/dev) - Merge requests
-- **Staging** (rigel/staging) - `main` branch
-- **Production** (rigel/prod) - Semver tags (`v1.2.3`)
-
-**Components published** for downstream projects:
-
-```yaml
-# In your project's .gitlab-ci.yml
-include:
-  - component: gitlab.com/yourorg/attic-iac/nix-build@main
-    inputs:
-      attic_cache: main
-      attic_server: https://attic-cache.example.com
-
-  - component: gitlab.com/yourorg/attic-iac/docker-build@main
-
-  - component: gitlab.com/yourorg/attic-iac/k8s-deploy@main
-```
+See [docs/infrastructure/quick-start.md](docs/infrastructure/quick-start.md) for the
+full deployment guide.
 
 ## Project Structure
 
 ```
-├── config/
-│   ├── organization.yaml           # Your org config (gitignored)
-│   └── organization.example.yaml   # Template
-├── tofu/
-│   ├── modules/                    # Reusable OpenTofu modules (15)
-│   └── stacks/                     # Deployable stacks (3)
-│       ├── attic/
-│       ├── bates-ils-runners/      # Rename to gitlab-runners
-│       └── runner-dashboard/
-├── app/                            # Runner dashboard (SvelteKit 5)
-│   ├── src/
-│   ├── scripts/
-│   └── tests/
-├── scripts/                        # Helper scripts
-│   ├── generate-attic-token.sh
-│   ├── validate-org-config.sh
-│   └── lib/
-├── examples/                       # CI/CD component examples
-│   ├── nix-project/
-│   ├── docker-project/
-│   └── k8s-deploy-project/
-├── docs/                           # Documentation
-│   ├── quick-start.md
-│   ├── customization-guide.md
-│   ├── greedy-build-pattern.md
-│   └── runners/                    # Runner documentation (12 files)
-├── .gitlab-ci.yml                  # Main CI/CD pipeline
-├── Justfile                        # Task runner
-├── flake.nix                       # Nix flake
-└── MODULE.bazel                    # Bazel workspace
+attic-iac/
+  app/                  # Runner dashboard (SvelteKit 5 + Skeleton v4)
+  docs/                 # Documentation (Mermaid diagrams, no ASCII art)
+  docs-site/            # Documentation site (SvelteKit + mdsvex + adapter-static)
+  tex_research/         # Research document (LaTeX)
+  tofu/
+    modules/            # Reusable OpenTofu modules
+    stacks/             # Deployment stacks
+  config/               # Organization configuration
+  k8s/                  # Kubernetes manifests
+  nix/                  # Nix packaging
+  build/                # Bazel overlay system
+  scripts/              # Build and deploy scripts
 ```
-
-## Development
-
-### Prerequisites
-
-- Nix with flakes enabled
-- direnv (recommended)
-- just (task runner)
-- pnpm (for dashboard development)
-
-### Local Setup
-
-```bash
-# Load Nix devShell
-direnv allow
-
-# Run checks
-just check
-
-# Build Nix packages
-nix build .#attic-client
-nix build .#container
-
-# Build dashboard
-cd app
-pnpm install
-pnpm dev
-```
-
-### Common Tasks
-
-```bash
-just                        # List all commands
-just check                  # Run all validations
-just tofu-plan <stack>      # Plan Tofu deployment
-just tofu-apply <stack>     # Apply Tofu deployment
-just proxy-up               # Start SOCKS proxy (if configured)
-just bk get pods            # kubectl through proxy
-```
-
-## Configuration
-
-All configuration is centralized in `config/organization.yaml`:
-
-```yaml
-organization:
-  name: myorg
-  full_name: "My Organization"
-  group_path: mygroup # GitLab group path
-
-gitlab:
-  url: https://gitlab.com
-  project_id: "12345678" # Project for Terraform state
-  agent_group: mygroup/k8s/agents
-
-clusters:
-  - name: dev
-    role: development
-    domain: dev.example.com
-    context: mygroup/k8s/agents:dev
-
-namespaces:
-  attic:
-    dev: attic-cache-dev
-    prod: attic-cache
-  runners:
-    all: gitlab-runners
-```
-
-See [Customization Guide](docs/customization-guide.md) for detailed options.
-
-## Monitoring
-
-### Prometheus Integration
-
-All services export Prometheus metrics via ServiceMonitors:
-
-- **Attic API** - Request rate, latency, cache hits
-- **PostgreSQL** - Connections, queries, replication lag
-- **MinIO** - Throughput, storage usage
-- **Runners** - Job queue depth, execution time
-
-### Runner Dashboard
-
-Real-time monitoring UI at `https://runner-dashboard.{your-domain}`:
-
-- Live runner status and metrics
-- HPA scaling visualization
-- Drift detection
-- Config management
-
-## Troubleshooting
-
-### Common Issues
-
-**Pods stuck in Pending**:
-
-```bash
-kubectl get pvc -n {namespace}
-kubectl describe pvc {name} -n {namespace}
-```
-
-**Ingress not accessible**:
-
-```bash
-kubectl get ingress -n {namespace}
-kubectl get certificate -n {namespace}
-```
-
-**PostgreSQL init failures**:
-
-```bash
-kubectl logs -n cnpg-system -l app.kubernetes.io/name=cloudnative-pg
-```
-
-See [comprehensive troubleshooting guide](docs/runners/troubleshooting.md) for more.
 
 ## Documentation
 
-- **[Quick Start Guide](docs/quick-start.md)** - Get up and running in 30 minutes
-- **[Customization Guide](docs/customization-guide.md)** - Adapt for your organization
-- **[Greedy Build Pattern](docs/greedy-build-pattern.md)** - Understanding the cache flywheel
-- **[Runners Documentation](docs/runners/)** - 12 guides covering all aspects of runner management
+Full documentation is available at the [docs site](https://jesssullivan.github.io/attic-iac/)
+or in [docs/](docs/index.md).
 
-## Contributing
+Key topics:
+- [Recursive Dogfooding](docs/architecture/recursive-dogfooding.md) -- the core concept
+- [Bzlmod Topology](docs/architecture/bzlmod-topology.md) -- two-module system
+- [Greedy Build Pattern](docs/build-system/greedy-build-pattern.md) -- build fast, cache everything
+- [Runner Selection](docs/runners/runner-selection.md) -- which runner to use
+- [OpenTofu Modules](docs/reference/tofu-modules.md) -- all modules documented
 
-Contributions welcome! Please:
+## Development
 
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Submit a pull request
+```bash
+just dev               # Start dashboard dev server
+just docs-dev          # Start docs site dev server
+just check             # Run all validations
+just app-test          # Run dashboard tests
+just tex               # Build research PDF
+```
 
-## Support
+## Creating an Overlay
 
-- **Issues**: https://github.com/Jesssullivan/attic-iac/issues
-- **Discussions**: https://github.com/Jesssullivan/attic-iac/discussions
+To deploy attic-iac for your organization:
+
+1. Create a new repository with `MODULE.bazel` declaring `bazel_dep(name = "attic-iac")`
+2. Add `local_path_override(path = "../attic-iac")` for local development
+3. Create `build/extensions.bzl` to merge upstream with your overrides
+4. Add organization-specific `config/organization.yaml` and stack tfvars
+5. Set up CI pipeline that clones upstream and runs tofu plan/apply
+
+See [docs/architecture/overlay-system.md](docs/architecture/overlay-system.md) for details.
 
 ## License
 
 Apache 2.0
-
-## Credits
-
-Originally developed for Tinyland.dev infrastructure. Open sourced for community use.

--- a/app/package.json
+++ b/app/package.json
@@ -16,23 +16,23 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@skeletonlabs/skeleton": "^3.1.3",
-    "@skeletonlabs/skeleton-svelte": "^1.2.3",
+    "@skeletonlabs/skeleton": "^4.9.0",
+    "@skeletonlabs/skeleton-svelte": "^4.12.0",
     "chart.js": "^4.4.7",
     "svelte-chartjs": "^3.1.5"
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^5.2.12",
-    "@sveltejs/kit": "^2.16.0",
-    "@sveltejs/vite-plugin-svelte": "^5.0.0",
-    "@tailwindcss/vite": "^4.0.0",
+    "@sveltejs/kit": "^2.49.0",
+    "@sveltejs/vite-plugin-svelte": "^7.0.0-next.0",
+    "@tailwindcss/vite": "^4.1.0",
     "@types/node": "^22.15.30",
-    "svelte": "^5.25.0",
+    "svelte": "^5.46.0",
     "svelte-check": "^4.0.0",
-    "tailwindcss": "^4.0.0",
+    "tailwindcss": "^4.1.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.0.0",
-    "vite": "^6.2.6",
+    "typescript": "^5.9.0",
+    "vite": "^8.0.0-beta.11",
     "vitest": "^3.0.0",
     "yaml": "^2.7.0"
   },

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+.svelte-kit/

--- a/docs-site/BUILD.bazel
+++ b/docs-site/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@aspect_rules_js//js:defs.bzl", "js_run_binary", "js_run_devserver")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+# Link all npm packages into this workspace
+npm_link_all_packages(name = "node_modules")
+
+# Source filegroup for cache invalidation
+filegroup(
+    name = "srcs",
+    srcs = glob(["src/**"]) + [
+        "package.json",
+        "svelte.config.js",
+        "mdsvex.config.js",
+        "tsconfig.json",
+        "vite.config.ts",
+    ] + glob(["static/**"]),
+)
+
+# Documentation markdown sources (from sibling docs/ directory)
+filegroup(
+    name = "docs_content",
+    srcs = glob(
+        ["../docs/**/*.md"],
+        allow_empty = True,
+    ),
+)
+
+# Production build via Vite (adapter-static output)
+js_run_binary(
+    name = "build",
+    srcs = [
+        ":node_modules",
+        ":srcs",
+        ":docs_content",
+        "//:.npmrc",
+    ],
+    args = ["build"],
+    chdir = package_name(),
+    out_dirs = ["build"],
+    tool = ":node_modules/vite/bin/vite.js",
+    visibility = ["//visibility:public"],
+)
+
+# Development server
+js_run_devserver(
+    name = "dev",
+    args = ["dev"],
+    chdir = package_name(),
+    data = [
+        ":node_modules",
+        ":srcs",
+        ":docs_content",
+    ],
+    tool = ":node_modules/vite/bin/vite.js",
+)

--- a/docs-site/mdsvex.config.js
+++ b/docs-site/mdsvex.config.js
@@ -1,0 +1,88 @@
+import rehypeSlug from 'rehype-slug';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import { escapeSvelte } from 'mdsvex';
+import { createHighlighter } from 'shiki';
+import {
+  transformerNotationDiff,
+  transformerNotationHighlight,
+  transformerNotationWordHighlight,
+  transformerNotationFocus,
+  transformerMetaHighlight
+} from '@shikijs/transformers';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const shikiHighlighter = await createHighlighter({
+  themes: ['github-light', 'github-dark-default'],
+  langs: [
+    'javascript', 'typescript', 'svelte', 'html', 'css', 'json', 'yaml', 'markdown',
+    'bash', 'shell', 'python', 'rust', 'go', 'java', 'c', 'cpp', 'sql', 'graphql',
+    'dockerfile', 'nginx', 'toml', 'xml', 'diff', 'hcl', 'nix',
+    'plaintext', 'text'
+  ]
+});
+
+/**
+ * Custom Shiki highlighter for MDsveX.
+ * Mermaid code blocks are encoded as base64 data attributes for client-side rendering.
+ */
+function highlightCode(code, lang, meta) {
+  if (lang === 'mermaid') {
+    const encoded = Buffer.from(code.trim()).toString('base64');
+    const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
+    return `<div class="mermaid-diagram my-6 not-prose" data-mermaid-code="${encoded}" data-mermaid-id="${id}"></div>`;
+  }
+
+  const language = lang || 'text';
+
+  try {
+    const html = shikiHighlighter.codeToHtml(code, {
+      lang: language,
+      themes: {
+        light: 'github-light',
+        dark: 'github-dark-default'
+      },
+      defaultColor: false,
+      transformers: [
+        transformerNotationDiff(),
+        transformerNotationHighlight(),
+        transformerNotationWordHighlight(),
+        transformerNotationFocus(),
+        transformerMetaHighlight()
+      ]
+    });
+
+    const escaped = escapeSvelte(html);
+    return `{@html \`${escaped}\`}`;
+  } catch (error) {
+    console.warn(`[mdsvex] Shiki highlighting failed for lang="${language}":`, error.message);
+    const escaped = escapeSvelte(code);
+    return `<pre><code class="language-${language}">${escaped}</code></pre>`;
+  }
+}
+
+/** @type {import('mdsvex').MdsvexOptions} */
+const config = {
+  extensions: ['.svelte.md', '.md', '.svx'],
+
+  layout: join(__dirname, 'src/lib/components/MdsvexLayout.svelte'),
+
+  rehypePlugins: [
+    rehypeSlug,
+    [rehypeAutolinkHeadings, {
+      behavior: 'wrap',
+      properties: {
+        className: ['heading-link']
+      }
+    }],
+  ],
+
+  highlight: {
+    highlighter: highlightCode
+  }
+};
+
+export default config;

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "glorious-flywheel-docs",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+  },
+  "dependencies": {
+    "@skeletonlabs/skeleton": "^4.9.0",
+    "@skeletonlabs/skeleton-svelte": "^4.12.0",
+    "mermaid": "^11.0.0"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-static": "^3.0.0",
+    "@sveltejs/kit": "^2.49.0",
+    "@sveltejs/vite-plugin-svelte": "^7.0.0-next.0",
+    "@tailwindcss/vite": "^4.1.0",
+    "@tailwindcss/typography": "^0.5.19",
+    "mdsvex": "^0.12.6",
+    "rehype-autolink-headings": "^7.0.0",
+    "rehype-slug": "^6.0.0",
+    "shiki": "^3.0.0",
+    "@shikijs/transformers": "^3.0.0",
+    "svelte": "^5.46.0",
+    "svelte-check": "^4.0.0",
+    "tailwindcss": "^4.1.0",
+    "typescript": "^5.9.0",
+    "vite": "^8.0.0-beta.11"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/docs-site/src/app.css
+++ b/docs-site/src/app.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@plugin "@tailwindcss/typography";
+
 @import "@skeletonlabs/skeleton";
 @import "@skeletonlabs/skeleton/themes/cerberus";
 
@@ -16,4 +18,12 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
+}
+
+.heading-link {
+  text-decoration: none;
+}
+
+.heading-link:hover {
+  text-decoration: underline;
 }

--- a/docs-site/src/app.d.ts
+++ b/docs-site/src/app.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="@sveltejs/kit" />
+
+declare global {
+	namespace App {
+		// interface Error {}
+		// interface Locals {}
+		// interface PageData {}
+		// interface PageState {}
+		// interface Platform {}
+	}
+}
+
+export {};

--- a/docs-site/src/app.html
+++ b/docs-site/src/app.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html data-theme="cerberus" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GloriousFlywheel</title>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/docs-site/src/lib/components/DocNav.svelte
+++ b/docs-site/src/lib/components/DocNav.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { base } from '$app/paths';
+	import DocNav from './DocNav.svelte';
+
+	interface NavItem {
+		title: string;
+		slug: string;
+		children?: NavItem[];
+	}
+
+	interface Props {
+		items: NavItem[];
+		depth?: number;
+	}
+
+	let { items, depth = 0 }: Props = $props();
+
+	function isActive(slug: string): boolean {
+		const currentPath = $page.url.pathname;
+		const itemPath = `${base}/docs/${slug}`;
+		return currentPath === itemPath || currentPath.startsWith(itemPath + '/');
+	}
+
+	function formatTitle(title: string): string {
+		return title
+			.replace(/-/g, ' ')
+			.replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+</script>
+
+<ul class="space-y-1 {depth > 0 ? 'ml-4 border-l border-surface-300 pl-3' : ''}">
+	{#each items as item}
+		<li>
+			{#if item.children && item.children.length > 0}
+				<details open={isActive(item.slug)}>
+					<summary class="cursor-pointer py-1 text-sm font-medium text-surface-600 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100">
+						{formatTitle(item.title)}
+					</summary>
+					<DocNav items={item.children} depth={depth + 1} />
+				</details>
+			{:else}
+				<a
+					href="{base}/docs/{item.slug}"
+					class="block py-1 text-sm {isActive(item.slug)
+						? 'font-medium text-primary-500'
+						: 'text-surface-600 hover:text-surface-900 dark:text-surface-400 dark:hover:text-surface-100'}"
+				>
+					{formatTitle(item.title)}
+				</a>
+			{/if}
+		</li>
+	{/each}
+</ul>

--- a/docs-site/src/lib/components/MdsvexLayout.svelte
+++ b/docs-site/src/lib/components/MdsvexLayout.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import MermaidRenderer from './MermaidRenderer.svelte';
+
+	let { children } = $props();
+</script>
+
+<MermaidRenderer />
+
+<article class="prose prose-invert max-w-none">
+	{@render children()}
+</article>

--- a/docs-site/src/lib/components/MermaidRenderer.svelte
+++ b/docs-site/src/lib/components/MermaidRenderer.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
+
+	let rendered = $state(false);
+
+	async function renderDiagrams() {
+		if (!browser) return;
+
+		const mermaid = (await import('mermaid')).default;
+		mermaid.initialize({
+			startOnLoad: false,
+			theme: 'dark',
+			securityLevel: 'loose'
+		});
+
+		const elements = document.querySelectorAll('[data-mermaid-code]');
+
+		for (const el of elements) {
+			const encoded = el.getAttribute('data-mermaid-code');
+			const id = el.getAttribute('data-mermaid-id') || `mermaid-${Math.random().toString(36).substr(2, 9)}`;
+
+			if (!encoded) continue;
+
+			try {
+				const source = atob(encoded);
+				const { svg } = await mermaid.render(id, source);
+				el.innerHTML = svg;
+				el.classList.add('mermaid-rendered');
+			} catch (err) {
+				console.warn(`Failed to render Mermaid diagram ${id}:`, err);
+				el.innerHTML = `<pre class="text-error-500">${err}</pre>`;
+			}
+		}
+
+		rendered = true;
+	}
+
+	onMount(() => {
+		renderDiagrams();
+	});
+
+	$effect(() => {
+		if (browser && !rendered) {
+			renderDiagrams();
+		}
+	});
+</script>

--- a/docs-site/src/lib/components/TableOfContents.svelte
+++ b/docs-site/src/lib/components/TableOfContents.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
+
+	interface TocEntry {
+		id: string;
+		text: string;
+		level: number;
+	}
+
+	let headings = $state<TocEntry[]>([]);
+	let activeId = $state('');
+
+	onMount(() => {
+		const elements = document.querySelectorAll('article h2, article h3');
+		headings = Array.from(elements).map((el) => ({
+			id: el.id,
+			text: el.textContent || '',
+			level: parseInt(el.tagName[1])
+		}));
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						activeId = entry.target.id;
+					}
+				}
+			},
+			{ rootMargin: '-80px 0px -80% 0px' }
+		);
+
+		elements.forEach((el) => observer.observe(el));
+
+		return () => observer.disconnect();
+	});
+</script>
+
+{#if headings.length > 0}
+	<nav class="hidden xl:block sticky top-6 w-56 shrink-0">
+		<h4 class="text-xs font-semibold uppercase text-surface-500 mb-3">On this page</h4>
+		<ul class="space-y-1 text-sm">
+			{#each headings as heading}
+				<li class="{heading.level === 3 ? 'ml-3' : ''}">
+					<a
+						href="#{heading.id}"
+						class="block py-0.5 {activeId === heading.id
+							? 'text-primary-500 font-medium'
+							: 'text-surface-500 hover:text-surface-300'}"
+					>
+						{heading.text}
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</nav>
+{/if}

--- a/docs-site/src/lib/server/docs.ts
+++ b/docs-site/src/lib/server/docs.ts
@@ -1,0 +1,141 @@
+import { readdir, readFile, stat } from 'fs/promises';
+import { join, relative, basename, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const DOCS_DIR = join(__dirname, '..', '..', '..', '..', '..', 'docs');
+
+export interface NavItem {
+	title: string;
+	slug: string;
+	order: number;
+	children?: NavItem[];
+}
+
+export interface DocPage {
+	content: string;
+	slug: string;
+	title: string;
+}
+
+function slugFromPath(filePath: string, base: string): string {
+	const rel = relative(base, filePath);
+	return rel
+		.replace(/\.md$/, '')
+		.replace(/\/index$/, '')
+		.replace(/\/README$/i, '');
+}
+
+function titleFromFilename(filename: string): string {
+	return basename(filename, '.md')
+		.replace(/^README$/i, 'Overview')
+		.replace(/^index$/, 'Overview')
+		.replace(/-/g, ' ')
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function extractFrontmatter(content: string): { title?: string; order?: number; body: string } {
+	const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+	if (!match) return { body: content };
+
+	const frontmatter: Record<string, string> = {};
+	for (const line of match[1].split('\n')) {
+		const [key, ...vals] = line.split(':');
+		if (key && vals.length) {
+			frontmatter[key.trim()] = vals.join(':').trim();
+		}
+	}
+
+	return {
+		title: frontmatter.title,
+		order: frontmatter.order ? parseInt(frontmatter.order) : undefined,
+		body: match[2]
+	};
+}
+
+async function walkDir(dir: string, base: string): Promise<NavItem[]> {
+	const items: NavItem[] = [];
+
+	let entries;
+	try {
+		entries = await readdir(dir);
+	} catch {
+		return items;
+	}
+
+	for (const entry of entries.sort()) {
+		const fullPath = join(dir, entry);
+		const s = await stat(fullPath);
+
+		if (s.isDirectory()) {
+			const children = await walkDir(fullPath, base);
+			if (children.length > 0) {
+				const indexFile = join(fullPath, 'index.md');
+				const readmeFile = join(fullPath, 'README.md');
+				let order = 50;
+
+				try {
+					const indexContent = await readFile(indexFile, 'utf-8');
+					const fm = extractFrontmatter(indexContent);
+					if (fm.order) order = fm.order;
+				} catch {
+					try {
+						const readmeContent = await readFile(readmeFile, 'utf-8');
+						const fm = extractFrontmatter(readmeContent);
+						if (fm.order) order = fm.order;
+					} catch {
+						// no index or readme
+					}
+				}
+
+				items.push({
+					title: titleFromFilename(entry),
+					slug: relative(base, fullPath),
+					order,
+					children
+				});
+			}
+		} else if (entry.endsWith('.md') && entry !== 'index.md' && entry.toUpperCase() !== 'README.MD') {
+			const content = await readFile(fullPath, 'utf-8');
+			const fm = extractFrontmatter(content);
+			items.push({
+				title: fm.title || titleFromFilename(entry),
+				slug: slugFromPath(fullPath, base),
+				order: fm.order ?? 50
+			});
+		}
+	}
+
+	items.sort((a, b) => a.order - b.order || a.title.localeCompare(b.title));
+	return items;
+}
+
+export async function getNavigation(): Promise<NavItem[]> {
+	return walkDir(DOCS_DIR, DOCS_DIR);
+}
+
+export async function getDocPage(slug: string): Promise<DocPage | null> {
+	const candidates = [
+		join(DOCS_DIR, `${slug}.md`),
+		join(DOCS_DIR, slug, 'index.md'),
+		join(DOCS_DIR, slug, 'README.md')
+	];
+
+	for (const filePath of candidates) {
+		try {
+			const content = await readFile(filePath, 'utf-8');
+			const fm = extractFrontmatter(content);
+			return {
+				content: fm.body,
+				slug,
+				title: fm.title || titleFromFilename(basename(filePath))
+			};
+		} catch {
+			continue;
+		}
+	}
+
+	return null;
+}

--- a/docs-site/src/routes/+layout.server.ts
+++ b/docs-site/src/routes/+layout.server.ts
@@ -1,0 +1,8 @@
+import { getNavigation } from '$lib/server/docs';
+
+export const prerender = true;
+
+export async function load() {
+	const navigation = await getNavigation();
+	return { navigation };
+}

--- a/docs-site/src/routes/+layout.svelte
+++ b/docs-site/src/routes/+layout.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import '../app.css';
+	import type { Snippet } from 'svelte';
+	import DocNav from '$lib/components/DocNav.svelte';
+	import { base } from '$app/paths';
+
+	let { data, children }: { data: any; children: Snippet } = $props();
+	let sidebarOpen = $state(true);
+</script>
+
+<div class="h-full flex">
+	<aside
+		class="w-64 shrink-0 overflow-y-auto border-r border-surface-300 p-4 {sidebarOpen ? '' : 'hidden'}"
+	>
+		<a href="{base}/" class="block mb-6">
+			<h1 class="text-lg font-bold">GloriousFlywheel</h1>
+			<p class="text-xs text-surface-500">attic-iac documentation</p>
+		</a>
+
+		{#if data.navigation}
+			<DocNav items={data.navigation} />
+		{/if}
+	</aside>
+
+	<main class="flex-1 overflow-auto p-8">
+		{@render children()}
+	</main>
+</div>

--- a/docs-site/src/routes/+page.svelte
+++ b/docs-site/src/routes/+page.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+</script>
+
+<svelte:head>
+	<title>GloriousFlywheel - attic-iac Documentation</title>
+</svelte:head>
+
+<div class="max-w-3xl">
+	<h1 class="text-4xl font-bold mb-4">GloriousFlywheel</h1>
+	<p class="text-lg text-surface-400 mb-8">
+		Self-deploying infrastructure that builds, caches, and monitors itself.
+	</p>
+
+	<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+		<a href="{base}/docs/architecture/recursive-dogfooding" class="block p-4 rounded-lg border border-surface-600 hover:border-primary-500 transition-colors">
+			<h3 class="font-semibold mb-1">Recursive Dogfooding</h3>
+			<p class="text-sm text-surface-400">Infrastructure that deploys itself using itself.</p>
+		</a>
+		<a href="{base}/docs/architecture/bzlmod-topology" class="block p-4 rounded-lg border border-surface-600 hover:border-primary-500 transition-colors">
+			<h3 class="font-semibold mb-1">Bzlmod Topology</h3>
+			<p class="text-sm text-surface-400">Two-module architecture with overlay merge.</p>
+		</a>
+		<a href="{base}/docs/build-system/greedy-build-pattern" class="block p-4 rounded-lg border border-surface-600 hover:border-primary-500 transition-colors">
+			<h3 class="font-semibold mb-1">Greedy Build Pattern</h3>
+			<p class="text-sm text-surface-400">Build immediately, cache incrementally, validate later.</p>
+		</a>
+		<a href="{base}/docs/infrastructure/quick-start" class="block p-4 rounded-lg border border-surface-600 hover:border-primary-500 transition-colors">
+			<h3 class="font-semibold mb-1">Quick Start</h3>
+			<p class="text-sm text-surface-400">Deploy the full stack from zero.</p>
+		</a>
+	</div>
+</div>

--- a/docs-site/src/routes/docs/[...slug]/+page.server.ts
+++ b/docs-site/src/routes/docs/[...slug]/+page.server.ts
@@ -1,0 +1,54 @@
+import { getDocPage, getNavigation } from '$lib/server/docs';
+import { compile } from 'mdsvex';
+import mdsvexConfig from '../../../../mdsvex.config.js';
+
+export const prerender = true;
+
+interface NavItem {
+	slug: string;
+	children?: NavItem[];
+}
+
+function collectLeafSlugs(items: NavItem[]): string[] {
+	const slugs: string[] = [];
+	for (const item of items) {
+		if (item.children && item.children.length > 0) {
+			slugs.push(...collectLeafSlugs(item.children));
+		} else {
+			slugs.push(item.slug);
+		}
+	}
+	return slugs;
+}
+
+export async function entries() {
+	const nav = await getNavigation();
+	const slugs = collectLeafSlugs(nav);
+	return slugs.map((slug) => ({ slug }));
+}
+
+export async function load({ params }) {
+	const slug = params.slug;
+	const page = await getDocPage(slug);
+
+	if (!page) {
+		return {
+			title: 'Not Found',
+			slug,
+			html: '',
+			error: true
+		};
+	}
+
+	const compiled = await compile(page.content, {
+		...mdsvexConfig,
+		layout: undefined
+	});
+
+	return {
+		title: page.title,
+		slug,
+		html: compiled?.code || page.content,
+		error: false
+	};
+}

--- a/docs-site/src/routes/docs/[...slug]/+page.svelte
+++ b/docs-site/src/routes/docs/[...slug]/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import TableOfContents from '$lib/components/TableOfContents.svelte';
+
+	let { data } = $props();
+</script>
+
+<svelte:head>
+	<title>{data.title} - GloriousFlywheel</title>
+</svelte:head>
+
+<div class="flex gap-8">
+	<div class="flex-1 min-w-0">
+		{#if data.error}
+			<div class="text-error-500">
+				<h1 class="text-2xl font-bold mb-2">Page not found</h1>
+				<p>The documentation page <code>{data.slug}</code> does not exist.</p>
+			</div>
+		{:else}
+			<h1 class="text-3xl font-bold mb-6">{data.title}</h1>
+			<article class="prose prose-invert max-w-none">
+				{@html data.html}
+			</article>
+		{/if}
+	</div>
+	<TableOfContents />
+</div>

--- a/docs-site/static/favicon.svg
+++ b/docs-site/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="14" fill="#1e293b" stroke="#38bdf8" stroke-width="2"/>
+  <path d="M10 20 L16 10 L22 20 Z" fill="none" stroke="#38bdf8" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/docs-site/svelte.config.js
+++ b/docs-site/svelte.config.js
@@ -1,0 +1,42 @@
+import adapter from '@sveltejs/adapter-static';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { mdsvex } from 'mdsvex';
+import mdsvexConfig from './mdsvex.config.js';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	preprocess: [
+		mdsvex(mdsvexConfig),
+		vitePreprocess()
+	],
+
+	extensions: ['.svelte', '.svelte.md', '.md', '.svx'],
+
+	kit: {
+		adapter: adapter({
+			pages: 'build',
+			assets: 'build',
+			fallback: '404.html',
+			precompress: false,
+			strict: false
+		}),
+		paths: {
+			base: process.env.DOCS_BASE_PATH || ''
+		},
+		prerender: {
+			handleHttpError: 'warn',
+			handleMissingId: 'warn'
+		}
+	},
+
+	vitePlugin: {
+		dynamicCompileOptions({ filename }) {
+			if (filename.endsWith('.md') || filename.endsWith('.svx')) {
+				return { runes: undefined };
+			}
+			return { runes: true };
+		}
+	}
+};
+
+export default config;

--- a/docs-site/tsconfig.json
+++ b/docs-site/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  },
+  "include": [
+    ".svelte-kit/ambient.d.ts",
+    ".svelte-kit/non-ambient.d.ts",
+    ".svelte-kit/types/**/$types.d.ts",
+    "src/**/*.ts",
+    "src/**/*.js",
+    "src/**/*.svelte"
+  ]
+}

--- a/docs-site/vite.config.ts
+++ b/docs-site/vite.config.ts
@@ -1,0 +1,10 @@
+import tailwindcss from '@tailwindcss/vite';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [tailwindcss(), sveltekit()],
+	ssr: {
+		noExternal: ['@skeletonlabs/skeleton', '@skeletonlabs/skeleton-svelte']
+	}
+});

--- a/docs/architecture/bzlmod-topology.md
+++ b/docs/architecture/bzlmod-topology.md
@@ -1,0 +1,103 @@
+---
+title: Bzlmod Topology
+order: 10
+---
+
+# Bzlmod Topology
+
+This document describes the two-module Bzlmod architecture that separates
+public upstream infrastructure from private institutional overlays.
+
+## Overview
+
+The system is split into two layers:
+
+1. **attic-iac** -- the public upstream module containing shared OpenTofu
+   modules, the SvelteKit application, documentation site, and build
+   tooling.
+2. **Overlay modules** (attic-cache-bates, tinyland-infra) -- private
+   repositories that depend on the upstream module and extend or override
+   its contents for a specific deployment.
+
+Each overlay declares a `bazel_dep` on `attic-iac` and uses
+`local_path_override` to point Bazel at a local checkout of the upstream
+repository. This keeps the two repositories as sibling directories on disk
+and avoids fetching upstream from a registry.
+
+## Module Dependency Graph
+
+```mermaid
+graph TD
+    subgraph upstream["attic-iac (upstream)"]
+        M[MODULE.bazel] --> TOFU[tofu/modules/]
+        M --> APP[app/]
+        M --> DOCS[docs-site/]
+        OVL[build/overlay.bzl]
+    end
+    subgraph bates["attic-cache-bates (overlay)"]
+        BM[MODULE.bazel] -->|"bazel_dep + local_path_override"| M
+        BM --> BEXT[build/extensions.bzl]
+        BEXT -->|"symlink merge"| MERGED["@attic_merged"]
+    end
+    subgraph tinyland["tinyland-infra (overlay)"]
+        TM[MODULE.bazel] -->|"bazel_dep + local_path_override"| M
+    end
+```
+
+## How Overlays Depend on Upstream
+
+An overlay `MODULE.bazel` contains two declarations:
+
+```starlark
+bazel_dep(name = "attic-iac")
+local_path_override(
+    module_name = "attic-iac",
+    path = "../../attic-iac",
+)
+```
+
+`bazel_dep` registers the upstream module as a dependency.
+`local_path_override` tells Bazel to resolve that dependency from a
+sibling directory rather than a remote registry. This means any local
+edits to the upstream checkout are immediately visible to the overlay
+build without publishing or fetching.
+
+## Symlink Merge via @attic_merged
+
+The overlay build tooling (`build/overlay.bzl` and `build/extensions.bzl`)
+creates a synthetic repository called `@attic_merged`. This repository is
+a symlink-based merge of the upstream and overlay file trees, with
+**private-wins-on-conflict** semantics: if both trees contain a file at
+the same path, the overlay version is used.
+
+See [Overlay System](overlay-system.md) for the full details of this
+merge process.
+
+## Automatic Invalidation
+
+Starting with Bazel 7.1, `ctx.watch_tree()` allows repository rules to
+register directory watches. The overlay repository rule watches both the
+upstream and overlay source trees. When any file in either tree changes,
+Bazel automatically invalidates the `@attic_merged` repository and
+re-runs the merge on the next build. No manual cache-clearing is needed.
+
+## pnpm-lock.yaml Constraint
+
+`npm_translate_lock` (from rules_js) processes exactly one
+`pnpm-lock.yaml` per Bazel module. Because the SvelteKit application has
+its own lockfile, it must live in the upstream module where the lockfile
+is declared. Overlays cannot introduce a second lockfile without creating
+a second module boundary, so the app source stays in attic-iac and
+overlays consume the built artifacts.
+
+This constraint is the primary reason the SvelteKit app is not moved into
+the overlay repositories.
+
+## Related Documents
+
+- [Overlay System](overlay-system.md) -- detailed mechanics of the
+  symlink merge
+- [Multi-Repo Layout](multi-repo-layout.md) -- how the repositories are
+  hosted and mirrored
+- [Recursive Dogfooding](recursive-dogfooding.md) -- the self-deploying
+  property that ties the architecture together

--- a/docs/architecture/multi-repo-layout.md
+++ b/docs/architecture/multi-repo-layout.md
@@ -1,0 +1,111 @@
+---
+title: Multi-Repo Layout
+order: 30
+---
+
+# Multi-Repo Layout
+
+This document describes how the three repositories are hosted, mirrored,
+and connected through CI/CD pipelines.
+
+## Repository Topology
+
+```mermaid
+graph TB
+    GH["GitHub: attic-iac (public)"]
+    GL_B["GitLab: bates-ils (CI/CD)"]
+    GL_T["GitLab: tinyland (CI/CD)"]
+    GH_M["GitHub: attic-cache-bates (mirror)"]
+    BH["Beehive K8s"]
+    TL["Tinyland K8s"]
+    GH_M -->|push| GL_B
+    GL_B -->|"CI clones upstream"| GH
+    GL_T -->|"CI clones upstream"| GH
+    GL_B -->|deploys| BH
+    GL_T -->|deploys| TL
+```
+
+## The Three Repositories
+
+### attic-iac (public upstream)
+
+- **Host**: GitHub (`Jesssullivan/attic-iac`)
+- **Visibility**: Public
+- **Contents**: Shared OpenTofu modules, SvelteKit application source,
+  documentation site, Bazel build tooling (`build/overlay.bzl`), and
+  Nix flake for container builds.
+- **Role**: Single source of truth for all reusable infrastructure
+  components. Contains no institutional secrets or deployment-specific
+  configuration.
+
+### attic-cache-bates (Bates overlay)
+
+- **Code mirror**: GitHub (`Jesssullivan/attic-cache-bates`)
+- **CI/CD**: GitLab (`bates-ils/people/jsullivan2/attic-cache`,
+  project ID 78189586)
+- **Visibility**: Private
+- **Contents**: Bates-specific tfvars, runner configurations,
+  `organization.yaml`, CI pipeline definitions, and any files that
+  override upstream defaults.
+- **Remotes**:
+  - `origin` points to the GitHub mirror (for code review and backup)
+  - `gitlab` points to the GitLab project (for CI/CD execution)
+
+Pushes to the GitHub mirror are forwarded to GitLab, which triggers
+the CI pipeline.
+
+### tinyland-infra (Tinyland overlay)
+
+- **Host**: GitLab (`tinyland/tinyland-infra`, project ID 78322246)
+- **Visibility**: Private
+- **Contents**: Tinyland-specific overlay files.
+- **Role**: Same overlay pattern as attic-cache-bates, targeting the
+  Tinyland Kubernetes cluster.
+
+## CI Pipeline Flow
+
+Both overlay repositories follow the same CI pattern:
+
+1. A push to the overlay repository triggers a GitLab CI pipeline.
+2. The pipeline clones the public upstream repository from GitHub.
+3. It symlinks upstream modules and source files into the overlay
+   workspace, replicating the `@attic_merged` layout that Bazel
+   produces locally.
+4. OpenTofu runs `plan` and `apply` against the merged file tree.
+5. On the `main` branch, deploys are automatic (not gated by manual
+   approval).
+
+This means the CI pipeline does not depend on Bazel itself. It
+reproduces the overlay merge with shell-level symlinks, keeping the
+CI environment lightweight.
+
+## GitLab Accounts
+
+Two separate GitLab accounts are involved:
+
+- **jsullivan2_bates** (ID 21565163): Institutional account. Owner of
+  the bates-ils group. PAT used for OpenTofu HTTP state backend. SSH
+  access via `~/.ssh/gitlab-work`.
+- **Jesssullivan** (ID 28461666): Personal account. Member of the
+  tinyland group. PAT stored in sops-encrypted secrets. SSH access via
+  default key.
+
+## Deployment Targets
+
+- **Beehive**: Bates development Kubernetes cluster. Deployed by the
+  bates-ils GitLab pipeline.
+- **Tinyland**: Separate Kubernetes cluster. Deployed by the tinyland
+  GitLab pipeline.
+
+Both clusters receive the same upstream infrastructure components
+(Attic cache, runners, dashboard) but with institution-specific
+configuration provided by their respective overlays.
+
+## Related Documents
+
+- [Bzlmod Topology](bzlmod-topology.md) -- how the overlay modules
+  depend on upstream via Bzlmod
+- [Overlay System](overlay-system.md) -- the symlink-merge mechanics
+  that CI replicates
+- [Recursive Dogfooding](recursive-dogfooding.md) -- the self-deploying
+  property of the deployed infrastructure

--- a/docs/architecture/overlay-system.md
+++ b/docs/architecture/overlay-system.md
@@ -1,0 +1,104 @@
+---
+title: Overlay System
+order: 20
+---
+
+# Overlay System
+
+This document describes the mechanics of `build/overlay.bzl` and
+`build/extensions.bzl`, which together implement the symlink-merge
+overlay that combines upstream and private files into a single Bazel
+repository.
+
+## Purpose
+
+Institutional deployments need to add private configuration (tfvars,
+secrets references, environment-specific configs) and occasionally
+replace upstream defaults. The overlay system provides this without
+forking: the overlay repository contains only the delta, and the merge
+happens at build time.
+
+## How the Merge Works
+
+The overlay is implemented as a Bazel repository rule. At a high level:
+
+1. The rule receives two directory paths: the upstream source tree
+   (resolved via `bazel_dep` + `local_path_override`) and the overlay
+   source tree (the overlay repository root).
+2. It walks both trees recursively, collecting every file path relative
+   to the root.
+3. For each file, it creates a symlink in the output repository
+   (`@attic_merged`):
+   - If the file exists only in upstream, the symlink points to the
+     upstream copy.
+   - If the file exists only in the overlay, the symlink points to the
+     overlay copy.
+   - If the file exists in both trees, the symlink points to the
+     **overlay copy**. This is the private-wins-on-conflict rule.
+4. The resulting `@attic_merged` repository looks like a single coherent
+   source tree and can be built with normal Bazel commands.
+
+## Private-Wins-on-Conflict Semantics
+
+The conflict resolution is intentionally simple: the overlay always wins.
+There is no file-level merging, no patch application, and no conditional
+logic. If an overlay provides `tofu/stacks/attic/terraform.tfvars`, that
+file completely replaces the upstream version of the same path.
+
+This makes the system predictable. To understand what Bazel sees for any
+given file, check whether the overlay contains it. If yes, that version
+is used. If no, the upstream version is used.
+
+## File Tree Watching with ctx.watch_tree()
+
+Bazel 7.1 introduced `ctx.watch_tree()`, which allows repository rules
+to declare file-system watches on directories. The overlay rule registers
+watches on both:
+
+- The upstream source tree
+- The overlay source tree
+
+When any file in either tree is created, modified, or deleted, Bazel
+marks the `@attic_merged` repository as stale. The next `bazel build`
+command will re-execute the repository rule, regenerating all symlinks.
+This means developers working on either the upstream or overlay codebase
+see their changes reflected immediately without running any manual
+invalidation commands.
+
+## What Overlays Typically Add
+
+Overlays are used for files that are specific to a deployment and should
+not be published upstream:
+
+- **tfvars files** -- variable values for OpenTofu stacks
+  (`cluster_context`, `gitlab_token`, environment-specific sizing)
+- **Stack configurations** -- additional stacks that exist only in one
+  deployment (e.g., `bates-ils-runners`)
+- **Environment configs** -- `organization.yaml` or similar files that
+  define the institutional identity
+- **CI pipeline definitions** -- `.gitlab-ci.yml` tailored to the
+  institution's GitLab setup
+
+Overlays can also **replace** upstream defaults. For example, an overlay
+might provide its own `tofu/stacks/attic/main.tf` if the upstream version
+does not support a required backend configuration.
+
+## Build Targets from the Merged Repository
+
+Once `@attic_merged` exists, the overlay `BUILD.bazel` can define aliases
+and aggregation targets that reference it:
+
+- `bazel build //...` builds all overlay and upstream targets.
+- `bazel build //:deployment_bundle` creates a `pkg_tar` of overlay
+  configs combined with upstream artifacts.
+- `bazel build //:validate_modules` validates all upstream OpenTofu
+  modules via `@attic-iac//tofu/modules:all_validate`.
+- `bazel build //:app` builds the SvelteKit application from upstream
+  source.
+
+## Related Documents
+
+- [Bzlmod Topology](bzlmod-topology.md) -- the module dependency
+  structure that feeds into the overlay
+- [Multi-Repo Layout](multi-repo-layout.md) -- where the upstream and
+  overlay repositories are hosted

--- a/docs/architecture/recursive-dogfooding.md
+++ b/docs/architecture/recursive-dogfooding.md
@@ -1,0 +1,126 @@
+---
+title: Recursive Dogfooding
+order: 1
+---
+
+# Recursive Dogfooding
+
+This is the central architectural concept of the attic-iac system:
+**infrastructure that deploys and updates itself using itself**.
+
+## Definition
+
+Recursive dogfooding means that the tools, services, and pipelines
+produced by this project are consumed by the same project to build,
+test, and deploy subsequent versions of themselves. Each component
+participates in a feedback loop where it is both producer and consumer.
+
+## The Three Self-Referential Loops
+
+### Runners Deploy Runners
+
+GitLab runners are deployed via `tofu apply`, which updates their
+Kubernetes manifests (resource limits, runner tokens, image versions).
+The `tofu apply` command runs inside a CI pipeline, which itself
+executes on those same runners. When a runner configuration change
+merges to `main`, the runners execute a pipeline that reconfigures
+themselves.
+
+### Attic Cache Caches Its Own Derivations
+
+The Attic binary cache server is built as a Nix derivation. That
+derivation is stored in the Attic cache. On subsequent builds, Nix
+fetches the cached closure from Attic rather than rebuilding from
+source. The cache accelerates the build of the very artifact that
+provides the cache.
+
+### Dashboard Monitors Its Own Deployers
+
+The runner dashboard is a SvelteKit application deployed by the CI
+pipeline. Once running, it monitors the health and activity of the
+runners that deployed it. If a runner degrades, the dashboard surfaces
+that information, prompting a fix that the runners will then deploy.
+
+## Convergence
+
+The system converges over time. Each successful cycle improves the next:
+
+- **Cache hits accumulate.** After the first build, Nix derivations are
+  cached. Subsequent builds are faster because they fetch from Attic
+  instead of rebuilding. Faster builds mean shorter CI cycle times.
+- **Runner configuration stabilizes.** Each deployment applies the
+  declared state. Configuration drift is corrected on every merge to
+  `main`.
+- **Monitoring improves visibility.** As the dashboard collects data
+  across cycles, patterns emerge (build duration trends, failure rates)
+  that inform further improvements.
+
+The steady state is a system where builds are fast (high cache hit
+rate), runners are correctly configured (no drift), and operators have
+clear visibility into system health.
+
+## Dependency Graph
+
+```mermaid
+graph LR
+    R[Runners] -->|"tofu apply"| R
+    R -->|deploy| AC[Attic Cache]
+    AC -->|accelerates| NB[Nix Builds]
+    NB -->|"executed by"| R
+    R -->|deploy| D[Dashboard]
+    D -->|monitors| R
+    AC -->|"caches its own derivations"| AC
+```
+
+## Bootstrap
+
+The self-referential nature creates a chicken-and-egg problem on first
+deployment. The system cannot deploy itself if it does not yet exist.
+The bootstrap sequence breaks the cycle:
+
+1. **Manual initial deploy.** The first `tofu apply` runs from a
+   developer workstation (or a temporary CI runner outside the cluster).
+   This creates the Kubernetes namespace, deploys the Attic cache with
+   an empty store, and registers the initial set of runners.
+2. **First CI pipeline.** With runners registered, the next push to
+   `main` triggers a pipeline that runs on the newly created runners.
+   This pipeline redeploys the same infrastructure, but now through the
+   self-referential path.
+3. **Cache warming.** The first Nix build has no cache hits and is slow.
+   Its outputs are pushed to Attic. The second build is faster. After a
+   few cycles, the cache is warm and builds reach steady-state speed.
+
+After bootstrap, the system is self-sustaining. No external CI
+infrastructure is needed.
+
+## Degradation
+
+The loops are loosely coupled through Kubernetes. If one component
+fails, the others continue:
+
+- **Attic cache down**: Nix builds fall back to nixpkgs.org or rebuild
+  from source. Builds are slower but still succeed. Runners and
+  dashboard are unaffected.
+- **Dashboard down**: Monitoring is lost, but runners continue to
+  execute pipelines and deploy infrastructure. The next pipeline run
+  will attempt to redeploy the dashboard.
+- **Runner degraded**: If one runner type fails (e.g., the Nix runner),
+  pipelines that require that runner type will queue. Other runner types
+  continue operating. The remaining runners can deploy a fix for the
+  broken runner.
+- **All runners down**: The self-referential loop is broken. Recovery
+  requires the same manual intervention as bootstrap: a local
+  `tofu apply` to recreate the runners.
+
+The system is designed so that total failure of all components
+simultaneously is unlikely. Partial failures are self-healing as long
+as at least one runner type remains operational.
+
+## Related Documents
+
+- [RenovateBot Flywheel](renovatebot-flywheel.md) -- automated
+  dependency updates that feed into the self-deployment loop
+- [Bzlmod Topology](bzlmod-topology.md) -- the build system structure
+  that produces the deployable artifacts
+- [Multi-Repo Layout](multi-repo-layout.md) -- where the code lives
+  and how CI pipelines are triggered

--- a/docs/architecture/renovatebot-flywheel.md
+++ b/docs/architecture/renovatebot-flywheel.md
@@ -1,0 +1,109 @@
+---
+title: RenovateBot Flywheel
+order: 40
+---
+
+# RenovateBot Flywheel
+
+This document describes how automated dependency updates form a
+self-improving loop when combined with the
+[recursive dogfooding](recursive-dogfooding.md) architecture.
+
+## Overview
+
+RenovateBot continuously scans the repository for outdated dependencies
+and creates merge requests with version bumps. Those merge requests are
+tested and deployed by the same infrastructure that RenovateBot is
+updating. The result is a flywheel: each update cycle leaves the system
+in a better state for the next cycle.
+
+## What RenovateBot Scans
+
+RenovateBot is configured to monitor three dependency manifests:
+
+- **flake.nix** -- Nix flake inputs (nixpkgs, flake-utils, nix2container,
+  and the attic-server source). Updates here change the Nix derivation
+  outputs, which flow through to container images.
+- **MODULE.bazel** -- Bazel module dependencies (rules_js, rules_ts,
+  aspect_bazel_lib). Updates here change the build toolchain.
+- **package.json** -- Node.js dependencies for the SvelteKit application
+  (Skeleton, Tailwind, Chart.js, SvelteKit itself). Updates here change
+  the application bundle.
+
+## The Flywheel
+
+```mermaid
+graph LR
+    RB[RenovateBot] -->|"version bump PRs"| PIPE[CI Pipeline]
+    PIPE -->|"executed by"| R[Runners]
+    R -->|"deploys updates from"| PIPE
+    RB -->|"next scan"| RB
+```
+
+The cycle proceeds as follows:
+
+1. **Scan.** RenovateBot detects that a dependency has a newer version.
+   It creates a merge request with the version bump and updated lockfile.
+2. **Test.** The merge request triggers a CI pipeline. Self-hosted
+   runners execute the pipeline, which runs `tofu validate`, `pnpm test`,
+   and `bazel build` against the proposed change.
+3. **Merge.** If the pipeline passes (and automerge is enabled for the
+   dependency type), the merge request is merged to `main`.
+4. **Deploy.** The merge to `main` triggers the deployment pipeline. The
+   runners execute `tofu apply`, which deploys the updated infrastructure.
+   If the update affects the runners themselves (e.g., a new runner image
+   tag), the runners redeploy themselves.
+5. **Next scan.** RenovateBot runs again on the now-updated codebase.
+   Any transitive dependency changes introduced by the previous update
+   are detected and the cycle repeats.
+
+## Self-Improvement Property
+
+Each cycle can improve the infrastructure in concrete ways:
+
+- **Nix input updates** may include security patches for the base image
+  or performance improvements in attic-server. After deployment, the
+  cache serves content faster or more securely.
+- **Build toolchain updates** (rules_js, rules_ts) may fix bugs or
+  improve build performance. After deployment, CI pipelines run faster.
+- **Application dependency updates** fix vulnerabilities and add features
+  to the dashboard. After deployment, operators have better monitoring
+  tools.
+
+Because the infrastructure deploys itself, these improvements take
+effect without manual intervention. The system trends toward its best
+available state.
+
+## Interaction with the Attic Cache
+
+When a dependency update changes Nix derivation outputs (e.g., a new
+nixpkgs pin), the first build after the update will miss the cache and
+rebuild affected derivations. Those new derivations are pushed to Attic.
+Subsequent builds (including the next RenovateBot cycle) benefit from
+the updated cache. Over time, the cache always contains derivations for
+the most recent dependency set.
+
+## Guardrails
+
+Fully automated updates carry risk. The following guardrails are in
+place:
+
+- **CI must pass.** No merge request is merged without a green pipeline.
+  This catches breaking changes before they reach `main`.
+- **Automerge scope.** Only patch and minor version bumps are
+  automerged. Major version bumps require manual review.
+- **Separate PRs.** RenovateBot creates one merge request per dependency
+  update. If an update breaks the build, it is easy to identify and
+  revert the specific change.
+- **Deployment is idempotent.** `tofu apply` converges to the declared
+  state. If an update introduces a bad configuration, the next
+  corrective merge will restore the system.
+
+## Related Documents
+
+- [Recursive Dogfooding](recursive-dogfooding.md) -- the self-deploying
+  architecture that makes the flywheel possible
+- [Bzlmod Topology](bzlmod-topology.md) -- the build system that
+  RenovateBot's MODULE.bazel updates feed into
+- [Multi-Repo Layout](multi-repo-layout.md) -- where the CI pipelines
+  run

--- a/docs/build-system/containers.md
+++ b/docs/build-system/containers.md
@@ -1,0 +1,144 @@
+---
+title: Container Builds
+order: 20
+---
+
+# Container Builds
+
+This project uses three methods for building OCI container images,
+selected based on the requirements of each component.
+
+## Build Methods
+
+### nix2container (Preferred)
+
+[nix2container](https://github.com/nlewo/nix2container) builds OCI
+images directly from Nix derivations without requiring a Docker daemon.
+It is the preferred method for all Nix-based components because it
+produces byte-for-byte reproducible images and generates optimized layers
+based on the Nix store graph.
+
+Key properties:
+
+- **No Docker daemon required.** Images are assembled from Nix store
+  paths. This is critical for CI runners that do not have Docker-in-Docker
+  available.
+- **Reproducible.** The same Nix inputs always produce the same image
+  digest.
+- **Optimized layers.** nix2container analyzes the Nix store closure and
+  groups paths into layers that minimize redundancy across image versions.
+  Shared dependencies (libc, openssl, etc.) land in stable base layers
+  that rarely change.
+- **Streamable push.** Images can be streamed directly to a registry
+  without first writing a tarball to disk.
+
+Usage in this project:
+
+```nix
+# Simplified example from flake.nix
+packages.attic-server-image = nix2container.buildImage {
+  name = "attic-server";
+  config = {
+    entrypoint = [ "${atticd}/bin/atticd" ];
+    cmd = [ "--mode" "monolithic" ];
+  };
+  layers = [
+    (nix2container.buildLayer { deps = [ atticd ]; })
+  ];
+};
+```
+
+### Dockerfile (Fallback)
+
+Standard multi-stage Dockerfiles are used when the component is not
+built with Nix or when the build requires a Node.js toolchain that is
+simpler to express as Docker stages.
+
+The runner dashboard uses this approach:
+
+- **Stage 1** (`node:20-alpine`): Install pnpm, copy lockfile, install
+  dependencies, run `pnpm build` to produce the adapter-node output.
+- **Stage 2** (`node:20-alpine`): Copy only the built output and
+  production `node_modules`. Set the entrypoint to `node build/index.js`.
+
+The Dockerfile lives at `app/Dockerfile` and can be built with any
+standard Docker-compatible tool (Docker, Podman, Buildah).
+
+### rules_img (Bazel-Native)
+
+For components managed entirely within Bazel, the `image_layer` and
+`image_manifest` rules from the Bazel ruleset produce OCI images without
+shelling out to Docker or Nix. This is used for the SvelteKit application
+image target.
+
+Key targets:
+
+- `//app:image` -- assembles the OCI image manifest from Bazel-built
+  layers.
+- `//app:push` -- pushes the image to the configured registry.
+
+The Bazel approach is useful when the image contents are already Bazel
+outputs (JavaScript bundles, static assets) and adding a Nix or Docker
+step would introduce unnecessary complexity.
+
+## Container Registries
+
+| Registry | Visibility | Usage |
+|---|---|---|
+| `ghcr.io/jesssullivan` | Public | Upstream images published for general consumption |
+| `registry.gitlab.com/bates-ils` | Private | Institutional overlay images, deployment-specific builds |
+
+Images are tagged with both a content-based digest and a mutable `latest`
+tag. CI pipelines push to the appropriate registry based on the build
+context (upstream vs. overlay).
+
+## Attic Server Container
+
+The Attic cache server runs as a container with the following
+characteristics:
+
+- The binary is located at `/bin/atticd` inside the image (not
+  `attic-server` or any other name).
+- The container must be started with `--mode monolithic` to enable
+  automatic database migrations on startup. Without this flag, schema
+  changes require a separate migration step.
+- The image is built with nix2container for reproducibility.
+- Configuration is injected via environment variables and a mounted
+  configuration file.
+
+```mermaid
+graph TD
+    A[nix2container] -->|builds| B[attic-server image]
+    B -->|contains| C["/bin/atticd"]
+    C -->|"--mode monolithic"| D[Auto-migrations + Server]
+    D -->|reads| E[Config file + env vars]
+    D -->|connects| F[PostgreSQL]
+    D -->|serves| G[Binary cache API]
+```
+
+## Choosing a Build Method
+
+```mermaid
+graph TD
+    Q["Is the component<br/>built with Nix?"]
+    Q -->|Yes| N[nix2container]
+    Q -->|No| Q2["Are all inputs<br/>Bazel targets?"]
+    Q2 -->|Yes| R[rules_img]
+    Q2 -->|No| D[Dockerfile]
+```
+
+- Use **nix2container** when the component is a Nix derivation. This
+  gives you reproducibility and daemon-free builds.
+- Use **rules_img** when all image contents are Bazel outputs and adding
+  Nix would be unnecessary overhead.
+- Use **Dockerfile** as a fallback for components that do not fit either
+  of the above, or when a standard Docker build is the simplest path.
+
+## Related Documents
+
+- [Greedy Build Pattern](greedy-build-pattern.md) -- how builds are
+  triggered and cached
+- [Watch-Store Bootstrap](watch-store.md) -- incremental caching of Nix
+  derivations used by nix2container
+- [Bazel Targets](bazel-targets.md) -- build targets including image
+  targets

--- a/docs/build-system/greedy-build-pattern.md
+++ b/docs/build-system/greedy-build-pattern.md
@@ -1,0 +1,127 @@
+---
+title: Greedy Build Pattern
+order: 1
+---
+
+# Greedy Build Pattern
+
+The greedy build pattern starts build jobs immediately -- before validation
+completes -- and pushes results to the Nix binary cache as a non-blocking
+side effect. This eliminates wasted time when validation fails and ensures
+that every build, successful or not, contributes to the cache.
+
+## Pipeline Topology
+
+In a conventional pipeline, stages run sequentially: validate, then build,
+then deploy. A validation failure means the build never starts, and no
+artifacts are cached. The greedy pattern inverts this by removing the
+dependency edge between validation and build:
+
+```mermaid
+graph LR
+    subgraph pipeline["CI Pipeline"]
+        V[Validate] --> B[Build]
+        B --> D[Deploy]
+    end
+    subgraph greedy["Greedy Pattern"]
+        GB[Build] -->|"needs: []"| GB
+        GB -->|"watch-store push"| C[Attic Cache]
+    end
+    C -->|"cache hit"| GB
+```
+
+Build jobs declare `needs: []` in GitLab CI, which tells the scheduler to
+start them as soon as a runner is available, without waiting for any
+upstream stage. Validation and build run in parallel. Deploy still depends
+on both.
+
+## Incremental Push with watch-store
+
+Pushing to the cache only after a build finishes creates a fragile
+all-or-nothing situation: if a 60-minute Nix build fails at minute 45,
+zero derivations are cached and the next pipeline repeats all 45 minutes
+of work.
+
+The `attic watch-store` command solves this by monitoring `/nix/store` for
+new paths during the build and pushing each one to the Attic cache as it
+appears. If the build fails partway through, every derivation completed
+before the failure is already in the cache. The next pipeline picks up
+from where the previous one left off.
+
+See [Watch-Store Bootstrap](watch-store.md) for the full bootstrap
+sequence and implementation details.
+
+## Bootstrap: Cached Attic Client Binary
+
+The `attic` CLI is itself a Nix derivation. Building it from source
+(Rust + Cargo) takes significant time, which defeats the purpose of
+fast-start caching if every pipeline must compile the client before it
+can push anything.
+
+The bootstrap strategy avoids this:
+
+1. Attempt to fetch the pre-built `attic` client from the cache using
+   `nix build .#attic-client --max-jobs 0`. The `--max-jobs 0` flag
+   restricts Nix to substituters only -- no local compilation.
+2. If the client is in the cache (the common case after the first
+   successful pipeline), start `attic watch-store` immediately in the
+   background.
+3. If the client is not in the cache (first pipeline, or cache was
+   cleared), skip watch-store entirely and fall back to an end-of-build
+   push. This seeds the cache so that subsequent pipelines have the
+   client available.
+
+The result is that only the very first pipeline pays the full compilation
+cost. Every pipeline after that has sub-second access to the cached
+client binary.
+
+## Benefits
+
+| Benefit | Mechanism |
+|---|---|
+| Roughly 50% faster iteration | Build and validate run in parallel instead of sequentially |
+| Resumable builds | Partial results are cached incrementally, so failures do not reset progress |
+| Higher cache hit rates | More derivations are cached because builds run regardless of validation outcome |
+| Reduced CI compute cost | Cached derivations are fetched instead of rebuilt |
+| Better parallelism | `needs: []` allows the scheduler to saturate available runners |
+
+## Tradeoffs
+
+| Consideration | Mitigation |
+|---|---|
+| Unvalidated code in cache | The cache is internal infrastructure, not a release channel. Validation gates still control deployment. Nothing reaches production without passing all checks. |
+| Cache bloat from speculative builds | The Attic GC worker prunes old derivations on a configurable schedule. Short-lived feature branches contribute minimal additional store paths. |
+| Pipeline complexity | The greedy pattern adds one concept (`needs: []`) and one background process (watch-store). Both are confined to the CI base template. |
+
+## Integration with Greedy Bazel Builds
+
+The same speculative philosophy applies to Bazel. Running `bazel build
+//...` in the overlay repository builds all targets -- upstream and
+private -- regardless of whether a specific change touches all of them.
+This is deliberate: Bazel's content-addressable cache means rebuilding
+an unchanged target is a no-op (cache hit), and building everything
+ensures that breakages in unrelated targets surface early rather than in
+a later pipeline.
+
+Combined with the Nix greedy pattern, the full build flow is:
+
+1. Pipeline starts. Build job launches immediately (`needs: []`).
+2. Bootstrap fetches the cached `attic` client. watch-store begins
+   monitoring `/nix/store`.
+3. `nix build` compiles all Nix derivations. Each completed derivation
+   streams to the Attic cache in real time.
+4. `bazel build //...` runs against the merged overlay repository,
+   producing all OpenTofu validations, the SvelteKit app bundle, and
+   the deployment tarball.
+5. Validation job runs in parallel. Deploy job waits for both build and
+   validation to succeed.
+
+See [Bazel Targets](bazel-targets.md) for the full list of build targets.
+
+## Related Documents
+
+- [Watch-Store Bootstrap](watch-store.md) -- incremental Nix store push
+- [Container Builds](containers.md) -- OCI image build methods
+- [Bazel Targets](bazel-targets.md) -- available build targets
+- [Overlay System](../architecture/overlay-system.md) -- how upstream and
+  private files merge at build time

--- a/docs/build-system/watch-store.md
+++ b/docs/build-system/watch-store.md
@@ -1,0 +1,129 @@
+---
+title: Watch-Store Bootstrap
+order: 10
+---
+
+# Watch-Store Bootstrap
+
+`attic watch-store` is the mechanism that turns Nix builds into
+incrementally cached operations. Rather than pushing the entire closure
+to the binary cache after the build completes, watch-store pushes each
+store path as it appears in `/nix/store`, making partial results
+available to future builds immediately.
+
+## How watch-store Works
+
+When started as a background process, `attic watch-store <cache-name>`
+opens an inotify (Linux) or FSEvents (macOS) watch on `/nix/store`. Each
+time Nix finalizes a new store path -- meaning the derivation built
+successfully and its output hash is registered -- watch-store detects the
+new entry and pushes it to the named Attic cache.
+
+The push is asynchronous relative to the build. Nix continues building
+the next derivation in the dependency graph while the previous one
+uploads. This overlap means that for most builds, the upload cost is
+hidden behind computation time.
+
+## Incremental Caching and Partial Failures
+
+The key advantage of watch-store over end-of-build push is resilience to
+partial failures. Consider a complex derivation tree with 80 intermediate
+outputs:
+
+- **End-of-build push**: If the build fails at output 60, zero outputs
+  are cached. The next pipeline rebuilds all 60 from scratch.
+- **watch-store**: Outputs 1 through 59 are already in the cache when the
+  failure occurs. The next pipeline substitutes those 59 outputs
+  instantly and resumes from output 60.
+
+This property is especially valuable for long-running Rust compilations
+(like the `attic` client itself) and for Nix builds that involve many
+independent intermediate derivations (system libraries, toolchains,
+compiler bootstraps).
+
+## The Bootstrap Problem
+
+watch-store depends on the `attic` CLI binary. The `attic` CLI is itself
+a Nix derivation -- building it from source involves compiling a
+substantial Rust codebase with Cargo, which can take 30-60 minutes on CI
+runners.
+
+This creates a circular dependency: to push derivations incrementally, we
+need `attic`; to get `attic` quickly, we need it to already be cached; to
+cache it, we need to have pushed it with `attic`.
+
+## Bootstrap Sequence
+
+The bootstrap logic resolves this circular dependency with a two-phase
+approach:
+
+### Phase 1: Attempt Substitution Only
+
+```bash
+nix build .#attic-client --out-link /tmp/attic-client --max-jobs 0
+```
+
+The `--max-jobs 0` flag tells Nix to fetch from configured substituters
+(binary caches) but never build locally. If the `attic` client is already
+in the cache, this completes in seconds. If not, it fails immediately --
+there is no 60-minute wait.
+
+### Phase 2a: Client Available (Common Case)
+
+If phase 1 succeeded, the cached client binary is at
+`/tmp/attic-client/bin/attic`. The CI job:
+
+1. Authenticates with `attic login ci <server-url> <token>`.
+2. Starts the background watcher with `attic watch-store <cache-name> &`.
+3. Proceeds to the main `nix build` step. All new derivations stream to
+   the cache in real time.
+4. In `after_script`, stops watch-store and logs the push count.
+
+### Phase 2b: Client Not Available (First Pipeline)
+
+If phase 1 failed (the client is not in any cache), the CI job skips
+watch-store entirely and falls back to end-of-build push:
+
+1. Runs `nix build` as normal. This builds the `attic` client along with
+   everything else.
+2. After the build, pushes the complete closure with `attic push`.
+3. Future pipelines now have the client in the cache and will follow the
+   Phase 2a path.
+
+The fallback means the very first pipeline for a fresh cache pays the
+full cost. Every subsequent pipeline bootstraps watch-store in seconds.
+
+## CI Lifecycle Integration
+
+The watch-store lifecycle maps to GitLab CI's job phases:
+
+| CI Phase | Action |
+|---|---|
+| `before_script` | Discover Attic server endpoint. Attempt client substitution. If available, authenticate and start watch-store in the background. |
+| `script` | Run `nix build` normally. Derivations are pushed incrementally by the background watch-store process. |
+| `after_script` | Terminate watch-store. Log the number of store paths pushed. Run a final `attic push result-*` as a belt-and-suspenders measure to ensure the top-level outputs and their closures are fully cached. |
+
+The final explicit push in `after_script` is not strictly necessary when
+watch-store is running, but it guards against edge cases where
+watch-store might miss a path (for example, if the process is terminated
+before it processes the last batch of events).
+
+## Monitoring
+
+watch-store logs its activity to stderr. In CI job logs, look for:
+
+```
+watch-store pushed 47 store paths incrementally
+```
+
+A high number indicates many cache misses were filled during the build.
+A low number (or zero) means most derivations were already cached. Both
+are normal -- the first indicates a productive cache-warming run, and the
+second indicates a mature cache.
+
+## Related Documents
+
+- [Greedy Build Pattern](greedy-build-pattern.md) -- the pipeline
+  strategy that drives watch-store usage
+- [Container Builds](containers.md) -- how built derivations become
+  container images

--- a/docs/ci-cd/deployment-flow.md
+++ b/docs/ci-cd/deployment-flow.md
@@ -1,0 +1,85 @@
+---
+title: Deployment Flow
+order: 20
+---
+
+# Deployment Flow
+
+This document describes how changes move from a developer commit to a running
+production deployment, and how drift detection catches out-of-band changes.
+
+## Merge Request Pipeline
+
+When a merge request is opened or updated, the pipeline runs a subset of stages:
+
+1. **Validate** -- format checks, schema validation, `tofu validate`
+2. **Plan** -- generates execution plans for all affected stacks
+
+The deploy stage is skipped. Plan output is posted as a comment or artifact so
+reviewers can inspect the exact infrastructure changes before approving the merge.
+
+## Main Branch Pipeline
+
+After a merge request is approved and merged into `main`, the full pipeline runs
+automatically. There is no manual gate or approval step.
+
+1. **Validate** -- same checks as the MR pipeline
+2. **Build** -- compiles the SvelteKit app, builds the container image
+3. **Plan** -- generates fresh execution plans from the merged code
+4. **Deploy** -- runs `tofu apply` with the saved plan artifacts
+5. **Verify** -- executes health checks against deployed services
+
+### Plan-Apply Handoff
+
+The plan artifact produced in the Plan stage is passed directly to the Deploy
+stage. This guarantees that `tofu apply` executes exactly the changes that were
+planned, with no opportunity for drift between planning and applying.
+
+### Health Checks
+
+The Verify stage confirms that deployed services are healthy:
+
+- HTTP GET against known health endpoints
+- Kubernetes pod readiness verification
+- Runner registration confirmation (for runner stacks)
+
+A failed health check marks the pipeline as failed and triggers notification.
+
+## Drift Detection
+
+A scheduled pipeline runs at a configured interval (typically daily) independent
+of any code change. It executes:
+
+```bash
+tofu plan -detailed-exitcode
+```
+
+The `-detailed-exitcode` flag causes tofu to exit with code 2 if the plan detects
+changes (drift) between the declared state and the actual cluster state. Exit
+code 0 means no drift.
+
+When drift is detected, the pipeline raises an alert. The team can then choose to:
+
+- Apply the existing code to bring the cluster back in line
+- Update the code to reflect intentional manual changes
+- Investigate and revert unauthorized modifications
+
+## Flow Diagram
+
+```mermaid
+graph TD
+    MR[Merge Request] -->|validate + plan| Review[Code Review]
+    Review -->|merge| Main[main branch]
+    Main -->|"auto deploy"| Plan[tofu plan]
+    Plan --> Apply[tofu apply]
+    Apply --> Health[Health Check]
+    Schedule[Scheduled] -->|"drift check"| Drift{Drift?}
+    Drift -->|Yes| Alert[Alert]
+    Drift -->|No| OK[Clean]
+```
+
+## Related
+
+- [Pipeline Overview](./pipeline-overview.md) -- stage-by-stage reference
+- [Overlay Pipelines](./overlay-pipelines.md) -- how overlays customize the flow
+- [OpenTofu Modules](../reference/tofu-modules.md) -- modules deployed by the pipeline

--- a/docs/ci-cd/overlay-pipelines.md
+++ b/docs/ci-cd/overlay-pipelines.md
@@ -1,0 +1,91 @@
+---
+title: Overlay Pipelines
+order: 10
+---
+
+# Overlay Pipelines
+
+Overlay repositories (such as `attic-cache-bates` or `tinyland-infra`) extend the
+upstream pipeline to deploy site-specific infrastructure. Each overlay maintains its
+own `.gitlab-ci.yml` that pulls upstream code at a pinned ref and merges it with
+local configuration.
+
+## How It Works
+
+### Upstream Clone
+
+The overlay pipeline begins by cloning the upstream repository from GitHub:
+
+```yaml
+variables:
+  UPSTREAM_REPO_URL: "https://github.com/Jesssullivan/attic-iac.git"
+  UPSTREAM_REF: "main"
+```
+
+The `UPSTREAM_REF` variable controls which commit, tag, or branch of upstream
+code is used. Pinning to a tag (e.g., `v1.2.0`) is recommended for production
+overlays; using `main` tracks the latest upstream changes.
+
+### Symlink Merge
+
+After cloning, the pipeline symlinks upstream modules and `.tf` files into the
+overlay stack directories. This gives each stack access to:
+
+- Shared module definitions from `tofu/modules/`
+- Upstream `.tf` root files (providers, backends, data sources)
+- Overlay-specific `.tfvars` files that override upstream defaults
+
+The result is a merged working directory where overlay configuration takes
+precedence over upstream defaults on conflict.
+
+### Stack-Specific tfvars
+
+Each overlay defines its own variable files for each target environment:
+
+- `beehive.tfvars` -- Bates development cluster
+- `tinyland.tfvars` -- Tinyland production cluster
+
+These files set cluster contexts, namespaces, domains, resource limits, and
+any other site-specific values.
+
+### Extra Stages and Jobs
+
+Overlays can add stages or jobs beyond the upstream pipeline. Common additions:
+
+- Organization config validation (checks overlay-specific `organization.yaml`)
+- Additional deployment targets not present in upstream
+- Site-specific integration tests or smoke tests
+
+## CI Variables
+
+The following CI/CD variables must be configured in the overlay project settings:
+
+| Variable | Purpose |
+|----------|---------|
+| `UPSTREAM_REPO_URL` | GitHub URL for the upstream repository |
+| `UPSTREAM_REF` | Git ref (branch, tag, or SHA) to clone from upstream |
+| `TF_HTTP_PASSWORD` | GitLab PAT for the tofu HTTP state backend |
+| `TF_VAR_gitlab_token` | GitLab token passed to the tofu GitLab provider |
+| `TF_VAR_gitlab_oauth_client_id` | OAuth application ID for dashboard auth |
+| `TF_VAR_gitlab_oauth_client_secret` | OAuth application secret |
+
+Cluster context variables are set per environment, either as CI variables or
+within the `.tfvars` files.
+
+## State Storage
+
+Each overlay project stores its own tofu state in the GitLab HTTP backend. State
+is scoped per project and per stack:
+
+- State name format: `{stack}-{environment}` (e.g., `attic-beehive`, `runners-beehive`)
+- Backend project ID: the GitLab project ID of the overlay repository
+- Authentication: via `TF_HTTP_PASSWORD`
+
+This ensures that each overlay maintains independent state, even when multiple
+overlays deploy the same upstream modules.
+
+## Related
+
+- [Pipeline Overview](./pipeline-overview.md) -- upstream pipeline stages
+- [Deployment Flow](./deployment-flow.md) -- commit-to-production flow
+- [Environment Variables](../reference/environment-variables.md) -- full variable reference

--- a/docs/ci-cd/pipeline-overview.md
+++ b/docs/ci-cd/pipeline-overview.md
@@ -1,0 +1,81 @@
+---
+title: Pipeline Overview
+order: 1
+---
+
+# Pipeline Overview
+
+The upstream attic-iac CI/CD pipeline is structured around five sequential stages
+that take changes from validation through to production deployment.
+
+## Stages
+
+### 1. Validate
+
+Static checks that run before any build or deploy work begins.
+
+- **Organization config validation** -- parses `organization.yaml` and checks
+  schema conformance, required fields, and cross-references between runners,
+  environments, and cache settings.
+- **tofu fmt --check** -- ensures all `.tf` files follow canonical formatting.
+- **tofu validate** -- runs `tofu validate` against every module in
+  `tofu/modules/` to catch syntax errors, missing variables, and provider
+  misconfigurations.
+
+### 2. Build
+
+Produces the artifacts needed by later stages.
+
+- **App build (Vite)** -- runs `pnpm install && pnpm build` for the
+  SvelteKit runner-dashboard application using adapter-node.
+- **Container image build** -- builds the OCI image for the dashboard
+  (via Dockerfile or Nix, depending on platform).
+
+### 3. Plan
+
+Generates OpenTofu execution plans for each infrastructure stack.
+
+- **attic** -- plans the Attic binary cache stack (server, database, ingress).
+- **runners** -- plans the GitLab Runner stack (all runner types, HPA, RBAC).
+- **dashboard** -- plans the runner-dashboard stack (deployment, service, ingress).
+
+Each plan is saved as an artifact and passed to the deploy stage.
+
+### 4. Deploy
+
+Applies the saved plans from the previous stage.
+
+- Runs `tofu apply` using the exact plan artifact produced in the Plan stage.
+- No interactive approval -- deployment is automatic on the main branch.
+
+### 5. Verify
+
+Post-deployment health checks confirm services are running.
+
+- HTTP health checks against deployed endpoints.
+- Kubernetes readiness probe verification.
+- Runner registration status check.
+
+## Drift Detection
+
+A scheduled pipeline runs independently of code changes. It executes
+`tofu plan -detailed-exitcode` against each stack. A non-zero exit code
+indicates configuration drift (manual changes made outside of tofu), which
+triggers an alert.
+
+## Pipeline Diagram
+
+```mermaid
+graph LR
+    V[Validate] --> B[Build]
+    B --> P[Plan]
+    P --> D[Deploy]
+    D --> VR[Verify]
+    S[Schedule] -->|"drift detection"| VR
+```
+
+## Related
+
+- [Overlay Pipelines](./overlay-pipelines.md) -- how downstream repos extend this pipeline
+- [Deployment Flow](./deployment-flow.md) -- how changes move from commit to production
+- [OpenTofu Modules](../reference/tofu-modules.md) -- module reference for planned stacks

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+---
+title: GloriousFlywheel
+order: 0
+---
+
+# GloriousFlywheel
+
+Self-deploying infrastructure that builds, caches, and monitors itself.
+
+## What is this?
+
+attic-iac is a set of OpenTofu modules, Nix packages, and a SvelteKit dashboard that
+together form a self-improving infrastructure system. The core insight is recursive
+dogfooding: the CI runners deploy themselves, the Nix cache caches its own derivations,
+and RenovateBot keeps everything up to date -- all running on infrastructure managed by
+the same code.
+
+## Architecture
+
+The system uses a two-module Bzlmod architecture. A public upstream repository
+([attic-iac](architecture/bzlmod-topology.md)) contains all reusable modules. Private
+overlay repositories add organization-specific configuration and deploy to their own
+clusters.
+
+- [Recursive Dogfooding](architecture/recursive-dogfooding.md) -- the core concept
+- [Bzlmod Topology](architecture/bzlmod-topology.md) -- two-module system
+- [Overlay System](architecture/overlay-system.md) -- how overlays merge with upstream
+- [Multi-Repo Layout](architecture/multi-repo-layout.md) -- three-repo topology
+- [RenovateBot Flywheel](architecture/renovatebot-flywheel.md) -- self-improving cycle
+
+## Getting Started
+
+- [Quick Start](infrastructure/quick-start.md) -- deploy from zero
+- [Customization Guide](infrastructure/customization-guide.md) -- configure for your org
+- [Clusters and Environments](infrastructure/clusters-and-environments.md) -- cluster layout
+
+## Build System
+
+- [Greedy Build Pattern](build-system/greedy-build-pattern.md) -- build fast, cache everything
+- [Watch-Store Bootstrap](build-system/watch-store.md) -- incremental Nix cache
+- [Container Builds](build-system/containers.md) -- nix2container, Dockerfile, rules_img
+- [Bazel Targets](build-system/bazel-targets.md) -- all build targets
+
+## Runners
+
+- [Overview](runners/README.md) -- 5 runner types
+- [Selection Guide](runners/runner-selection.md) -- which runner to use
+- [Runbook](runners/runbook.md) -- operational procedures
+
+## CI/CD
+
+- [Pipeline Overview](ci-cd/pipeline-overview.md) -- 4-stage pipeline
+- [Overlay Pipelines](ci-cd/overlay-pipelines.md) -- how overlays extend CI
+- [Deployment Flow](ci-cd/deployment-flow.md) -- commit to production
+
+## Reference
+
+- [OpenTofu Modules](reference/tofu-modules.md) -- all modules documented
+- [Configuration Reference](reference/config-reference.md) -- organization.yaml schema
+- [Environment Variables](reference/environment-variables.md) -- all env vars
+- [Justfile Commands](reference/justfile-commands.md) -- all just recipes

--- a/docs/infrastructure/clusters-and-environments.md
+++ b/docs/infrastructure/clusters-and-environments.md
@@ -1,0 +1,114 @@
+---
+title: Clusters and Environments
+order: 20
+---
+
+# Clusters and Environments
+
+This document describes the Kubernetes clusters, their roles, namespace layout, authentication methods, and database considerations.
+
+## Cluster Roles
+
+| Cluster | Role | Status | Access |
+|---------|------|--------|--------|
+| **beehive** | Development | Active | On-campus or via SOCKS proxy |
+| **rigel** | Staging / Production | Planned | TBD |
+
+### beehive
+
+The development cluster, managed by Rancher (UI at `rancher2.bates.edu`). All initial development, testing, and iteration happens here. The cluster runs on campus infrastructure and requires a SOCKS proxy for off-campus access. See [Proxy and Access](./proxy-and-access.md) for connectivity details.
+
+### rigel
+
+Reserved for staging and production workloads. Not yet provisioned. When brought online, it will mirror the beehive namespace layout but with production-grade resource limits, replica counts, and ingress configuration.
+
+## Namespace Layout
+
+Each functional component runs in its own namespace to provide resource isolation and RBAC boundaries.
+
+```mermaid
+graph TD
+    subgraph beehive["Beehive Cluster"]
+        NS1[attic-cache-dev]
+        NS2[bates-ils-runners]
+        NS3[runner-dashboard]
+    end
+    NS1 -->|"PostgreSQL via CNPG"| DB[(CloudNativePG)]
+    NS2 -->|"env: ATTIC_SERVER"| NS1
+```
+
+### attic-cache-dev
+
+Houses the Attic binary cache server and its PostgreSQL database:
+
+- **atticd** -- the cache daemon, running in monolithic mode (`--mode monolithic`) so it auto-runs database migrations on startup
+- **CloudNativePG cluster** -- manages the PostgreSQL instance(s) for Attic's metadata store
+- **PVCs** -- Longhorn-backed persistent volumes for cache object storage
+
+### bates-ils-runners
+
+Contains all GitLab Runner deployments. Each runner type (docker, dind, rocky8, rocky9, nix) runs as a separate pod managed by a Helm release. Runners reference the Attic cache via the `ATTIC_SERVER` environment variable pointing into the `attic-cache-dev` namespace.
+
+### runner-dashboard
+
+Hosts the SvelteKit runner dashboard application. The dashboard reads runner status from the GitLab API and displays build metrics.
+
+## Kubernetes Authentication
+
+Authentication differs between local development and CI pipelines.
+
+### Local Development
+
+Use a kubeconfig file obtained from Rancher:
+
+1. Log into Rancher at `rancher2.bates.edu` (requires SOCKS proxy if off-campus).
+2. Download the kubeconfig for the target cluster.
+3. Save it as `kubeconfig-beehive` at the overlay repository root (this path is gitignored).
+4. Pass it to OpenTofu:
+
+```bash
+tofu plan \
+  -var k8s_config_path=$PWD/kubeconfig-beehive \
+  -var cluster_context=beehive \
+  ...
+```
+
+### CI Pipelines
+
+CI uses the GitLab Kubernetes Agent, which provides in-cluster authentication without a kubeconfig file or proxy. The agent path follows the pattern:
+
+```
+bates-ils/projects/kubernetes/gitlab-agents:{environment}
+```
+
+This is set in the tfvars files used by CI and requires no additional network configuration.
+
+## CloudNativePG (PostgreSQL)
+
+The Attic cache stores metadata in PostgreSQL, managed by the CloudNativePG operator.
+
+### Key Details
+
+- Operator must be installed cluster-wide before deploying the Attic stack.
+- The OpenTofu modules create a `Cluster` custom resource that provisions PostgreSQL instances within the `attic-cache-dev` namespace.
+- Instance count and storage size are configured in `organization.yaml` under `environments.<env>.cache.postgres`.
+
+### Connection String Encoding
+
+CloudNativePG generates random passwords for database users. These passwords are stored in Kubernetes secrets and injected into the Attic pod as environment variables.
+
+**Passwords must be URL-encoded in connection strings.** If the generated password contains characters like `#`, `:`, `?`, `@`, `<`, `>`, or `&`, an unencoded connection string will fail to parse. The OpenTofu modules handle this encoding automatically via the `urlencode()` function, but be aware of this requirement if constructing connection strings manually.
+
+```
+# Correct
+postgresql://attic:p%40ss%3Aword@cnpg-cluster-rw:5432/attic
+
+# Incorrect -- will fail
+postgresql://attic:p@ss:word@cnpg-cluster-rw:5432/attic
+```
+
+## Related Documentation
+
+- [Quick Start](./quick-start.md) -- deployment walkthrough
+- [Customization Guide](./customization-guide.md) -- organization.yaml reference
+- [Proxy and Access](./proxy-and-access.md) -- SOCKS proxy setup for off-campus access

--- a/docs/infrastructure/customization-guide.md
+++ b/docs/infrastructure/customization-guide.md
@@ -1,0 +1,195 @@
+---
+title: Customization Guide
+order: 10
+---
+
+# Customization Guide
+
+All deployment parameters flow from a single file: `organization.yaml` at the repository root. This document explains its structure, how it feeds into the build system, and how overlay repositories extend it.
+
+## organization.yaml as the Single Source of Truth
+
+Rather than scattering configuration across tfvars, Helm values, and application config, this project consolidates everything into `organization.yaml`. Other configuration artifacts are either generated from it or reference it directly.
+
+```mermaid
+graph TD
+    OY["organization.yaml"] --> GEN["scripts/generate-environments.ts"]
+    OY --> TF["OpenTofu tfvars"]
+    OY --> HELM["Runner Helm values"]
+    GEN --> SK["SvelteKit env config"]
+```
+
+## Configuration Structure
+
+A representative `organization.yaml`:
+
+```yaml
+organization:
+  name: bates-ils
+
+environments:
+  beehive:
+    cluster_context: beehive
+    namespaces:
+      attic: attic-cache-dev
+      runners: bates-ils-runners
+      dashboard: runner-dashboard
+    cache:
+      host: attic.example.com
+      storage_class: longhorn
+      postgres:
+        instances: 1
+        storage: 10Gi
+
+  rigel:
+    cluster_context: rigel
+    # staging/production settings...
+
+runners:
+  docker:
+    executor: kubernetes
+    image: docker:27
+    tags: [docker]
+  dind:
+    executor: kubernetes
+    image: docker:27-dind
+    tags: [dind, privileged]
+    privileged: true
+  rocky8:
+    executor: kubernetes
+    image: rockylinux:8
+    tags: [rocky8]
+  rocky9:
+    executor: kubernetes
+    image: rockylinux:9
+    tags: [rocky9]
+  nix:
+    executor: kubernetes
+    image: nixos/nix:latest
+    tags: [nix]
+
+dashboard:
+  oauth:
+    provider: gitlab
+```
+
+### Top-Level Keys
+
+| Key | Purpose |
+|-----|---------|
+| `organization.name` | Names the deployment (used in resource labels and state keys) |
+| `environments` | Map of cluster environments, each with its own namespaces and settings |
+| `runners` | Runner type definitions shared across all environments |
+| `dashboard` | Dashboard-specific settings (OAuth provider, theme, etc.) |
+
+### Environment Block
+
+Each environment entry describes a single Kubernetes cluster target:
+
+- `cluster_context` -- the kubeconfig context name (or GitLab Agent path for CI)
+- `namespaces` -- maps logical roles (attic, runners, dashboard) to Kubernetes namespace names
+- `cache` -- Attic-specific settings: hostname, storage class, PostgreSQL sizing
+- Any environment-level overrides for runner resource limits
+
+### Runner Block
+
+Each key under `runners` defines a runner type. The key becomes the runner name. Fields map directly to GitLab Runner Helm chart values. See the "Adding a New Runner Type" section below.
+
+## Environment Config Generation
+
+The script `scripts/generate-environments.ts` reads `organization.yaml` and produces the SvelteKit environment configuration used by the runner dashboard:
+
+```bash
+npx tsx scripts/generate-environments.ts
+```
+
+This generates TypeScript files under `app/src/lib/config/` that export typed environment metadata, ensuring the dashboard UI stays in sync with the actual infrastructure.
+
+## Overlay Repositories
+
+Overlay repos (such as `attic-cache-bates` or `tinyland-infra`) contain their own `organization.yaml` that overrides the upstream defaults. The merge strategy is straightforward:
+
+1. The overlay `organization.yaml` is authoritative for all keys it defines.
+2. Keys not present in the overlay fall back to the upstream defaults.
+3. The Bazel overlay mechanism (`build/overlay.bzl`) handles the file-level merge when building targets.
+
+For OpenTofu, overlays supply their own tfvars files that point to the correct cluster contexts, namespaces, and credentials. The upstream `.tf` module definitions are reused without modification.
+
+## Adding a New Runner Type
+
+1. Add the runner definition to `organization.yaml`:
+
+```yaml
+runners:
+  # ...existing runners...
+  custom-builder:
+    executor: kubernetes
+    image: your-registry/custom-builder:latest
+    tags: [custom-builder]
+    run_untagged: false
+    cpu_limit: "2"
+    memory_limit: "4Gi"
+```
+
+2. Create or update the tfvars file for the target environment to include the new runner. Runners in the `bates-ils-runners` namespace use a self-contained `main.tf` in the overlay, so add the runner resource block there if it is overlay-specific.
+
+3. Plan and apply:
+
+```bash
+cd tofu/stacks/gitlab-runners
+tofu plan -var-file=../../../tfvars/runners-beehive.tfvars
+tofu apply -var-file=../../../tfvars/runners-beehive.tfvars
+```
+
+4. Verify registration:
+
+```bash
+kubectl -n bates-ils-runners get pods | grep custom-builder
+```
+
+The runner should appear as registered in the GitLab group's CI/CD settings.
+
+## Adding a New Environment
+
+1. Add the environment block to `organization.yaml`:
+
+```yaml
+environments:
+  # ...existing environments...
+  new-cluster:
+    cluster_context: new-cluster-context
+    namespaces:
+      attic: attic-cache-prod
+      runners: runners-prod
+      dashboard: dashboard-prod
+    cache:
+      host: attic-prod.example.com
+      storage_class: default
+      postgres:
+        instances: 2
+        storage: 50Gi
+```
+
+2. Create tfvars files for each stack targeting the new environment:
+
+```
+tfvars/attic-new-cluster.tfvars
+tfvars/runners-new-cluster.tfvars
+tfvars/dashboard-new-cluster.tfvars
+```
+
+3. Initialize a new backend state for each stack:
+
+```bash
+tofu init \
+  -backend-config="address=.../terraform/state/attic-new-cluster" \
+  # ...
+```
+
+4. Follow the [Quick Start](./quick-start.md) deployment order (attic, then runners, then dashboard) using the new tfvars files.
+
+## Related Documentation
+
+- [Quick Start](./quick-start.md) -- end-to-end deployment walkthrough
+- [Clusters and Environments](./clusters-and-environments.md) -- namespace layout and auth
+- [Proxy and Access](./proxy-and-access.md) -- network connectivity for on-premise clusters

--- a/docs/infrastructure/proxy-and-access.md
+++ b/docs/infrastructure/proxy-and-access.md
@@ -1,0 +1,119 @@
+---
+title: Proxy and Access
+order: 30
+---
+
+# Proxy and Access
+
+The beehive development cluster runs on campus infrastructure behind a firewall. Off-campus access requires a SOCKS5 proxy through a Tailscale node. CI pipelines bypass this requirement entirely by using the GitLab Kubernetes Agent.
+
+## Network Topology
+
+```mermaid
+graph LR
+    DEV["Developer (off-campus)"] -->|"SSH tunnel"| TS["xoxd-bates<br/>100.124.134.27"]
+    TS -->|"Campus network"| BH["Beehive Cluster"]
+    TS -->|"Campus network"| RN["Rancher UI<br/>rancher2.bates.edu"]
+    CI["GitLab CI"] -->|"K8s Agent (direct)"| BH
+```
+
+## Starting the SOCKS Proxy
+
+The Justfile provides a convenience command:
+
+```bash
+just proxy-up
+```
+
+This starts a SOCKS5 proxy by opening an SSH tunnel through the Tailscale node `xoxd-bates` (IP `100.124.134.27`). The tunnel runs in the background on `localhost:1080`.
+
+Under the hood, the command runs:
+
+```bash
+ssh -fN bates-socks
+```
+
+This relies on an SSH config entry named `bates-socks` that defines the Tailscale host and dynamic port forwarding. Ensure your `~/.ssh/config` includes the appropriate entry.
+
+## Using kubectl Through the Proxy
+
+Direct `kubectl` calls will fail off-campus because they cannot reach the cluster API server. The Justfile wraps kubectl with the proxy:
+
+```bash
+just bk get pods -n attic-cache-dev
+just bk logs -n bates-ils-runners <pod-name>
+```
+
+`just bk` is shorthand for running `kubectl` with `HTTPS_PROXY=socks5h://localhost:1080` set in the environment.
+
+## Using curl Through the Proxy
+
+For ad-hoc HTTP requests to cluster services or the Rancher API:
+
+```bash
+just bcurl https://rancher2.bates.edu/v3/clusters
+```
+
+`just bcurl` wraps `curl` with the same SOCKS proxy configuration.
+
+## Setting the Proxy for OpenTofu
+
+When running `tofu plan` or `tofu apply` against beehive from off-campus, export the proxy before invoking tofu:
+
+```bash
+export HTTPS_PROXY=socks5h://localhost:1080
+tofu plan -var-file=...
+```
+
+The `socks5h://` scheme (note the trailing `h`) ensures that DNS resolution also goes through the proxy, which is required for resolving internal hostnames.
+
+## Rancher UI
+
+The Rancher management interface is available at:
+
+```
+https://rancher2.bates.edu
+```
+
+Access requires the SOCKS proxy when off-campus. Use it to:
+
+- Download kubeconfig files for local development
+- Monitor cluster health and workloads
+- Inspect logs and events
+
+## kubeconfig-beehive
+
+The kubeconfig file for the beehive cluster is **not checked into version control** (it is listed in `.gitignore`). To obtain it:
+
+1. Start the proxy: `just proxy-up`
+2. Open Rancher at `https://rancher2.bates.edu` (configure your browser to use `localhost:1080` as a SOCKS proxy, or use a proxy-aware browser extension).
+3. Navigate to the beehive cluster and download the kubeconfig.
+4. Save it as `kubeconfig-beehive` at the repository root (or overlay root).
+
+The file contains cluster credentials and must not be committed or shared.
+
+## CI Pipelines -- No Proxy Needed
+
+GitLab CI pipelines do not use the SOCKS proxy. Instead, they authenticate via the GitLab Kubernetes Agent, which provides a direct, authenticated channel to the cluster:
+
+```
+bates-ils/projects/kubernetes/gitlab-agents:beehive
+```
+
+This agent path is configured in the CI tfvars files. The pipeline runner communicates with the agent through GitLab's infrastructure, bypassing the campus firewall entirely.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| `kubectl` hangs or times out | Proxy not running | Run `just proxy-up` |
+| `connection refused` on port 1080 | SSH tunnel died | Kill stale SSH processes, re-run `just proxy-up` |
+| DNS resolution failures | Using `socks5://` instead of `socks5h://` | Use `socks5h://` to proxy DNS |
+| Certificate errors from Rancher | Proxy not forwarding correctly | Verify `~/.ssh/config` entry for `bates-socks` |
+| CI pipeline cannot reach cluster | Agent not installed or misconfigured | Check GitLab Agent status in Rancher |
+
+## Related Documentation
+
+- [Quick Start](./quick-start.md) -- full deployment walkthrough
+- [Clusters and Environments](./clusters-and-environments.md) -- namespace layout and auth details
+- [Customization Guide](./customization-guide.md) -- organization.yaml reference

--- a/docs/infrastructure/quick-start.md
+++ b/docs/infrastructure/quick-start.md
@@ -1,0 +1,163 @@
+---
+title: Quick Start
+order: 1
+---
+
+# Quick Start
+
+A consolidated guide for deploying the Attic cache infrastructure from scratch or from an overlay repository.
+
+## Prerequisites
+
+Install the following tools before proceeding:
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| **Nix** (with flakes enabled) | Reproducible builds, container images, devShell | `experimental-features = nix-command flakes` in `nix.conf` |
+| **kubectl** | Kubernetes cluster access | Provided by the devShell |
+| **OpenTofu** | Infrastructure provisioning | Provided by the devShell |
+| **direnv** | Automatic environment loading | Hooks into `.envrc` at repo root |
+
+## Clone and Enter the DevShell
+
+```bash
+git clone https://github.com/Jesssullivan/attic-iac.git ~/git/attic-iac
+cd ~/git/attic-iac
+direnv allow
+```
+
+If you prefer not to use direnv, enter the shell manually:
+
+```bash
+nix develop
+```
+
+The devShell provides pinned versions of `tofu`, `kubectl`, `pnpm`, `node`, and other tooling.
+
+## Configure organization.yaml
+
+`organization.yaml` is the single source of truth for all deployment parameters. Edit it to match your cluster and organization details:
+
+```yaml
+organization:
+  name: your-org
+environments:
+  beehive:
+    cluster_context: beehive
+    # ...
+```
+
+See the [Customization Guide](./customization-guide.md) for a full breakdown of every field.
+
+## Initialize OpenTofu Backends
+
+Each stack uses a GitLab HTTP backend for remote state. Initialize them one at a time:
+
+```bash
+cd tofu/stacks/attic
+tofu init \
+  -backend-config="address=https://gitlab.com/api/v4/projects/<PROJECT_ID>/terraform/state/attic-beehive" \
+  -backend-config="lock_address=https://gitlab.com/api/v4/projects/<PROJECT_ID>/terraform/state/attic-beehive/lock" \
+  -backend-config="unlock_address=https://gitlab.com/api/v4/projects/<PROJECT_ID>/terraform/state/attic-beehive/lock" \
+  -backend-config="username=<GITLAB_USERNAME>"
+# TF_HTTP_PASSWORD env var provides the GitLab PAT for authentication
+```
+
+Repeat for each stack (`attic`, `gitlab-runners`, `runner-dashboard`), substituting the appropriate state name (`{stack}-{env}`).
+
+## Deployment Order
+
+Deploy the components in the following sequence. Each step depends on the one before it.
+
+```mermaid
+graph LR
+    A["1. Attic Cache"] --> B["2. GitLab Runners"]
+    B --> C["3. Runner Dashboard"]
+```
+
+### Step 1 -- Attic Cache
+
+The cache must be running first because runners reference it via the `ATTIC_SERVER` environment variable.
+
+```bash
+cd tofu/stacks/attic
+tofu plan -var-file=../../../tfvars/attic-beehive.tfvars
+tofu apply -var-file=../../../tfvars/attic-beehive.tfvars
+```
+
+Verify:
+
+```bash
+kubectl -n attic-cache-dev get pods
+# Expect: atticd pod Running, CloudNativePG cluster Ready
+```
+
+### Step 2 -- GitLab Runners
+
+```bash
+cd tofu/stacks/gitlab-runners
+tofu plan -var-file=../../../tfvars/runners-beehive.tfvars
+tofu apply -var-file=../../../tfvars/runners-beehive.tfvars
+```
+
+Verify:
+
+```bash
+kubectl -n bates-ils-runners get pods
+# Expect: one pod per runner type (docker, dind, rocky8, rocky9, nix)
+```
+
+### Step 3 -- Runner Dashboard
+
+```bash
+cd tofu/stacks/runner-dashboard
+tofu plan -var-file=../../../tfvars/dashboard-beehive.tfvars
+tofu apply -var-file=../../../tfvars/dashboard-beehive.tfvars
+```
+
+Verify:
+
+```bash
+kubectl -n runner-dashboard get pods
+# Expect: dashboard pod Running
+```
+
+## Overlay Deployments
+
+If you are deploying from an overlay repository (for example, a campus-specific configuration layered on top of the upstream project):
+
+1. Clone both repos as siblings:
+
+```bash
+git clone https://github.com/Jesssullivan/attic-iac.git ~/git/attic-iac
+git clone <overlay-repo-url> ~/git/attic-cache-bates
+```
+
+2. The overlay `MODULE.bazel` already declares a `local_path_override` pointing to the upstream sibling directory:
+
+```starlark
+local_path_override(
+    module_name = "attic-iac",
+    path = "../../attic-iac",
+)
+```
+
+Adjust the `path` value if your directory layout differs.
+
+3. Run Bazel and OpenTofu commands from within the overlay directory. The overlay's tfvars files supply campus-specific values, while the upstream `.tf` files provide the module definitions.
+
+```bash
+cd ~/git/attic-cache-bates
+tofu -chdir=../attic-iac/tofu/stacks/attic plan \
+  -var-file=~/git/attic-cache-bates/tfvars/attic-beehive.tfvars \
+  -var cluster_context=beehive \
+  -var k8s_config_path=$HOME/git/attic-cache-bates/kubeconfig-beehive
+```
+
+4. For off-campus deployments, start the SOCKS proxy first. See [Proxy and Access](./proxy-and-access.md) for details.
+
+## Next Steps
+
+- [Customization Guide](./customization-guide.md) -- configure organization.yaml for your site
+- [Clusters and Environments](./clusters-and-environments.md) -- understand the namespace layout
+- [Proxy and Access](./proxy-and-access.md) -- off-campus connectivity

--- a/docs/reference/config-reference.md
+++ b/docs/reference/config-reference.md
@@ -1,0 +1,151 @@
+---
+title: Configuration Reference
+order: 10
+---
+
+# Configuration Reference
+
+The `organization.yaml` file is the central configuration source for an
+attic-iac deployment. It defines the organization identity, target environments,
+runner fleet, and cache settings.
+
+## Schema
+
+### Top-Level Structure
+
+```yaml
+organization:
+  name: <string>
+  environments:
+    <env_name>: <environment_config>
+
+runners:
+  <runner_name>: <runner_config>
+
+cache:
+  server: <string>
+  name: <string>
+  storage_size: <string>
+```
+
+### organization
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Organization display name |
+| `environments` | map | Map of environment name to environment configuration |
+
+### organization.environments.\<env_name\>
+
+Each key under `environments` names a deployment target (e.g., `beehive`,
+`tinyland`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cluster_context` | string | Kubernetes context name or GitLab Agent path |
+| `namespace` | string | Target Kubernetes namespace for this environment |
+| `domain` | string | Base domain for ingress hosts in this environment |
+
+Example:
+
+```yaml
+organization:
+  name: bates-ils
+  environments:
+    beehive:
+      cluster_context: beehive
+      namespace: attic-cache
+      domain: apps.bates.edu
+```
+
+### runners
+
+A map of runner names to their configuration. Each runner corresponds to a
+GitLab Runner deployment in the target cluster.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Runner executor type: `docker`, `dind`, `rocky8`, `rocky9`, `nix` |
+| `image` | string | Default container image for job execution |
+| `concurrent_jobs` | integer | Maximum number of concurrent jobs |
+| `tags` | list of string | GitLab CI tags that route jobs to this runner |
+| `resources` | object | Kubernetes resource requests and limits |
+| `hpa` | object | Horizontal Pod Autoscaler configuration |
+
+#### runners.\<name\>.resources
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cpu_request` | string | CPU request (e.g., `"500m"`) |
+| `cpu_limit` | string | CPU limit (e.g., `"2"`) |
+| `memory_request` | string | Memory request (e.g., `"1Gi"`) |
+| `memory_limit` | string | Memory limit (e.g., `"4Gi"`) |
+
+Note: resource fields must be flat keys in TOML-based runner configuration.
+Nested tables cause type mismatches in GitLab Runner 17.x.
+
+#### runners.\<name\>.hpa
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `min_replicas` | integer | Minimum pod count |
+| `max_replicas` | integer | Maximum pod count |
+| `target_cpu_utilization` | integer | CPU utilization percentage target for scaling |
+
+Example:
+
+```yaml
+runners:
+  docker:
+    type: docker
+    image: docker:27
+    concurrent_jobs: 4
+    tags:
+      - docker
+      - linux
+    resources:
+      cpu_request: "500m"
+      cpu_limit: "2"
+      memory_request: "1Gi"
+      memory_limit: "4Gi"
+    hpa:
+      min_replicas: 1
+      max_replicas: 3
+      target_cpu_utilization: 70
+```
+
+### cache
+
+Configuration for the Attic binary cache server.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `server` | string | Full URL of the Attic cache server |
+| `name` | string | Cache name within the Attic server |
+| `storage_size` | string | Persistent volume size for cache storage (e.g., `"50Gi"`) |
+
+Example:
+
+```yaml
+cache:
+  server: https://attic.apps.bates.edu
+  name: bates
+  storage_size: 50Gi
+```
+
+## Validation
+
+The pipeline validate stage checks `organization.yaml` against this schema. The
+validation confirms:
+
+- All required fields are present
+- Environment names are valid DNS labels
+- Runner types are from the allowed set
+- Resource values parse as valid Kubernetes quantities
+- Cross-references between runners and environments are consistent
+
+## Related
+
+- [OpenTofu Modules](./tofu-modules.md) -- modules that consume this configuration
+- [Environment Variables](./environment-variables.md) -- variables that supplement config
+- [Pipeline Overview](../ci-cd/pipeline-overview.md) -- validation stage details

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,82 @@
+---
+title: Environment Variables
+order: 20
+---
+
+# Environment Variables
+
+This document lists all environment variables used across the attic-iac project,
+including CI/CD pipelines, local development, and runtime configuration.
+
+## OpenTofu Backend and Provider
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `TF_HTTP_PASSWORD` | Yes | GitLab Personal Access Token for the tofu HTTP state backend. Must have `api` scope on the project that stores state. |
+| `TF_VAR_gitlab_token` | Yes | GitLab token passed to the tofu GitLab provider for managing GitLab resources (runner registrations, project settings). |
+
+## OAuth (Runner Dashboard)
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `TF_VAR_gitlab_oauth_client_id` | For dashboard | OAuth2 application ID for GitLab authentication in the runner dashboard. |
+| `TF_VAR_gitlab_oauth_client_secret` | For dashboard | OAuth2 application secret. Must be kept confidential. |
+
+## Attic Cache
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ATTIC_SERVER` | On nix runners | URL of the Attic binary cache server (e.g., `https://attic.apps.bates.edu`). Set as a runner environment variable on nix-type runners. |
+| `ATTIC_CACHE` | On nix runners | Name of the Attic cache to push/pull from (e.g., `bates`). |
+
+## SvelteKit Runtime (Runner Dashboard)
+
+The runner-dashboard application reads environment variables with the
+`DASHBOARD_` prefix at runtime (SvelteKit `$env/dynamic/private`).
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DASHBOARD_GITLAB_API_URL` | Yes | Base URL for the GitLab API (e.g., `https://gitlab.com/api/v4`). |
+| `DASHBOARD_GITLAB_TOKEN` | Yes | GitLab token for the dashboard to query runner and pipeline status. |
+| `DASHBOARD_GITLAB_GROUP_ID` | Yes | GitLab group ID whose runners are displayed. |
+
+## Documentation Site
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DOCS_BASE_PATH` | No | Base URL path for the documentation site when deployed under a subpath (e.g., `/attic-iac/docs`). Defaults to `/`. |
+
+## Network and Proxy
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `HTTPS_PROXY` | Off-campus | SOCKS5 proxy URL for accessing on-campus Kubernetes clusters from off-campus (e.g., `socks5h://localhost:1080`). Required when running tofu or kubectl against clusters behind a campus firewall. |
+
+## CI/CD Pipeline
+
+These variables are typically set in the GitLab project CI/CD settings, not
+locally.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `UPSTREAM_REPO_URL` | Overlay only | GitHub URL of the upstream attic-iac repository. Used by overlay pipelines to clone upstream code. |
+| `UPSTREAM_REF` | Overlay only | Git ref (branch, tag, or SHA) to check out from the upstream repository. Defaults to `main`. |
+| `GITLAB_TOKEN` | CI only | Token used by CI jobs for GitLab API calls (runner registration, status checks). Distinct from `TF_VAR_gitlab_token` in scope. |
+| `CI_ENVIRONMENT_NAME` | CI only | Set by GitLab CI; used to select the correct `.tfvars` file and state key. |
+
+## Local Development
+
+These are not environment variables per se, but local configuration that
+supplements the variables above.
+
+| Item | Description |
+|------|-------------|
+| `kubeconfig-beehive` | Kubeconfig file (gitignored) for direct cluster access. Path passed via `TF_VAR_k8s_config_path`. |
+| `~/.ssh/gitlab-work` | SSH key for the institutional GitLab account (`jsullivan2_bates`). |
+| `.env` | Local environment file (gitignored) containing `TF_HTTP_PASSWORD` and other secrets. Never committed. |
+
+## Related
+
+- [Configuration Reference](./config-reference.md) -- organization.yaml schema
+- [Overlay Pipelines](../ci-cd/overlay-pipelines.md) -- CI variable usage in overlays
+- [Justfile Commands](./justfile-commands.md) -- recipes that consume these variables

--- a/docs/reference/justfile-commands.md
+++ b/docs/reference/justfile-commands.md
@@ -1,0 +1,139 @@
+---
+title: Justfile Commands
+order: 30
+---
+
+# Justfile Commands
+
+The project Justfile provides recipes for common development, build, and
+deployment tasks. Run `just --list` to see all available recipes or
+`just <recipe> --help` for usage details.
+
+## Proxy
+
+Recipes for managing the SOCKS5 proxy used to reach on-campus clusters from
+off-campus.
+
+| Recipe | Description |
+|--------|-------------|
+| `just proxy-up` | Start the SOCKS5 proxy via SSH tunnel to the campus jump host |
+| `just proxy-down` | Stop the SOCKS5 proxy tunnel |
+| `just proxy-status` | Check whether the proxy tunnel is running |
+| `just bk <args>` | Run kubectl through the SOCKS proxy (shorthand for proxied kubectl) |
+| `just bcurl <args>` | Run curl through the SOCKS proxy |
+
+## Development
+
+General development workflow recipes.
+
+| Recipe | Description |
+|--------|-------------|
+| `just dev` | Start all development servers (app + docs) |
+| `just check` | Run quick checks (lint, format, type check) |
+| `just check-full` | Run full validation suite (lint, format, type check, tests, tofu validate) |
+| `just info` | Print project info (versions, paths, git status) |
+
+## Nix
+
+Recipes for Nix-based builds and maintenance.
+
+| Recipe | Description |
+|--------|-------------|
+| `just nix-build` | Build the project with Nix |
+| `just nix-build-container` | Build the OCI container image via nix2container |
+| `just nix-check` | Run `nix flake check` |
+| `just nix-update` | Update flake inputs |
+
+## OpenTofu
+
+Infrastructure-as-code recipes for planning and applying changes.
+
+| Recipe | Description |
+|--------|-------------|
+| `just tofu-init` | Initialize tofu for all stacks |
+| `just tofu-plan` | Run tofu plan for all stacks |
+| `just tofu-apply` | Run tofu apply for all stacks |
+| `just tofu-deploy` | Full deploy cycle: init, plan, apply |
+| `just tofu-validate-all` | Run tofu validate against every module in `tofu/modules/` |
+
+## Bazel
+
+Build system recipes for the Bzlmod-based build.
+
+| Recipe | Description |
+|--------|-------------|
+| `just bazel-build` | Build all targets (`bazel build //...`) |
+| `just bazel-test` | Run all tests (`bazel test //...`) |
+| `just bazel-clean` | Clean Bazel build outputs |
+
+## Kubernetes
+
+Cluster inspection and debugging recipes. All commands route through the proxy
+when `HTTPS_PROXY` is set.
+
+| Recipe | Description |
+|--------|-------------|
+| `just k8s-pods` | List pods in the target namespace |
+| `just k8s-logs` | Tail logs from a pod |
+| `just k8s-describe` | Describe a Kubernetes resource |
+| `just k8s-events` | Show recent events in the namespace |
+| `just k8s-forward` | Port-forward to a pod or service |
+
+## App (Runner Dashboard)
+
+Recipes for the SvelteKit runner-dashboard application.
+
+| Recipe | Description |
+|--------|-------------|
+| `just app-install` | Install app dependencies with pnpm |
+| `just app-dev` | Start the SvelteKit dev server |
+| `just app-build` | Production build via adapter-node |
+| `just app-test` | Run the test suite (Vitest) |
+| `just app-check` | Run svelte-check (type checking) |
+
+## Runners
+
+Recipes specific to the GitLab Runner infrastructure stack.
+
+| Recipe | Description |
+|--------|-------------|
+| `just runners-init` | Initialize tofu for the runners stack |
+| `just runners-plan` | Plan changes to the runners stack |
+| `just runners-apply` | Apply changes to the runners stack |
+
+## Attic
+
+Recipes for the Attic binary cache stack.
+
+| Recipe | Description |
+|--------|-------------|
+| `just attic-init` | Initialize tofu for the attic stack |
+| `just attic-plan` | Plan changes to the attic stack |
+| `just attic-apply` | Apply changes to the attic stack |
+| `just attic-status` | Show current attic deployment status |
+| `just attic-health` | Run health check against the attic server endpoint |
+
+## Docs
+
+Recipes for the documentation site.
+
+| Recipe | Description |
+|--------|-------------|
+| `just docs-dev` | Start the documentation site dev server |
+| `just docs-build` | Build the documentation site for deployment |
+
+## TeX
+
+Recipes for building the research document.
+
+| Recipe | Description |
+|--------|-------------|
+| `just tex` | Compile the TeX research document to PDF |
+| `just tex-clean` | Remove TeX build artifacts |
+| `just tex-watch` | Watch for changes and recompile automatically |
+
+## Related
+
+- [Environment Variables](./environment-variables.md) -- variables consumed by these recipes
+- [Configuration Reference](./config-reference.md) -- organization.yaml used by tofu recipes
+- [Pipeline Overview](../ci-cd/pipeline-overview.md) -- CI equivalents of local recipes

--- a/docs/reference/tofu-modules.md
+++ b/docs/reference/tofu-modules.md
@@ -1,0 +1,124 @@
+---
+title: OpenTofu Modules
+order: 1
+---
+
+# OpenTofu Modules
+
+All reusable infrastructure modules live in `tofu/modules/`. Each module is
+designed to be composed by stack root configurations in `tofu/stacks/`.
+
+## attic-server
+
+Deploys the Attic binary cache server as a Kubernetes Deployment with an
+associated Service and Ingress.
+
+- **Inputs**: image, replicas, storage size, database URL, server URL, cache name,
+  namespace, ingress host, TLS secret name
+- **Outputs**: service endpoint, ingress host
+- **Dependencies**: `cloudnative-pg` (for PostgreSQL), `k8s-namespace`
+
+## attic-gc
+
+Deploys a garbage collection CronJob that periodically cleans expired entries
+from the Attic cache.
+
+- **Inputs**: image, schedule (cron expression), cache name, server URL, namespace
+- **Outputs**: cronjob name
+- **Dependencies**: `attic-server`
+
+## cloudnative-pg
+
+Provisions a PostgreSQL cluster using the CloudNativePG operator.
+
+- **Inputs**: cluster name, instances, storage size, database name, namespace,
+  backup schedule
+- **Outputs**: connection URI (with urlencode-safe credentials), cluster name
+- **Dependencies**: CloudNativePG operator must be installed in the cluster
+
+Note: connection strings must use `urlencode()` for passwords, as CNPG may
+generate credentials containing URL-unsafe characters.
+
+## gitlab-runner
+
+Deploys a GitLab Runner with Horizontal Pod Autoscaler support. Supports
+multiple runner types (docker, dind, rocky8, rocky9, nix) through configuration
+variables.
+
+- **Inputs**: runner name, type, image, tags, concurrent jobs, namespace,
+  registration token, resource requests/limits, HPA min/max replicas,
+  CPU utilization target
+- **Outputs**: runner name, HPA name
+- **Dependencies**: `k8s-namespace`, GitLab group/project for registration
+
+## k8s-namespace
+
+Creates a Kubernetes namespace with RBAC bindings and optional resource quotas.
+
+- **Inputs**: namespace name, labels, annotations, resource quota (cpu, memory,
+  pods), role bindings
+- **Outputs**: namespace name
+- **Dependencies**: none
+
+## k8s-ingress
+
+Creates a Kubernetes Ingress resource with TLS termination via cert-manager.
+
+- **Inputs**: name, namespace, host, service name, service port, TLS secret name,
+  cert-manager cluster issuer, annotations
+- **Outputs**: ingress name, host
+- **Dependencies**: cert-manager operator, target Service
+
+## k8s-deployment
+
+A generic Kubernetes Deployment module for workloads that do not need
+specialized logic.
+
+- **Inputs**: name, namespace, image, replicas, ports, environment variables,
+  resource requests/limits, volume mounts, liveness/readiness probes
+- **Outputs**: deployment name, selector labels
+- **Dependencies**: `k8s-namespace`
+
+## k8s-service
+
+Creates a Kubernetes Service to expose a Deployment.
+
+- **Inputs**: name, namespace, selector labels, port, target port, type
+  (ClusterIP, NodePort, LoadBalancer)
+- **Outputs**: service name, cluster IP
+- **Dependencies**: target Deployment
+
+## k8s-secret
+
+Creates a Kubernetes Secret from a map of key-value pairs.
+
+- **Inputs**: name, namespace, data (map of string to string), type (Opaque,
+  kubernetes.io/tls, etc.)
+- **Outputs**: secret name
+- **Dependencies**: `k8s-namespace`
+
+## runner-dashboard
+
+Deploys the SvelteKit runner-dashboard application as a Kubernetes Deployment
+with Service and Ingress.
+
+- **Inputs**: image, replicas, namespace, ingress host, TLS secret name,
+  GitLab API URL, OAuth client ID, OAuth client secret, environment variables
+- **Outputs**: service endpoint, ingress host
+- **Dependencies**: `k8s-namespace`, `k8s-ingress`
+
+## monitoring
+
+Creates a Prometheus ServiceMonitor resource for scraping metrics from a target
+Service.
+
+- **Inputs**: name, namespace, service name, port name, path, interval,
+  labels (for Prometheus selector matching)
+- **Outputs**: servicemonitor name
+- **Dependencies**: Prometheus Operator (kube-prometheus-stack or equivalent)
+
+## Related
+
+- [Configuration Reference](./config-reference.md) -- organization.yaml schema
+- [Pipeline Overview](../ci-cd/pipeline-overview.md) -- how modules are validated and deployed
+- [Environment Variables](./environment-variables.md) -- variables consumed by stacks

--- a/docs/runners/hpa-tuning.md
+++ b/docs/runners/hpa-tuning.md
@@ -1,300 +1,64 @@
-# HPA Tuning Guide
+---
+title: HPA Tuning
+order: 40
+---
 
-Guide for tuning Horizontal Pod Autoscaler settings for the GitLab runners.
+# HPA Tuning
 
-## Overview
-
-Each runner type has an HPA that scales based on:
-
-- CPU utilization (target: 70%)
-- Memory utilization (target: 80%)
+Each runner type has an independent HorizontalPodAutoscaler (HPA) that
+manages replica count based on CPU utilization.
 
 ## Default Configuration
 
-| Runner | Min | Max | Scale Up | Scale Down |
-| ------ | --- | --- | -------- | ---------- |
-| docker | 1   | 5   | 15s      | 5min       |
-| dind   | 1   | 3   | 15s      | 5min       |
-| rocky8 | 1   | 3   | 15s      | 5min       |
-| rocky9 | 1   | 3   | 15s      | 5min       |
-| nix    | 1   | 3   | 15s      | 5min       |
+| Parameter | Value |
+|-----------|-------|
+| Minimum replicas | 1 |
+| Maximum replicas | 5 |
+| Scale-up stabilization window | 15 seconds |
+| Scale-down stabilization window | 5 minutes |
+| Target metric | CPU utilization at 70% |
 
-## Checking HPA Status
+The asymmetric stabilization windows are intentional. The short scale-up
+window allows the cluster to respond quickly to load spikes. The longer
+scale-down window prevents thrashing when load fluctuates around the
+threshold.
+
+## Overriding Defaults
+
+HPA parameters are configured per runner type in `organization.yaml`. To
+change the replica range or stabilization windows for a specific runner,
+edit the corresponding entry and run `tofu apply` from the overlay.
+
+## Monitoring
+
+Check HPA status for all runners in the namespace:
 
 ```bash
-# View all HPAs
 kubectl get hpa -n bates-ils-runners
-
-# Detailed HPA status
-kubectl describe hpa bates-docker-hpa -n bates-ils-runners
-
-# Watch HPA in real-time
-kubectl get hpa -n bates-ils-runners -w
-
-# Check metrics
-kubectl top pods -n bates-ils-runners
 ```
 
-## Understanding HPA Metrics
+This shows current and desired replica counts, current CPU utilization, and
+whether the autoscaler is actively scaling.
+
+For more detail on a specific runner:
 
 ```bash
-# Example output
-NAME                    REFERENCE             TARGETS           MINPODS   MAXPODS   REPLICAS
-bates-docker-hpa        Deployment/bates-...  45%/70%, 30%/80%  1         5         2
+kubectl describe hpa runner-docker -n bates-ils-runners
 ```
 
-- `45%/70%`: Current CPU / Target CPU
-- `30%/80%`: Current Memory / Target Memory
-- `REPLICAS`: Current number of pods
-
-## Tuning Parameters
-
-### Adjusting Targets
-
-Edit `beehive.tfvars`:
-
-```hcl
-# Lower targets = more aggressive scaling
-hpa_cpu_target    = 60  # Scale up earlier
-hpa_memory_target = 70  # Scale up earlier
-
-# Higher targets = less aggressive scaling
-hpa_cpu_target    = 80  # Wait longer to scale
-hpa_memory_target = 90  # Wait longer to scale
-```
-
-### Adjusting Replica Limits
-
-```hcl
-# High-volume runner
-docker_hpa_min_replicas = 2   # Always have 2 running
-docker_hpa_max_replicas = 10  # Allow more scaling
-
-# Low-volume runner
-rocky8_hpa_min_replicas = 1
-rocky8_hpa_max_replicas = 2
-```
-
-### Adjusting Stabilization Windows
-
-```hcl
-# Faster scale-up for bursty workloads
-hpa_scale_up_window = 0  # No stabilization, scale immediately
-
-# Slower scale-down to handle repeated bursts
-hpa_scale_down_window = 600  # 10 minutes
-```
-
-## Scaling Behavior
-
-### Scale Up Behavior
-
-Default configuration:
-
-```yaml
-scaleUp:
-  stabilizationWindowSeconds: 15
-  policies:
-    - type: Percent
-      value: 100 # Can double pods
-      periodSeconds: 30
-    - type: Pods
-      value: 2 # Or add 2 pods
-      periodSeconds: 30
-  selectPolicy: Max # Use whichever adds more
-```
-
-This means:
-
-- Scale up can happen 15 seconds after detection
-- Can double pods OR add 2, whichever is more
-
-### Scale Down Behavior
-
-Default configuration:
-
-```yaml
-scaleDown:
-  stabilizationWindowSeconds: 300 # 5 minutes
-  policies:
-    - type: Percent
-      value: 30 # Remove 30% of pods
-      periodSeconds: 60
-  selectPolicy: Min # Conservative
-```
-
-This means:
-
-- Wait 5 minutes before scaling down
-- Remove max 30% of pods per minute
-- This protects running jobs
-
-## Workload Patterns
-
-### Bursty Workloads (Push-triggered)
-
-```hcl
-# Fast scale-up, slow scale-down
-hpa_scale_up_window   = 0
-hpa_scale_down_window = 600
-
-docker_hpa_min_replicas = 1
-docker_hpa_max_replicas = 10
-```
-
-### Steady Workloads (Scheduled)
-
-```hcl
-# Moderate scaling
-hpa_scale_up_window   = 60
-hpa_scale_down_window = 300
-
-docker_hpa_min_replicas = 2
-docker_hpa_max_replicas = 4
-```
-
-### Peak Hour Patterns
-
-Consider using scheduled scaling with CronJobs:
-
-```yaml
-# Scale up before peak hours
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: scale-up-morning
-  namespace: bates-ils-runners
-spec:
-  schedule: "0 8 * * 1-5" # 8 AM weekdays
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          containers:
-            - name: scale
-              image: bitnami/kubectl:1.29
-              command:
-                - kubectl
-                - scale
-                - deployment/bates-docker
-                - --replicas=3
-                - -n
-                - bates-ils-runners
-          restartPolicy: OnFailure
-```
-
-## Monitoring HPA
-
-### Prometheus Queries
-
-```promql
-# HPA desired replicas vs actual
-kube_horizontalpodautoscaler_status_desired_replicas{namespace="bates-ils-runners"}
-- kube_horizontalpodautoscaler_status_current_replicas{namespace="bates-ils-runners"}
-
-# HPA utilization ratio
-kube_horizontalpodautoscaler_status_current_replicas{namespace="bates-ils-runners"}
-/ kube_horizontalpodautoscaler_spec_max_replicas{namespace="bates-ils-runners"}
-
-# Scaling events
-changes(kube_horizontalpodautoscaler_status_current_replicas{namespace="bates-ils-runners"}[1h])
-```
-
-### Grafana Dashboard
-
-Key panels to include:
-
-1. Replica count over time
-2. CPU/Memory utilization vs targets
-3. Scaling events timeline
-4. Job queue depth (if available)
-
-## Troubleshooting
-
-### HPA Not Scaling Up
-
-1. **Check metrics-server**
-
-   ```bash
-   kubectl get pods -n kube-system | grep metrics
-   kubectl top pods -n bates-ils-runners
-   ```
-
-2. **Check resource requests**
-
-   ```bash
-   kubectl get deployment bates-docker -n bates-ils-runners -o yaml | grep -A5 resources
-   ```
-
-   HPA requires resource requests to calculate utilization.
-
-3. **Check target values**
-   ```bash
-   kubectl describe hpa bates-docker-hpa -n bates-ils-runners | grep -A5 Metrics
-   ```
-
-### HPA Scaling Too Aggressively
-
-1. **Increase targets**
-
-   ```hcl
-   hpa_cpu_target    = 80
-   hpa_memory_target = 90
-   ```
-
-2. **Increase stabilization window**
-
-   ```hcl
-   hpa_scale_up_window = 60  # Wait 1 minute
-   ```
-
-3. **Check for noisy metrics**
-   ```bash
-   kubectl top pods -n bates-ils-runners
-   # Run multiple times to see variance
-   ```
-
-### HPA Not Scaling Down
-
-1. **Check stabilization window**
-   The default 5-minute window means it won't scale down quickly.
-
-2. **Check minimum replicas**
-
-   ```bash
-   kubectl get hpa bates-docker-hpa -n bates-ils-runners -o yaml | grep minReplicas
-   ```
-
-3. **Check for stuck pods**
-   ```bash
-   kubectl get pods -n bates-ils-runners | grep -v Running
-   ```
-
-## Best Practices
-
-1. **Start conservative**: Begin with default settings and adjust based on data
-
-2. **Monitor before tuning**: Collect at least a week of data before making changes
-
-3. **Test in off-hours**: Make HPA changes during low-activity periods
-
-4. **Use PDB**: Always pair HPA with Pod Disruption Budget to protect running jobs
-
-5. **Document changes**: Track HPA tuning decisions in commit messages
-
-## Applying Changes
-
-After editing `beehive.tfvars`:
-
-```bash
-cd tofu/stacks/bates-ils-runners
-just plan
-just apply
-```
-
-Or from the root:
-
-```bash
-just ils-runners-plan
-just ils-runners-apply
-```
+## Scaling Considerations
+
+- **docker**: Scales frequently under mixed workloads. The default range
+  (1--5) is usually sufficient.
+- **dind**: Container builds are bursty. If builds queue during peak hours,
+  consider increasing the maximum.
+- **rocky8/rocky9**: Typically low utilization. Minimum of 1 keeps a warm
+  pod available.
+- **nix**: CPU-intensive builds can saturate a pod quickly. Monitor
+  utilization and adjust the maximum if builds are queuing.
+
+## Related
+
+- [Runbook](runbook.md) -- procedures for scaling up and emergency stop
+- [Troubleshooting](troubleshooting.md) -- diagnosing pod crashes from
+  resource pressure

--- a/docs/runners/nix-builds.md
+++ b/docs/runners/nix-builds.md
@@ -1,17 +1,31 @@
-# Nix Builds with Attic Cache
+---
+title: Nix Builds
+order: 30
+---
 
-Guide for using the Nix runner with Attic binary cache integration.
+# Nix Builds
 
-## Overview
+The `nix` runner provides a NixOS-based environment with Nix flakes enabled
+and the Attic binary cache pre-configured.
 
-The `bates-nix` runner provides:
+## Environment
 
-- Nix with flakes enabled
-- Integration with Attic binary cache
-- 20Gi ephemeral Nix store per job
-- Automatic experimental features enabled
+The following environment variables are set automatically on every nix runner
+pod:
 
-## Quick Start
+- `ATTIC_SERVER` -- URL of the Attic cache server (in the
+  `attic-cache-dev` namespace).
+- `ATTIC_CACHE` -- name of the binary cache to push to and pull from.
+
+These variables allow CI jobs to interact with the Attic cache without
+manual configuration.
+
+## Recommended Pipeline Pattern
+
+A typical Nix CI job follows this sequence:
+
+1. **Build** the derivation with `nix build`.
+2. **Push** the result to the Attic cache with `attic push`.
 
 ```yaml
 nix-build:
@@ -19,361 +33,50 @@ nix-build:
     - nix
     - flakes
   script:
-    - nix build .#default
-    - nix flake check
+    - nix build .#package
+    - attic push "$ATTIC_CACHE" ./result
 ```
 
-## Attic Cache Integration
+## watch-store for Incremental Caching
 
-The Nix runner is pre-configured with the Attic cache at `https://attic-cache.beehive.bates.edu`.
-
-### Environment Variables
-
-Available in all Nix jobs:
-
-- `ATTIC_SERVER`: `https://attic-cache.beehive.bates.edu`
-- `ATTIC_CACHE`: `main`
-- `NIX_CONFIG`: `experimental-features = nix-command flakes`
-
-### Pushing to Cache
-
-To push build results to the cache, you need the `ATTIC_TOKEN` variable:
+For long-running builds, use `attic watch-store` to incrementally populate
+the cache as store paths are realized. This is useful when a build produces
+many intermediate derivations:
 
 ```yaml
-nix-build-and-cache:
-  tags:
-    - nix
-  variables:
-    ATTIC_TOKEN: $ATTIC_TOKEN # Set in GitLab CI/CD variables
-  script:
-    - nix build .#default
-    # Configure attic
-    - attic login bates $ATTIC_SERVER $ATTIC_TOKEN
-    - attic use main
-    # Push result to cache
-    - attic push main result
-```
-
-### Setting Up ATTIC_TOKEN
-
-1. Go to your project's **Settings > CI/CD > Variables**
-2. Add `ATTIC_TOKEN` with:
-   - Value: Your Attic token
-   - Type: Variable
-   - Protect variable: Yes (recommended)
-   - Mask variable: Yes
-
-## Common Workflows
-
-### Build and Test
-
-```yaml
-stages:
-  - build
-  - test
-
-build:
-  stage: build
-  tags:
-    - nix
-  script:
-    - nix build .#default
-  artifacts:
-    paths:
-      - result
-
-test:
-  stage: test
-  tags:
-    - nix
-  script:
-    - nix flake check
-```
-
-### Build Multiple Packages
-
-```yaml
-build-all:
-  tags:
-    - nix
-  script:
-    - nix build .#package1
-    - nix build .#package2
-    - nix build .#all # Or use a combined output
-```
-
-### Development Shell Testing
-
-```yaml
-test-devshell:
-  tags:
-    - nix
-  script:
-    - nix develop -c bash -c "echo 'Dev shell works'"
-    - nix develop -c make test
-```
-
-### Cross-Compilation
-
-```yaml
-cross-compile:
-  tags:
-    - nix
-  script:
-    - nix build .#packages.aarch64-linux.default
-```
-
-### OCI Container Build
-
-```yaml
-build-container:
-  tags:
-    - nix
-  script:
-    - nix build .#container
-    # Load into docker if needed
-    - docker load < result
-```
-
-## Flake Templates
-
-### Basic flake.nix
-
-```nix
-{
-  description = "My project";
-
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
-
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-      in {
-        packages.default = pkgs.hello;
-
-        devShells.default = pkgs.mkShell {
-          buildInputs = [ pkgs.hello ];
-        };
-
-        checks.default = self.packages.${system}.default;
-      });
-}
-```
-
-### With Attic Cache Configuration
-
-Add to your `flake.nix`:
-
-```nix
-{
-  nixConfig = {
-    extra-substituters = [
-      "https://attic-cache.beehive.bates.edu/main"
-    ];
-    extra-trusted-public-keys = [
-      "main:YOUR_PUBLIC_KEY_HERE"
-    ];
-  };
-
-  # ... rest of flake
-}
-```
-
-## Caching Strategies
-
-### Greedy Push (Recommended)
-
-Push everything that was built:
-
-```yaml
-build-and-cache:
-  tags:
-    - nix
-  script:
-    - nix build .#default
-    - attic push main result -j 4 # Parallel upload
-```
-
-### Selective Push
-
-Push only specific outputs:
-
-```yaml
-build-and-cache:
-  tags:
-    - nix
-  script:
-    - nix build .#mypackage
-    - attic push main ./result
-    # Don't push development dependencies
-```
-
-### Pre-warm Cache
-
-For large projects, pre-warm the cache:
-
-```yaml
-warm-cache:
-  tags:
-    - nix
-  only:
-    - schedules
-  script:
-    - nix build .#default --dry-run 2>&1 | grep "will be built" && \
-      nix build .#default && attic push main result || \
-      echo "Cache is warm"
-```
-
-## Performance Tips
-
-### 1. Use Nix Sandbox
-
-Ensure builds are reproducible:
-
-```yaml
-build:
-  tags:
-    - nix
-  script:
-    - nix build .#default --sandbox
-```
-
-### 2. Limit Parallelism for Memory
-
-```yaml
-build-large:
-  tags:
-    - nix
-  variables:
-    NIX_BUILD_CORES: "2"
-  script:
-    - nix build .#large-package
-```
-
-### 3. Garbage Collection
-
-Clean up before large builds:
-
-```yaml
-build:
-  tags:
-    - nix
-  before_script:
-    - nix-collect-garbage
-  script:
-    - nix build .#default
-```
-
-### 4. Flake Lock Updates
-
-Cache the lock file:
-
-```yaml
-build:
-  tags:
-    - nix
-  cache:
-    key: flake-lock-$CI_COMMIT_REF_SLUG
-    paths:
-      - flake.lock
-  script:
-    - nix build .#default
-```
-
-## Troubleshooting
-
-### "experimental Nix feature 'flakes' is disabled"
-
-Ensure you're using the correct tags:
-
-```yaml
-tags:
-  - nix
-  - flakes
-```
-
-### Slow builds (no cache hits)
-
-1. Check Attic configuration:
-
-   ```yaml
-   script:
-     - echo "Server: $ATTIC_SERVER"
-     - echo "Cache: $ATTIC_CACHE"
-   ```
-
-2. Verify substituters are configured:
-   ```yaml
-   script:
-     - nix show-config | grep substituters
-   ```
-
-### Out of disk space
-
-The Nix store has a 20Gi limit. For large builds:
-
-1. Clean garbage first:
-
-   ```yaml
-   before_script:
-     - nix-collect-garbage -d
-   ```
-
-2. Request larger store (contact admin)
-
-### "cannot build on remote"
-
-The Nix runner doesn't use remote builders. All builds are local. For distributed builds, consider Hydra.
-
-## Example: Full CI/CD Pipeline
-
-```yaml
-stages:
-  - check
-  - build
-  - test
-  - deploy
-
-variables:
-  ATTIC_TOKEN: $ATTIC_TOKEN
-
-.nix-job:
+nix-build-large:
   tags:
     - nix
     - flakes
-
-lint:
-  extends: .nix-job
-  stage: check
   script:
-    - nix flake check
-
-build:
-  extends: .nix-job
-  stage: build
-  script:
-    - nix build .#default
-    - attic push main result
-  artifacts:
-    paths:
-      - result
-
-test:
-  extends: .nix-job
-  stage: test
-  script:
-    - nix develop -c make test
-
-deploy:
-  extends: .nix-job
-  stage: deploy
-  only:
-    - main
-  script:
-    - nix build .#deploy-script
-    - ./result/bin/deploy
+    - attic watch-store "$ATTIC_CACHE" &
+    - nix build .#large-package
+    - wait
 ```
+
+The background `watch-store` process monitors the Nix store and pushes new
+paths to Attic as they appear, rather than waiting for the entire build to
+complete.
+
+## Bootstrap Behavior
+
+The first build on a fresh cache has no cached paths to pull from, so it
+will be slow. Subsequent builds benefit from the cache and complete
+significantly faster. This is expected and does not indicate a
+misconfiguration.
+
+## Attic Binary
+
+The Attic binary is located at `/bin/atticd` inside the container. Note that
+the binary is called `atticd`, not `attic-server`.
+
+## Resource Limits
+
+Nix builds tend to be CPU-intensive due to derivation evaluation and
+compilation:
+
+- **CPU**: 2 cores
+- **Memory**: 4Gi
+
+If builds fail with out-of-memory errors or take excessively long, consider
+adjusting the resource limits. See [HPA Tuning](hpa-tuning.md).

--- a/docs/runners/security-model.md
+++ b/docs/runners/security-model.md
@@ -1,151 +1,59 @@
-# Runner Security Model
+---
+title: Security Model
+order: 50
+---
 
-Security controls applied to the bates-ils HPA runner pool.
+# Security Model
 
-## Overview
+This document describes the security boundaries and access controls for the
+runner infrastructure.
 
-Each CI job (except dind) runs in an ephemeral Kubernetes namespace with
-network isolation, resource limits, and restricted RBAC. Namespaces are
-created at job start and cleaned up after completion, with a CronJob as a
-safety net for orphans.
+## Privilege Boundary
 
-## Namespace-Per-Job Isolation
+Only the `dind` runner operates in privileged mode. This is required for the
+Docker daemon sidecar and cannot be avoided for Docker-in-Docker builds. All
+other runner types (`docker`, `rocky8`, `rocky9`, `nix`) run as unprivileged
+containers.
 
-Runners with `namespace_per_job` enabled create a unique `ci-job-*` namespace
-for each pipeline job:
+For container builds that do not require a full Docker daemon, consider using
+Kaniko on the unprivileged `docker` runner instead. See
+[Docker Builds](docker-builds.md) for details.
 
-| Runner | namespace_per_job | Reason                                     |
-| ------ | ----------------- | ------------------------------------------ |
-| docker | yes               | Standard isolation                         |
-| rocky8 | yes               | Standard isolation                         |
-| rocky9 | yes               | Standard isolation                         |
-| nix    | yes               | Standard isolation                         |
-| dind   | **no**            | Requires shared Docker daemon (privileged) |
+## Namespace Isolation
 
-Each ephemeral namespace is provisioned with the security resources described
-below.
-
-## NetworkPolicy
-
-**Policy**: default-deny ingress, allow-all egress.
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: default-deny-ingress
-spec:
-  podSelector: {}
-  policyTypes:
-    - Ingress
-```
-
-- No pod in the job namespace can receive inbound traffic from other namespaces
-  or pods.
-- Full egress is allowed so jobs can pull images, fetch dependencies, and push
-  artifacts.
-
-## ResourceQuota
-
-Each ephemeral namespace is capped:
-
-| Resource          | Limit |
-| ----------------- | ----- |
-| CPU (requests)    | 16    |
-| Memory (requests) | 32Gi  |
-| Pods              | 50    |
-
-This prevents a single job from consuming the entire node. Jobs exceeding the
-quota will fail to schedule with an event explaining the limit.
-
-## LimitRange
-
-Default and maximum container resource boundaries:
-
-| Setting         | CPU  | Memory |
-| --------------- | ---- | ------ |
-| Default request | 100m | 128Mi  |
-| Default limit   | 1    | 1Gi    |
-| Max limit       | 4    | 8Gi    |
-
-Containers without explicit resource requests/limits get the defaults.
-Containers requesting more than the max are rejected at admission.
+All runners are deployed into a dedicated namespace: `bates-ils-runners`.
+This isolates runner workloads from application services and other
+infrastructure components.
 
 ## RBAC
 
-A `ci-job-runner-access` Role is created in each ephemeral namespace:
+Runners have minimal RBAC permissions scoped to their own namespace. They
+cannot create, modify, or delete resources outside `bates-ils-runners`.
+The GitLab Runner Helm chart creates a ServiceAccount with only the
+permissions needed to manage job pods within the namespace.
 
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: ci-job-runner-access
-rules:
-  - apiGroups: ["", "apps", "autoscaling", "batch"]
-    resources:
-      - pods
-      - deployments
-      - horizontalpodautoscalers
-      - jobs
-      - events
-    verbs: [get, list, watch]
-```
+## Secrets Management
 
-The job service account is bound to this role. Jobs can **read** cluster state
-for debugging and status checks but cannot create, modify, or delete resources.
+- **Runner registration token**: Stored as a Kubernetes Secret in the
+  `bates-ils-runners` namespace. Created and managed by the `gitlab-runner`
+  OpenTofu module.
+- **Attic credentials**: Nix runners receive Attic connection details via
+  environment variables injected from Kubernetes Secrets.
+- **No secrets in CI variables**: Sensitive values are managed through
+  Kubernetes Secrets and OpenTofu, not GitLab CI/CD variable settings where
+  possible.
 
-Deployments to the cluster go through the `k8s-deploy` component, which uses
-the GitLab Agent `ci_access` path with its own RBAC (separate from the job
-namespace).
+## Network Access
 
-## DinD Exception
+- Runners can reach the Attic cache server in the `attic-cache-dev`
+  namespace for binary cache operations.
+- Runners can reach external registries for pulling container images.
+- Runners do not have write access to any container registry by default.
+  Push access must be configured explicitly per job via CI/CD credentials.
 
-The `dind` runner is the deliberate exception to namespace-per-job isolation:
+## Container Images
 
-- Runs in a **shared namespace** (`bates-ils-runners`).
-- Requires **privileged** mode for the Docker daemon sidecar.
-- No ephemeral namespace creation or teardown.
-
-**Mitigations**:
-
-- DinD jobs are tagged `privileged` -- only pipelines that explicitly request
-  the tag use this runner.
-- The Docker daemon runs as a sidecar per pod, not as a shared cluster-wide
-  daemon.
-- Image pull policies and resource limits still apply at the pod level.
-
-Use `dind` only for container image builds. For everything else, use `docker`.
-
-## Orphaned Namespace Cleanup
-
-A `CronJob` runs on a schedule (default: every 15 minutes) to garbage-collect
-`ci-job-*` namespaces that were not cleaned up by the runner:
-
-- Namespaces older than a configurable TTL (default: 1 hour) are deleted.
-- The CronJob runs in the `bates-ils-runners` namespace with a service account
-  that has permission to list and delete namespaces matching `ci-job-*`.
-- Logs are emitted for each namespace deleted.
-
-This handles edge cases like runner pod crashes, node failures, or network
-partitions that prevent normal cleanup.
-
-## Pod Security Admission
-
-The `bates-ils-runners` namespace carries PSA labels:
-
-```yaml
-metadata:
-  labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/warn: restricted
-```
-
-- **enforce: baseline** -- blocks known-dangerous pod configurations (e.g.,
-  hostPath, hostNetwork) except for the dind runner which is explicitly
-  exempted.
-- **audit: restricted** -- logs violations against the strictest profile.
-- **warn: restricted** -- shows warnings for restricted-profile violations
-  without blocking.
-
-Ephemeral `ci-job-*` namespaces inherit the same PSA labels.
+Runner job pods pull images from public registries (Docker Hub, GitLab
+Container Registry). The runners themselves do not have push access to any
+registry. Image provenance is determined by the base image specified in the
+runner configuration (Alpine, Rocky Linux, NixOS).

--- a/docs/runners/troubleshooting.md
+++ b/docs/runners/troubleshooting.md
@@ -1,337 +1,84 @@
-# Runner Troubleshooting Guide
+---
+title: Troubleshooting
+order: 60
+---
 
-Common issues and their solutions for GitLab Runners.
+# Troubleshooting
 
-## Quick Diagnostics
+Common issues with the runner infrastructure and how to resolve them.
 
-```bash
-# Check if runners are running
-kubectl get pods -n bates-ils-runners
+## Runner Not Registering
 
-# Check HPA status
-kubectl get hpa -n bates-ils-runners
+**Symptom**: Runner pod starts but does not appear in the GitLab group
+runner list.
 
-# View recent events
-kubectl get events -n bates-ils-runners --sort-by='.lastTimestamp' | tail -20
+**Causes and fixes**:
 
-# Check runner logs
-kubectl logs -n bates-ils-runners -l release=bates-docker --tail=50
-```
+- **Invalid runner token**: Verify the Kubernetes Secret containing the
+  registration token exists and is current. Delete the secret and run
+  `tofu apply` to recreate it.
+- **Group access**: Confirm that the service account or user associated with
+  the token has access to the target GitLab group.
+- **Token auto-creation**: Automatic runner token creation requires the
+  **Owner** role on the GitLab group. If the deploying user does not have
+  Owner, token creation will fail silently. Verify role assignment in
+  GitLab group settings.
 
-## Common Issues
+## Pods Crashing (OOMKilled)
 
-### Job Stuck in "Pending"
+**Symptom**: Runner pods restart repeatedly. `kubectl describe pod` shows
+`OOMKilled` as the termination reason.
 
-**Symptoms:**
+**Fix**: Increase the memory limit for the affected runner type in
+`organization.yaml` and run `tofu apply`. See [HPA Tuning](hpa-tuning.md)
+for resource limit configuration.
 
-- Job shows "Pending" status in GitLab
-- "This job is stuck because you don't have any active runners"
+Common memory-hungry workloads:
+- `dind`: Container builds with large build contexts.
+- `nix`: Derivations that compile large packages from source.
 
-**Causes & Solutions:**
+## Cache Misses on Nix Runner
 
-1. **No matching tags**
+**Symptom**: Nix builds download or compile everything from scratch despite
+previous builds having populated the cache.
 
-   ```yaml
-   # Wrong - no runner has these exact tags
-   job:
-     tags:
-       - custom-tag
-       - another-tag
-   ```
+**Causes and fixes**:
 
-   Fix: Use correct tags from [README.md](README.md#available-runners)
+- **ATTIC_SERVER not set**: Verify the environment variable is present in
+  the runner pod. Check that the Kubernetes Secret for Attic credentials
+  exists in the `bates-ils-runners` namespace.
+- **Attic service unreachable**: Confirm the Attic cache service is running
+  in the `attic-cache-dev` namespace. Test connectivity from a runner pod
+  with `curl $ATTIC_SERVER`.
+- **Cache name mismatch**: Verify `ATTIC_CACHE` matches the cache name
+  used in `attic push` commands.
 
-2. **Runner pods not running**
+## TOML Configuration Gotchas
 
-   ```bash
-   kubectl get pods -n bates-ils-runners
-   # If 0/1 Ready, check logs:
-   kubectl logs -n bates-ils-runners deployment/bates-docker
-   ```
+The GitLab Runner TOML configuration has several pitfalls in Runner 17.x:
 
-3. **Runner not registered**
-   ```bash
-   # Check runner status in GitLab
-   # Group > Settings > CI/CD > Runners
-   ```
+- **Resource limits must be flat keys**: Values like `cpu_limit`,
+  `memory_limit`, `cpu_request`, and `memory_request` must be specified as
+  flat keys in the `[[runners.kubernetes]]` section. Do not nest them inside
+  a TOML table.
+- **pod_spec.containers type mismatch**: Using `pod_spec` with a
+  `containers` field causes a type mismatch error in Runner 17.x. Instead,
+  use `environment = [...]` on the `[[runners]]` section to inject
+  environment variables.
 
-### Job Fails Immediately
+## Runner Pods Pending
 
-**Symptoms:**
+**Symptom**: Pods stay in `Pending` state and are not scheduled.
 
-- Job starts but fails within seconds
-- Error: "Job failed: prepare environment"
+**Causes and fixes**:
 
-**Causes & Solutions:**
+- **Insufficient cluster resources**: Check node capacity with
+  `kubectl describe nodes`. The cluster may need more nodes or the runner
+  resource requests may be too high.
+- **HPA at maximum**: If all replicas are running and jobs are still
+  queuing, increase the HPA maximum. See [HPA Tuning](hpa-tuning.md).
 
-1. **Image pull failure**
+## Related
 
-   ```yaml
-   # Check if image exists and is accessible
-   job:
-     image: my-private-registry/image:tag
-   ```
-
-   Fix: Use public images or configure registry credentials
-
-2. **Resource limits exceeded**
-
-   ```bash
-   kubectl describe pod <job-pod-name> -n bates-ils-runners
-   # Look for "OOMKilled" or resource errors
-   ```
-
-3. **Privileged mode required but not enabled**
-
-   ```yaml
-   # Wrong - trying to run docker without dind
-   job:
-     tags:
-       - docker
-     script:
-       - docker build . # This will fail!
-   ```
-
-   Fix: Use `dind` tag for Docker builds
-
-### DinD Build Failures
-
-**Symptoms:**
-
-- "Cannot connect to the Docker daemon"
-- "docker: command not found"
-
-**Solutions:**
-
-1. **Missing service configuration**
-
-   ```yaml
-   # Correct DinD setup
-   build:
-     tags:
-       - dind
-       - privileged
-     services:
-       - docker:27-dind
-     variables:
-       DOCKER_HOST: tcp://localhost:2375
-       DOCKER_TLS_CERTDIR: ""
-     script:
-       - docker build .
-   ```
-
-2. **Docker daemon not ready**
-   ```yaml
-   build:
-     before_script:
-       # Wait for Docker daemon
-       - |
-         for i in $(seq 1 30); do
-           docker info && break
-           echo "Waiting for Docker..."
-           sleep 1
-         done
-     script:
-       - docker build .
-   ```
-
-### Nix Build Failures
-
-**Symptoms:**
-
-- "error: experimental Nix feature 'flakes' is disabled"
-- Slow builds (no cache hits)
-
-**Solutions:**
-
-1. **Flakes not enabled**
-
-   The Nix runner has flakes enabled by default. If you see this error, ensure you're using the `nix` tag:
-
-   ```yaml
-   job:
-     tags:
-       - nix
-       - flakes
-   ```
-
-2. **Cache misses**
-
-   Check Attic configuration:
-
-   ```yaml
-   job:
-     tags:
-       - nix
-     script:
-       - echo "Attic server: $ATTIC_SERVER"
-       - nix build .#default
-       # Push to cache after successful build
-       - attic push main result
-   ```
-
-3. **Nix store full**
-
-   The Nix store is an emptyDir with 20Gi limit. For large builds:
-
-   ```yaml
-   job:
-     variables:
-       NIX_BUILD_CORES: "2" # Limit parallelism
-     script:
-       - nix-collect-garbage -d # Clean before build
-       - nix build .#default
-   ```
-
-### Rocky Linux Package Issues
-
-**Symptoms:**
-
-- "No match for argument: <package>"
-- DNF errors
-
-**Solutions:**
-
-1. **Package name differences**
-
-   Rocky 8 and 9 have different package names:
-
-   ```yaml
-   # Rocky 8
-   job-rocky8:
-     tags: [rocky8]
-     script:
-       - dnf install -y python3 # Python 3.6
-
-   # Rocky 9
-   job-rocky9:
-     tags: [rocky9]
-     script:
-       - dnf install -y python3 # Python 3.9
-   ```
-
-2. **EPEL needed**
-   ```yaml
-   job:
-     tags: [rocky8]
-     script:
-       - dnf install -y epel-release
-       - dnf install -y <epel-package>
-   ```
-
-### HPA Not Scaling
-
-**Symptoms:**
-
-- High CPU/memory but no scale-up
-- Jobs queuing despite low utilization
-
-**Diagnostics:**
-
-```bash
-# Check HPA status
-kubectl get hpa -n bates-ils-runners
-
-# Detailed HPA info
-kubectl describe hpa bates-docker-hpa -n bates-ils-runners
-
-# Check metrics server
-kubectl top pods -n bates-ils-runners
-```
-
-**Solutions:**
-
-1. **Metrics server not available**
-
-   ```bash
-   # Check if metrics-server is running
-   kubectl get pods -n kube-system | grep metrics
-   ```
-
-2. **Resource requests not set**
-
-   HPA requires resource requests to calculate utilization. Check deployment:
-
-   ```bash
-   kubectl get deployment bates-docker -n bates-ils-runners -o yaml | grep -A 10 resources
-   ```
-
-### Pod Eviction/OOM
-
-**Symptoms:**
-
-- Pod status: "Evicted" or "OOMKilled"
-- Job fails mid-execution
-
-**Solutions:**
-
-1. **Increase job memory limit**
-
-   Contact admin to increase limits in `beehive.tfvars`:
-
-   ```hcl
-   nix_job_memory_limit = "16Gi"  # For large Nix builds
-   ```
-
-2. **Optimize build**
-   ```yaml
-   job:
-     script:
-       # Stream output to avoid buffering
-       - make build 2>&1 | tee build.log
-       # Clear caches between steps
-       - rm -rf node_modules/.cache
-   ```
-
-## Debugging Commands
-
-### View Job Pod Logs
-
-```bash
-# Find the job pod
-kubectl get pods -n bates-ils-runners | grep runner-
-
-# View logs
-kubectl logs <pod-name> -n bates-ils-runners -c build
-
-# If pod crashed, view previous logs
-kubectl logs <pod-name> -n bates-ils-runners -c build --previous
-```
-
-### Check Resource Usage
-
-```bash
-# Current usage
-kubectl top pods -n bates-ils-runners
-
-# Historical events
-kubectl get events -n bates-ils-runners --field-selector reason=OOMKilling
-```
-
-### Inspect Runner Configuration
-
-```bash
-# Check runner manager config
-kubectl exec -n bates-ils-runners deployment/bates-docker -- cat /home/gitlab-runner/.gitlab-runner/config.toml
-```
-
-### Test Runner Connectivity
-
-```bash
-# Exec into runner manager
-kubectl exec -it -n bates-ils-runners deployment/bates-docker -- sh
-
-# Check GitLab connectivity
-curl -I https://gitlab.com/api/v4/version
-```
-
-## Getting Help
-
-1. Check this documentation first
-2. Review GitLab CI/CD documentation: https://docs.gitlab.com/ee/ci/
-3. Check runner logs for specific error messages
-4. Contact ILS team with:
-   - Job URL
-   - Error message
-   - Runner tags used
-   - Output of `kubectl get events -n bates-ils-runners`
+- [Runbook](runbook.md) -- operational procedures for common tasks
+- [Security Model](security-model.md) -- access and permission details

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,20 +1,21 @@
-lockfileVersion: "9.0"
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
+
   .: {}
 
   app:
     dependencies:
-      "@skeletonlabs/skeleton":
-        specifier: ^3.1.3
-        version: 3.2.2(tailwindcss@4.1.18)
-      "@skeletonlabs/skeleton-svelte":
-        specifier: ^1.2.3
-        version: 1.5.3(svelte@5.49.2)
+      '@skeletonlabs/skeleton':
+        specifier: ^4.9.0
+        version: 4.12.0(tailwindcss@4.1.18)
+      '@skeletonlabs/skeleton-svelte':
+        specifier: ^4.12.0
+        version: 4.12.0(svelte@5.49.2)
       chart.js:
         specifier: ^4.4.7
         version: 4.5.1
@@ -22,1084 +23,1058 @@ importers:
         specifier: ^3.1.5
         version: 3.1.5(chart.js@4.5.1)(svelte@5.49.2)
     devDependencies:
-      "@sveltejs/adapter-node":
+      '@sveltejs/adapter-node':
         specifier: ^5.2.12
-        version: 5.5.2(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))
-      "@sveltejs/kit":
-        specifier: ^2.16.0
-        version: 2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      "@sveltejs/vite-plugin-svelte":
-        specifier: ^5.0.0
-        version: 5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      "@tailwindcss/vite":
-        specifier: ^4.0.0
-        version: 4.1.18(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      "@types/node":
+        version: 5.5.2(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))
+      '@sveltejs/kit':
+        specifier: ^2.49.0
+        version: 2.50.2(@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.0.0-next.0
+        version: 7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@tailwindcss/vite':
+        specifier: ^4.1.0
+        version: 4.1.18(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
         specifier: ^22.15.30
         version: 22.19.9
       svelte:
-        specifier: ^5.25.0
+        specifier: ^5.46.0
         version: 5.49.2
       svelte-check:
         specifier: ^4.0.0
         version: 4.3.6(picomatch@4.0.3)(svelte@5.49.2)(typescript@5.9.3)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: ^4.1.0
         version: 4.1.18
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^5.0.0
+        specifier: ^5.9.0
         version: 5.9.3
       vite:
-        specifier: ^6.2.6
-        version: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        specifier: ^8.0.0-beta.11
+        version: 8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       yaml:
         specifier: ^2.7.0
         version: 2.8.2
 
+  docs-site:
+    dependencies:
+      '@skeletonlabs/skeleton':
+        specifier: ^4.9.0
+        version: 4.12.0(tailwindcss@4.1.18)
+      '@skeletonlabs/skeleton-svelte':
+        specifier: ^4.12.0
+        version: 4.12.0(svelte@5.49.2)
+      mermaid:
+        specifier: ^11.0.0
+        version: 11.12.2
+    devDependencies:
+      '@shikijs/transformers':
+        specifier: ^3.0.0
+        version: 3.22.0
+      '@sveltejs/adapter-static':
+        specifier: ^3.0.0
+        version: 3.0.10(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))
+      '@sveltejs/kit':
+        specifier: ^2.49.0
+        version: 2.50.2(@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.0.0-next.0
+        version: 7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.18)
+      '@tailwindcss/vite':
+        specifier: ^4.1.0
+        version: 4.1.18(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      mdsvex:
+        specifier: ^0.12.6
+        version: 0.12.6(svelte@5.49.2)
+      rehype-autolink-headings:
+        specifier: ^7.0.0
+        version: 7.1.0
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
+      shiki:
+        specifier: ^3.0.0
+        version: 3.22.0
+      svelte:
+        specifier: ^5.46.0
+        version: 5.49.2
+      svelte-check:
+        specifier: ^4.0.0
+        version: 4.3.6(picomatch@4.0.3)(svelte@5.49.2)(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4.1.0
+        version: 4.1.18
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0-beta.11
+        version: 8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+
 packages:
-  "@esbuild/aix-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
-      }
-    engines: { node: ">=18" }
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/cst-dts-gen@11.0.3':
+    resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
+
+  '@chevrotain/gast@11.0.3':
+    resolution: {integrity: sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==}
+
+  '@chevrotain/regexp-to-ast@11.0.3':
+    resolution: {integrity: sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==}
+
+  '@chevrotain/types@11.0.3':
+    resolution: {integrity: sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==}
+
+  '@chevrotain/utils@11.0.3':
+    resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
+
+  '@emnapi/core@1.8.1':
+    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.8.1':
+    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/aix-ppc64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-arm@0.27.3":
-    resolution:
-      {
-        integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  "@esbuild/android-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-arm@0.27.3":
-    resolution:
-      {
-        integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.27.3":
-    resolution:
-      {
-        integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.25.12":
-    resolution:
-      {
-        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.27.3":
-    resolution:
-      {
-        integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.27.3":
-    resolution:
-      {
-        integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/linux-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openharmony-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/openharmony-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/sunos-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/sunos-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.27.3":
-    resolution:
-      {
-        integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  "@esbuild/win32-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==,
-      }
-    engines: { node: ">=18" }
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  "@floating-ui/core@1.7.4":
-    resolution:
-      {
-        integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==,
-      }
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
-  "@floating-ui/dom@1.7.2":
-    resolution:
-      {
-        integrity: sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==,
-      }
+  '@floating-ui/dom@1.7.5':
+    resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
 
-  "@floating-ui/utils@0.2.10":
-    resolution:
-      {
-        integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==,
-      }
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  "@jridgewell/gen-mapping@0.3.13":
-    resolution:
-      {
-        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
-      }
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  "@jridgewell/remapping@2.3.5":
-    resolution:
-      {
-        integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
-      }
+  '@iconify/utils@3.1.0':
+    resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
 
-  "@jridgewell/resolve-uri@3.1.2":
-    resolution:
-      {
-        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-      }
-    engines: { node: ">=6.0.0" }
+  '@internationalized/date@3.10.1':
+    resolution: {integrity: sha512-oJrXtQiAXLvT9clCf1K4kxp3eKsQhIaZqxEyowkBcsvZDdZkbWrVmnGknxs5flTD0VGsxrxKgBCZty1EzoiMzA==}
 
-  "@jridgewell/sourcemap-codec@1.5.5":
-    resolution:
-      {
-        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
-      }
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
-  "@jridgewell/trace-mapping@0.3.31":
-    resolution:
-      {
-        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
-      }
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
-  "@kurkle/color@0.3.4":
-    resolution:
-      {
-        integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==,
-      }
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
 
-  "@polka/url@1.0.0-next.29":
-    resolution:
-      {
-        integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==,
-      }
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  "@rollup/plugin-commonjs@28.0.9":
-    resolution:
-      {
-        integrity: sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==,
-      }
-    engines: { node: ">=16.0.0 || 14 >= 14.17" }
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@kurkle/color@0.3.4':
+    resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
+  '@mermaid-js/parser@0.6.3':
+    resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@oxc-project/runtime@0.112.0':
+    resolution: {integrity: sha512-4vYtWXMnXM6EaweCxbJ6bISAhkNHeN33SihvuX3wrpqaSJA4ZEoW35i9mSvE74+GDf1yTeVE+aEHA+WBpjDk/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.112.0':
+    resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.3':
+    resolution: {integrity: sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
+    resolution: {integrity: sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.3':
+    resolution: {integrity: sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
+    resolution: {integrity: sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
+    resolution: {integrity: sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
+    resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
+    resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
+    resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
+    resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
+    resolution: {integrity: sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
+    resolution: {integrity: sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
+    resolution: {integrity: sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
+    resolution: {integrity: sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/plugin-commonjs@28.0.9':
+    resolution: {integrity: sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
     peerDependencies:
       rollup: ^2.68.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  "@rollup/plugin-json@6.1.0":
-    resolution:
-      {
-        integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==,
-      }
-    engines: { node: ">=14.0.0" }
+  '@rollup/plugin-json@6.1.0':
+    resolution: {integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  "@rollup/plugin-node-resolve@16.0.3":
-    resolution:
-      {
-        integrity: sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==,
-      }
-    engines: { node: ">=14.0.0" }
+  '@rollup/plugin-node-resolve@16.0.3':
+    resolution: {integrity: sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.78.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  "@rollup/pluginutils@5.3.0":
-    resolution:
-      {
-        integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==,
-      }
-    engines: { node: ">=14.0.0" }
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  "@rollup/rollup-android-arm-eabi@4.57.1":
-    resolution:
-      {
-        integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==,
-      }
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
     cpu: [arm]
     os: [android]
 
-  "@rollup/rollup-android-arm64@4.57.1":
-    resolution:
-      {
-        integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==,
-      }
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
     cpu: [arm64]
     os: [android]
 
-  "@rollup/rollup-darwin-arm64@4.57.1":
-    resolution:
-      {
-        integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==,
-      }
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
     cpu: [arm64]
     os: [darwin]
 
-  "@rollup/rollup-darwin-x64@4.57.1":
-    resolution:
-      {
-        integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==,
-      }
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
     cpu: [x64]
     os: [darwin]
 
-  "@rollup/rollup-freebsd-arm64@4.57.1":
-    resolution:
-      {
-        integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==,
-      }
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
     cpu: [arm64]
     os: [freebsd]
 
-  "@rollup/rollup-freebsd-x64@4.57.1":
-    resolution:
-      {
-        integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==,
-      }
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
     cpu: [x64]
     os: [freebsd]
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.57.1":
-    resolution:
-      {
-        integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==,
-      }
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm-musleabihf@4.57.1":
-    resolution:
-      {
-        integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==,
-      }
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-gnu@4.57.1":
-    resolution:
-      {
-        integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==,
-      }
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-musl@4.57.1":
-    resolution:
-      {
-        integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==,
-      }
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-loong64-gnu@4.57.1":
-    resolution:
-      {
-        integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==,
-      }
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-loong64-musl@4.57.1":
-    resolution:
-      {
-        integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==,
-      }
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-gnu@4.57.1":
-    resolution:
-      {
-        integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==,
-      }
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-musl@4.57.1":
-    resolution:
-      {
-        integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==,
-      }
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-gnu@4.57.1":
-    resolution:
-      {
-        integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==,
-      }
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-musl@4.57.1":
-    resolution:
-      {
-        integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==,
-      }
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-s390x-gnu@4.57.1":
-    resolution:
-      {
-        integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==,
-      }
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-gnu@4.57.1":
-    resolution:
-      {
-        integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==,
-      }
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-musl@4.57.1":
-    resolution:
-      {
-        integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==,
-      }
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-openbsd-x64@4.57.1":
-    resolution:
-      {
-        integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==,
-      }
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
     cpu: [x64]
     os: [openbsd]
 
-  "@rollup/rollup-openharmony-arm64@4.57.1":
-    resolution:
-      {
-        integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==,
-      }
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
     cpu: [arm64]
     os: [openharmony]
 
-  "@rollup/rollup-win32-arm64-msvc@4.57.1":
-    resolution:
-      {
-        integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==,
-      }
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
     cpu: [arm64]
     os: [win32]
 
-  "@rollup/rollup-win32-ia32-msvc@4.57.1":
-    resolution:
-      {
-        integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==,
-      }
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
     cpu: [ia32]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-gnu@4.57.1":
-    resolution:
-      {
-        integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==,
-      }
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
     cpu: [x64]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-msvc@4.57.1":
-    resolution:
-      {
-        integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==,
-      }
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
     cpu: [x64]
     os: [win32]
 
-  "@skeletonlabs/skeleton-svelte@1.5.3":
-    resolution:
-      {
-        integrity: sha512-YFSJbaK6QPhrTyzlNy3fA3lSOg7hB7D/qkLAJDVlqwu5E2cz6WWS+/J3Tu9qOBO50PuSsgdOaFPc+QQ5+vQZHA==,
-      }
+  '@shikijs/core@3.22.0':
+    resolution: {integrity: sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==}
+
+  '@shikijs/engine-javascript@3.22.0':
+    resolution: {integrity: sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==}
+
+  '@shikijs/engine-oniguruma@3.22.0':
+    resolution: {integrity: sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==}
+
+  '@shikijs/langs@3.22.0':
+    resolution: {integrity: sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==}
+
+  '@shikijs/themes@3.22.0':
+    resolution: {integrity: sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==}
+
+  '@shikijs/transformers@3.22.0':
+    resolution: {integrity: sha512-E7eRV7mwDBjueLF6852n2oYeJYxBq3NSsDk+uyruYAXONv4U8holGmIrT+mPRJQ1J1SNOH6L8G19KRzmBawrFw==}
+
+  '@shikijs/types@3.22.0':
+    resolution: {integrity: sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@skeletonlabs/skeleton-common@4.12.0':
+    resolution: {integrity: sha512-nLobxtEfhUVtvET4asPbVaz9eDA9JFyskvF8j1WLcvK2mNxxku8JZE235Fz/QX5pR200KTXpjwYCp6Mfyb+0EA==}
+
+  '@skeletonlabs/skeleton-svelte@4.12.0':
+    resolution: {integrity: sha512-PkF+X6fNCDbXOnzbOzw0HzNzmK9vqZIdMS9StDvD4ixvrZgRa/vBTluCI9WMBa3TCtjMNkXhAxXBYI3LqLHq4A==}
     peerDependencies:
-      svelte: ^5.20.0
+      svelte: ^5.29.0
 
-  "@skeletonlabs/skeleton@3.2.2":
-    resolution:
-      {
-        integrity: sha512-dAunBAWqRMcNTGAvCKUgpADJdbtqL65eNEb7pDIKQZ6bI6qsxakR6MuF2E4B3jmUEpcaxaggDp0UdnUjlkAZ1Q==,
-      }
+  '@skeletonlabs/skeleton@4.12.0':
+    resolution: {integrity: sha512-5Zch+aAarrWQaWEtjdb/jlaT5Q2H4Lt6pCl8utvrkKGGlXfAWd2yjzho75E1nxdbsS9F2q+5ipewlbrtmGYB8Q==}
     peerDependencies:
       tailwindcss: ^4.0.0
 
-  "@standard-schema/spec@1.1.0":
-    resolution:
-      {
-        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
-      }
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  "@sveltejs/acorn-typescript@1.0.8":
-    resolution:
-      {
-        integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==,
-      }
+  '@sveltejs/acorn-typescript@1.0.8':
+    resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
     peerDependencies:
       acorn: ^8.9.0
 
-  "@sveltejs/adapter-node@5.5.2":
-    resolution:
-      {
-        integrity: sha512-L15Djwpr7HrSAPj/Z8PYfc0pa9A1tllrr18phKI0WJHJeoWw45yinPf0IGgVTmakqx1B3JQ+C/OFl9ZwmxHU1Q==,
-      }
+  '@sveltejs/adapter-node@5.5.2':
+    resolution: {integrity: sha512-L15Djwpr7HrSAPj/Z8PYfc0pa9A1tllrr18phKI0WJHJeoWw45yinPf0IGgVTmakqx1B3JQ+C/OFl9ZwmxHU1Q==}
     peerDependencies:
-      "@sveltejs/kit": ^2.4.0
+      '@sveltejs/kit': ^2.4.0
 
-  "@sveltejs/kit@2.50.2":
-    resolution:
-      {
-        integrity: sha512-875hTUkEbz+MyJIxWbQjfMaekqdmEKUUfR7JyKcpfMRZqcGyrO9Gd+iS1D/Dx8LpE5FEtutWGOtlAh4ReSAiOA==,
-      }
-    engines: { node: ">=18.13" }
+  '@sveltejs/adapter-static@3.0.10':
+    resolution: {integrity: sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
+  '@sveltejs/kit@2.50.2':
+    resolution: {integrity: sha512-875hTUkEbz+MyJIxWbQjfMaekqdmEKUUfR7JyKcpfMRZqcGyrO9Gd+iS1D/Dx8LpE5FEtutWGOtlAh4ReSAiOA==}
+    engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
-      "@opentelemetry/api": ^1.0.0
-      "@sveltejs/vite-plugin-svelte": ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: ^5.3.3
       vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0
     peerDependenciesMeta:
-      "@opentelemetry/api":
+      '@opentelemetry/api':
         optional: true
       typescript:
         optional: true
 
-  "@sveltejs/vite-plugin-svelte-inspector@4.0.1":
-    resolution:
-      {
-        integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22 }
+  '@sveltejs/vite-plugin-svelte@7.0.0-next.0':
+    resolution: {integrity: sha512-S/QeWT/jtA6scSrDF2nxNKjCqLu0eszZGayJYfqAipYbmt8JM/2dmHVubliikqos8LBeuxRvC14p3GVZMQwoRw==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
-      "@sveltejs/vite-plugin-svelte": ^5.0.0
-      svelte: ^5.0.0
-      vite: ^6.0.0
+      svelte: ^5.46.4
+      vite: ^8.0.0-beta.7 || ^8.0.0
 
-  "@sveltejs/vite-plugin-svelte@5.1.1":
-    resolution:
-      {
-        integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22 }
-    peerDependencies:
-      svelte: ^5.0.0
-      vite: ^6.0.0
+  '@swc/helpers@0.5.18':
+    resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
 
-  "@tailwindcss/node@4.1.18":
-    resolution:
-      {
-        integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==,
-      }
+  '@tailwindcss/node@4.1.18':
+    resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
 
-  "@tailwindcss/oxide-android-arm64@4.1.18":
-    resolution:
-      {
-        integrity: sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    resolution: {integrity: sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [android]
 
-  "@tailwindcss/oxide-darwin-arm64@4.1.18":
-    resolution:
-      {
-        integrity: sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    resolution: {integrity: sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  "@tailwindcss/oxide-darwin-x64@4.1.18":
-    resolution:
-      {
-        integrity: sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    resolution: {integrity: sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==}
+    engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  "@tailwindcss/oxide-freebsd-x64@4.1.18":
-    resolution:
-      {
-        integrity: sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    resolution: {integrity: sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==}
+    engines: {node: '>= 10'}
     cpu: [x64]
     os: [freebsd]
 
-  "@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18":
-    resolution:
-      {
-        integrity: sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    resolution: {integrity: sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==}
+    engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  "@tailwindcss/oxide-linux-arm64-gnu@4.1.18":
-    resolution:
-      {
-        integrity: sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    resolution: {integrity: sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  "@tailwindcss/oxide-linux-arm64-musl@4.1.18":
-    resolution:
-      {
-        integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  "@tailwindcss/oxide-linux-x64-gnu@4.1.18":
-    resolution:
-      {
-        integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
+    engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  "@tailwindcss/oxide-linux-x64-musl@4.1.18":
-    resolution:
-      {
-        integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
+    engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  "@tailwindcss/oxide-wasm32-wasi@4.1.18":
-    resolution:
-      {
-        integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==,
-      }
-    engines: { node: ">=14.0.0" }
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
+    engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
-      - "@napi-rs/wasm-runtime"
-      - "@emnapi/core"
-      - "@emnapi/runtime"
-      - "@tybys/wasm-util"
-      - "@emnapi/wasi-threads"
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
       - tslib
 
-  "@tailwindcss/oxide-win32-arm64-msvc@4.1.18":
-    resolution:
-      {
-        integrity: sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    resolution: {integrity: sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==}
+    engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  "@tailwindcss/oxide-win32-x64-msvc@4.1.18":
-    resolution:
-      {
-        integrity: sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    resolution: {integrity: sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==}
+    engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  "@tailwindcss/oxide@4.1.18":
-    resolution:
-      {
-        integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==,
-      }
-    engines: { node: ">= 10" }
+  '@tailwindcss/oxide@4.1.18':
+    resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
+    engines: {node: '>= 10'}
 
-  "@tailwindcss/vite@4.1.18":
-    resolution:
-      {
-        integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==,
-      }
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
+  '@tailwindcss/vite@4.1.18':
+    resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
-  "@types/chai@5.2.3":
-    resolution:
-      {
-        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
-      }
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  "@types/cookie@0.6.0":
-    resolution:
-      {
-        integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==,
-      }
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  "@types/deep-eql@4.0.2":
-    resolution:
-      {
-        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
-      }
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
-  "@types/estree@1.0.8":
-    resolution:
-      {
-        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
-      }
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
-  "@types/node@22.19.9":
-    resolution:
-      {
-        integrity: sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==,
-      }
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
 
-  "@types/resolve@1.20.2":
-    resolution:
-      {
-        integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==,
-      }
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
 
-  "@vitest/expect@3.2.4":
-    resolution:
-      {
-        integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==,
-      }
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
 
-  "@vitest/mocker@3.2.4":
-    resolution:
-      {
-        integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==,
-      }
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/node@22.19.9':
+    resolution: {integrity: sha512-PD03/U8g1F9T9MI+1OBisaIARhSzeidsUjQaf51fOxrfjeiKN9bLVO06lHuHYjxdnqLWJijJHfqXPSJri2EM2A==}
+
+  '@types/resolve@1.20.2':
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
@@ -1109,443 +1084,499 @@ packages:
       vite:
         optional: true
 
-  "@vitest/pretty-format@3.2.4":
-    resolution:
-      {
-        integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==,
-      }
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  "@vitest/runner@3.2.4":
-    resolution:
-      {
-        integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==,
-      }
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
-  "@vitest/snapshot@3.2.4":
-    resolution:
-      {
-        integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==,
-      }
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
-  "@vitest/spy@3.2.4":
-    resolution:
-      {
-        integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==,
-      }
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  "@vitest/utils@3.2.4":
-    resolution:
-      {
-        integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==,
-      }
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  "@zag-js/accordion@1.18.3":
-    resolution:
-      {
-        integrity: sha512-h+Qw9uLZXlSL3vx+pe6sCHLK4pZAzKdj+2CuH3lIAp8GdOcO6MUfcfo905jl0vM0mUyWpELxRypzplcFioIVkw==,
-      }
+  '@zag-js/accordion@1.32.0':
+    resolution: {integrity: sha512-sTn7xuaPvuG/YNO8aZIMBC0DMy+IacpxjduYUTdrjHrbvMKHuFdWuh9C7qg7AufM53bF1aWqVGltdIBXD9F8WA==}
 
-  "@zag-js/anatomy@1.18.3":
-    resolution:
-      {
-        integrity: sha512-D1Qaxq1NS+Wud9KEdnO1bQE1Yb1pLxi78iqj007pr+gmFfo2Br3QLJNcMm2x/IWLBCdETwgDhq6nvHTrCjmiwg==,
-      }
+  '@zag-js/anatomy@1.32.0':
+    resolution: {integrity: sha512-99u8VBSt5wkP9ZluIV6lR06Pvyt0AQaTGnvhZkvSmbz5U5+1XwCU0Db7Q+dcQRpM7d0p1ViWFxNVHDuuwY25Fw==}
 
-  "@zag-js/aria-hidden@1.18.3":
-    resolution:
-      {
-        integrity: sha512-CQ4BkawuNfL8yezXjT5zsdFNGKCudz+p13TVW2eP8hHGuMQilK32h4fNd2536U9SRQNi0BjF/e9Qgfl8G2ipDg==,
-      }
+  '@zag-js/aria-hidden@1.32.0':
+    resolution: {integrity: sha512-rgOSWjFMbeFwGPCdUWaSFbb4GM0Ovdr6sM0ilHmGQeXsrYkfg56R/o7I4/8P0kDIi/hDoE5TwBMUiGvKwWMLgA==}
 
-  "@zag-js/auto-resize@1.18.3":
-    resolution:
-      {
-        integrity: sha512-r+eP3R51fFPTd4TYJnjDf62o9Rr4EltuhWEEx+jDahP0hFfK74SDvb0HYMu1j9WQIb2O84JlBma+PNsZSsJasQ==,
-      }
+  '@zag-js/auto-resize@1.32.0':
+    resolution: {integrity: sha512-r9VnppK6rxsFhmfyaQSoHTEoD4yPQ4hmBDrXRoNTjpGeJoF9AKnzkY4YFFGZIuyWsFNLAMZJ3S6C3M2XZgzveA==}
 
-  "@zag-js/avatar@1.18.3":
-    resolution:
-      {
-        integrity: sha512-2yaWSMDG73/2J0NxDtdaAKoto/jg/W/mJ7QGR+1Ay7bNcHnnCaYJcVKPdx/v4k46Swhtt/GKkIqavnRXT6brAw==,
-      }
+  '@zag-js/avatar@1.32.0':
+    resolution: {integrity: sha512-IdwVP/6EI51yUEW8CrCQp0dbzw2V2pcKUS8aayyB4+ihz0L9aWQDE6unUYuSc4xjxK1uGVGRdU67gEQCd6IXSg==}
 
-  "@zag-js/collection@1.18.3":
-    resolution:
-      {
-        integrity: sha512-0IS4nKgFP6s0XwIBdhNrEtPghlIa+cxl4emkppQS0Q/bGEytA+0tE73ZcIY2i/PN15DRdlLmOWX8g0IWFm8R3g==,
-      }
+  '@zag-js/carousel@1.32.0':
+    resolution: {integrity: sha512-WKWrALPe+KWvsZY/ZIfJP3aU01qeghB16Mn8zd8AdL362pvQhKWhBLPSDk9OXh7OFcsiKm382gFHV5ko8CtBRw==}
 
-  "@zag-js/combobox@1.18.3":
-    resolution:
-      {
-        integrity: sha512-RnJUb67Dv/erKjNv1x+wZvEiHoToBQv8xNh5WOhsLD5TNZEHF7zYsYnKbywR+RlAUysDb8HWfV4OfeFKUWxV3A==,
-      }
+  '@zag-js/collapsible@1.32.0':
+    resolution: {integrity: sha512-kQwbPja0Nap1/ighmWCc5pemJG9Sx5Mw4zQ9p77O3znKbroq45AXSMr298Xx0zY44PEDhshKfLmeRT75jJRmpA==}
 
-  "@zag-js/core@1.18.3":
-    resolution:
-      {
-        integrity: sha512-FuB4ClNyob6Fqx57mEWbPui59uU1x9I6MvTyJunnPjJMWr1M0bxsgrqkePoEzt+osel8qLMyaa1oHaxszSNxKQ==,
-      }
+  '@zag-js/collection@1.32.0':
+    resolution: {integrity: sha512-m4ViU0CdsTNiLjuIJknpPN8PPrsudfXC5GMAVykSBFnD6cnOWFKr7w4dM19Wp8VnlfsAsf4t86BPO+gsGm598w==}
 
-  "@zag-js/dialog@1.18.3":
-    resolution:
-      {
-        integrity: sha512-gLWYKYpUyp3IyLr0BX/c6izvX59rCugwv4ClGpojL+chv6KlmgPX6qKj6XVoyWlYsnxvIL3mF2SX+lgUz+SOrA==,
-      }
+  '@zag-js/combobox@1.32.0':
+    resolution: {integrity: sha512-DITA9JhKcbX2IlowjqhZRK5a0Z0Y5ZRO0DUlueYFY5DUwiG1LIhV4AZolzpx24K95/L5V3c9+62DDbBeRS0Qsg==}
 
-  "@zag-js/dismissable@1.18.3":
-    resolution:
-      {
-        integrity: sha512-6q8OlX/W+TvP73r7tDcsLbTZEipczO4TNZnDHGFra+tP8CPslZZ39SZYomhrtRWqOKWu5R3UX+Vgl4gO1wtykA==,
-      }
+  '@zag-js/core@1.32.0':
+    resolution: {integrity: sha512-aibBwyqw3saAzYBf2YHfuyOGt9kdNc4+ile3D1jbUsXiccLvGuFPP3+Ox7fULcILIiQhR0X6M+sTF17IyEMrYA==}
 
-  "@zag-js/dom-query@1.18.3":
-    resolution:
-      {
-        integrity: sha512-mPj2xvjxXyB++aGoIIZZ0cCbMu+nfLvks/Q2fe6SgfSaTdGw8jvJtp4F5Qs3Q+MOHbIZRnAqYyBLv56qav3AeA==,
-      }
-
-  "@zag-js/file-upload@1.18.3":
-    resolution:
-      {
-        integrity: sha512-Noq/DaNwuoDK7klyqy86IJOmxQIKaUY15PBiU7u2sU+VMqKWcWLm1hSlRLpnhkJrhRGJRXxKd8rGuCO/i8t1Xg==,
-      }
-
-  "@zag-js/file-utils@1.18.3":
-    resolution:
-      {
-        integrity: sha512-JoQJsP3OWJTP/mGzKD/N7RKXdnigaT4ExKQPQaHF+jT/uQtHs+8J088Td/WVkfLTHIyW/s3t09pLk7z6ufZJkA==,
-      }
-
-  "@zag-js/focus-trap@1.18.3":
-    resolution:
-      {
-        integrity: sha512-EhAJb7xIHaUYP+WxlmN2SKEvsqTWih0FUX4Jf+rh2xr4v/dd/09ki+/yQjtTxVrKshCGe4LxCGeiws7mTkOZrA==,
-      }
-
-  "@zag-js/focus-visible@1.18.3":
-    resolution:
-      {
-        integrity: sha512-od0TDV0oCwldqyIOLyfLcLlQlsAnlsO03Je2TrL1/48vxbnPaYQRQK8HUjIFnPcr/rPDKojoRjmNi4OryD2/4w==,
-      }
-
-  "@zag-js/i18n-utils@1.18.3":
-    resolution:
-      {
-        integrity: sha512-7ihl4sJEyTL4LHwLgmRcSn9nGBEbbRkN6W552dFjeV5rAIgRGvrdKvEHGdkSQkrDHNlVU2zEHlN50vEdfsG4Vw==,
-      }
-
-  "@zag-js/interact-outside@1.18.3":
-    resolution:
-      {
-        integrity: sha512-DDcFBOZRjJ2a4qxQ2QU/37mIRCJivnVV87bKy8i/Zu+ea4URerBAsLp23/UC1aqEnDK+QXWRMQsK02SySR/RiA==,
-      }
-
-  "@zag-js/live-region@1.18.3":
-    resolution:
-      {
-        integrity: sha512-n3kKr4a+RWwBdkaZc+EZXBMb7joHg1lyxK95oP0/9l+Aeltut5gpjA+VQP49pLagakUnMzt1KbkHekO8FKeX3A==,
-      }
-
-  "@zag-js/pagination@1.18.3":
-    resolution:
-      {
-        integrity: sha512-n6+BVIR1MtBLu0w2CftbNpmWEL7F1RO/MgltQTI0MVUNUEqWEErn44m6oTckIGpF43B42IVbr5MIZrQyBmjhUg==,
-      }
-
-  "@zag-js/popover@1.18.3":
-    resolution:
-      {
-        integrity: sha512-60kMLotCgPBKvMmPkQTJpSRWQpIPOvxD3ZhbD2q9ZgvxH0tyLX9YpjDrCFoMCm90gsBeRbXObLcCnMfRecn4EA==,
-      }
-
-  "@zag-js/popper@1.18.3":
-    resolution:
-      {
-        integrity: sha512-g8qH1fzT3xPYsLfj/07fiNPintf3xr/VkAZ7btW8uO9fjJGe++1Dmk1qze1gFYReMGrSGg/6eB53QN5QxNYLtw==,
-      }
-
-  "@zag-js/progress@1.18.3":
-    resolution:
-      {
-        integrity: sha512-M37PpfL9ihiVUpeHMXbmm/88WO8RMPVXi5Dd4CJcc0pw5sh53b5SgxFbjm5ICrEqPRoxOIZ7Rg6yCgNMHMvaQg==,
-      }
-
-  "@zag-js/radio-group@1.18.3":
-    resolution:
-      {
-        integrity: sha512-LwsO1tgSYjQksWN3l9wLA8qisP+tLl/bex6hAGhaH1SFAbbr51xS+f1Sfyxiqv6Fk9P78ONW1Rb3eoIkTeZmUw==,
-      }
-
-  "@zag-js/rating-group@1.18.3":
-    resolution:
-      {
-        integrity: sha512-+2tqw7XwXf3Gv2uYBxYYIHfwQtuf7C/LjsakngtNxMfAyYwoldux/EKlm7Y7wEruKK7WqifsTbFxEdCvLrc3cw==,
-      }
-
-  "@zag-js/remove-scroll@1.18.3":
-    resolution:
-      {
-        integrity: sha512-cqWdN2uCRHiuXxLQq/HPTOLddHwp0UzGk/9fySox3kbZ2bsHtG1FXza2nrG99PlSrgorp3FIOsM8cT97cJfhCw==,
-      }
-
-  "@zag-js/slider@1.18.3":
-    resolution:
-      {
-        integrity: sha512-H85nDzQBl/Ab9ZCSqG3gHPyf/0TbFLKVdsPGLBVkbhZRhdcsOCwHQIcBIzbb7if6XM4zuOFClHJhDm3WaFfMEA==,
-      }
-
-  "@zag-js/store@1.18.3":
-    resolution:
-      {
-        integrity: sha512-9Df5Zr1pi9B7+2/OFdhyVDOkUaFUWLqgyKYx+DGaHh1LC6QbPJKoOsQ1zr23Q8G4//Dh1vNnES1SXojJA5+Nlg==,
-      }
-
-  "@zag-js/svelte@1.18.3":
-    resolution:
-      {
-        integrity: sha512-eGtlAtw2eQHASMs4wmJBpK6uGwFNibIQ+5Zw4TLPrvms0ZOOcZm4//DYqEdOhsunm95y8lYFRhaeDyVagrabtQ==,
-      }
+  '@zag-js/date-picker@1.32.0':
+    resolution: {integrity: sha512-gfSPXKHE6IwbKXJrsyfi2pozsLdoiLCaxxX4hofa9nuenRDhgZjtkFeR4ZpmLomxKRjiDi2Hy4PLcfadMRxF2A==}
     peerDependencies:
-      svelte: ^5.0.0-next.1
+      '@internationalized/date': '>=3.0.0'
 
-  "@zag-js/switch@1.18.3":
-    resolution:
-      {
-        integrity: sha512-JpdJR9pWMqfQWy3jcYwlNO2Av4UfY6ZvVnScOMU72bg8DWiv32SVZrdhBghhAPngWO8B181mJ30y9bUNths0tg==,
-      }
+  '@zag-js/date-utils@1.32.0':
+    resolution: {integrity: sha512-TOhUURjMgaEpjDETwxcfuN9IdwjgtLWLBflaDCXZlipLQ7kuEDiT1G9tKKVr7ioZmapgd9b482sevH2H89Lxiw==}
+    peerDependencies:
+      '@internationalized/date': '>=3.0.0'
 
-  "@zag-js/tabs@1.18.3":
-    resolution:
-      {
-        integrity: sha512-Bo+V5w0Lh2uVEyY8la7t8A0RxljyVwZmii+SzhWmsuSRBBvQ1y82Gyk0CbwuranARryIFHwWFl8c4sp4fSZvqA==,
-      }
+  '@zag-js/dialog@1.32.0':
+    resolution: {integrity: sha512-aIrui9Wfxqags3jBsnAPBN7Af2U3icfbrHUXgAJ7cxsfsj58b7amM6Y42Ro7t1lBmpH86+3IxqfDkdBH1VQU7A==}
 
-  "@zag-js/tags-input@1.18.3":
-    resolution:
-      {
-        integrity: sha512-gqC8r5m8Cp6B0wfGwivxl2gEQuiezua1nlonQSGgt/AQqPnILTqvziwkPurRKuG8S7e0M12pDTcJjSnsdZb2Nw==,
-      }
+  '@zag-js/dismissable@1.32.0':
+    resolution: {integrity: sha512-AUjajoaj2/3GfQvYJ5cdVwnov/dqAuS2N2dHRwxxSe/ktD4FbN/t0AcJ5Q2ojOuT6nBScEZQNd2vOrVgxLEiwQ==}
 
-  "@zag-js/toast@1.18.3":
-    resolution:
-      {
-        integrity: sha512-q+dH7Z8uUBezxWlJWdUqCDxkuIXQw9KN3AtNbCvM2ZFbJFHzvzvYwSiU3VBuML0cLxmNjXO3EpenKyPAla/VyA==,
-      }
+  '@zag-js/dom-query@1.32.0':
+    resolution: {integrity: sha512-12XCCV1bchIFC7wjtYim5sEqUrAddzt0eysMTbBrCuK5r6TmLecwLtxUNKIRQ8adkCn0jqecUiuNyXojaArP3g==}
 
-  "@zag-js/tooltip@1.18.3":
-    resolution:
-      {
-        integrity: sha512-FzG2epZX/ZmnrK9G1u9f3nmYLC1/a6mrp9BI2elaqO00cQNg7+WH+jhmrRofv2YrfpCgFYeo4yzAOcX6OkOiKA==,
-      }
+  '@zag-js/file-upload@1.32.0':
+    resolution: {integrity: sha512-tuE3nOACmidiyu17GD13csInnmXS7xkWeJwGW0gFk20054uXA0ajF07NLCMpv6bToEgK+65/g3Vn0Mkw92X7lQ==}
 
-  "@zag-js/types@1.18.3":
-    resolution:
-      {
-        integrity: sha512-M99ji5nha2/C2IQFkTkIA4SMR5w9rE0havAN55P8qpVtFzbcncCkSUZ4O0J2I4pA+NnJpCF5TcT1t7WnsyWlZQ==,
-      }
+  '@zag-js/file-utils@1.32.0':
+    resolution: {integrity: sha512-bZ43xFGt6zn7zKKvAi/WNG7uhvOPRwR8xv/yrHk9W3IPqEj3k3zYkZkfQQbwfBKwWWcQe48WtzV+hwSDsatvOg==}
 
-  "@zag-js/utils@1.18.3":
-    resolution:
-      {
-        integrity: sha512-yS8M286qUp6gf4d4tnnsNehdGIlI0Feuug9QiWkWSTbAUNmGJyh5cmjNxNSuLWVCPMREC89BIIWq09s113zPig==,
-      }
+  '@zag-js/floating-panel@1.32.0':
+    resolution: {integrity: sha512-qBZHA1Y4v8f9so8LcHVJXwfe+3qJ7M+6mRpl3llQO+InlPtXAd1jiBUa4u9v5PHj74Rmc0cWo+HJ2dPobynDCw==}
+
+  '@zag-js/focus-trap@1.32.0':
+    resolution: {integrity: sha512-irzYMaz1ycAnHOGLr4r6+3MwhfKnA67N9jPft9ejnE2QoTp40W+xp07K2KQNf6xN7Boe6xGlw8SwLBnGZw2eCQ==}
+
+  '@zag-js/focus-visible@1.32.0':
+    resolution: {integrity: sha512-/Gwu6Yt/c8tgpx32vkOxj2AIdmNdJv0WFHNBTl3xu60FR65oFfdpJsZR6MEbyL0F+srTYxuLZMdIoW5bN6nkQA==}
+
+  '@zag-js/i18n-utils@1.32.0':
+    resolution: {integrity: sha512-OMJTVMKjESWCAndYAi5kn+aYmVsU2pgJPWfH2nDS/wvGI4Z7WpJbbGZixbP7k6BSqewXS71xZRu98CNmL0IWwA==}
+
+  '@zag-js/interact-outside@1.32.0':
+    resolution: {integrity: sha512-OwQgBxijmv9ZXFu6WzhLRULJh0FoixuP6DJV9B2CGBKJZz4hbQAqVrW9PFaPiBuWOILZpZ/iI6ZDjkGSKZ0WHw==}
+
+  '@zag-js/listbox@1.32.0':
+    resolution: {integrity: sha512-7zENHml+igdm8xRiPSKTzEqUbRhSiusMv4JWSLamHswF+jN9ZG7yany1MEwiPrqizY9O3DbO/JYuZXliPsBACQ==}
+
+  '@zag-js/live-region@1.32.0':
+    resolution: {integrity: sha512-TN3fz8bk1k3ovGQJm7Lsr9xAaU+TwyPLhbBQzuApwz1aUzY4PFNdSdK56P7jnFlw6vrFq8/yOwUoDlTRzTGeRA==}
+
+  '@zag-js/menu@1.32.0':
+    resolution: {integrity: sha512-vMOPYg2a6dnTu8+E2wUptYkkdGyViUvf6je4+WEc5w0AGU1sGaZE+jckPK9f8vPUhL2I2TqwiI5dg85L+JZ1uw==}
+
+  '@zag-js/pagination@1.32.0':
+    resolution: {integrity: sha512-cfPaO9GyDSB1luaNEkh+RUYQzv1qZqP17Hq3AlJZQ5LQWc97U0ZyiptMm6oXApDKREoUhNcRNdpG9Mo5vz8Rbg==}
+
+  '@zag-js/popover@1.32.0':
+    resolution: {integrity: sha512-GTUQTWtMLyIXxHeV9dQy+xmIQVZ0KAION0XX/211ncrzWZ5guQXa2LECEH252uIEehRwRaFY08cZsacTqTOKsg==}
+
+  '@zag-js/popper@1.32.0':
+    resolution: {integrity: sha512-nTSdbgZKIEERNEpNhMlbATRiKhMrxo0t2206MbVhrM52TuraIc+nRmJNwWKoagalXs62/TlSpFvXmcpVyfWTMQ==}
+
+  '@zag-js/progress@1.32.0':
+    resolution: {integrity: sha512-BvxmOUqUFh8W0g/6kRMr991aGgoOq1nWos2gOrni6UKDz2KWyIfiMl4mhobsal8a8u3f/58zLNHp21VKd578NQ==}
+
+  '@zag-js/radio-group@1.32.0':
+    resolution: {integrity: sha512-OoCVyh7JK1WIbmoWtjOr56joi3J9RyL/fHMQlX6Nk1a4wCB1Bb0aZ6TgSDqMBrcPG7ufIqdEagSU0o5Uq9GD6Q==}
+
+  '@zag-js/rating-group@1.32.0':
+    resolution: {integrity: sha512-lEXxuhxHMHCSgMEilLKJjEF4vTgnCHaNIsZG9XRTL8BTIjbusTmvB6i3s2edLEdy0IFNK1HJ6JIXMT1G4r6fPg==}
+
+  '@zag-js/rect-utils@1.32.0':
+    resolution: {integrity: sha512-waBJL57PA90mYRMCDF7WNa3ZEfNhnWPu6lGqNB1Lh/1GMUzIto1X/Lw1oJoGig8Ui9Af9pgRG4QPyKSRULFgKQ==}
+
+  '@zag-js/remove-scroll@1.32.0':
+    resolution: {integrity: sha512-gWx8z/8ayNo624ibET4cNWbdVLc8A0Vyy9L9t67KT/slrBjcOA/zp9JL3Ngw/TZKgtR+wDh7P8ZoNAe0euaLSQ==}
+
+  '@zag-js/scroll-snap@1.32.0':
+    resolution: {integrity: sha512-N77nO4dhDyLYeemrUBEGuJEl7u357WjMozEkErLzpg4vSTIOrzHPh1oqVzykcQa/eVq9qyHGz4/txqgkEy+fbg==}
+
+  '@zag-js/slider@1.32.0':
+    resolution: {integrity: sha512-sbxQWp+/YxSvMDNkl5QDU7JyN6AGszASBZ1fT41Ctup17CQXnTwRK6CaAr00fgd4d21JlWd7T74/M393XgA6iQ==}
+
+  '@zag-js/steps@1.32.0':
+    resolution: {integrity: sha512-b0tA20GG5Kb+JDUHFPFT4QEQiDMsotWlIFXphntkzXFNqXOc/stPfllT78YoDAGx5hnvE20fSHooXze9A5Ad5Q==}
+
+  '@zag-js/store@1.32.0':
+    resolution: {integrity: sha512-m9jvTKJB/lTC2I8NpDf+yo2XVN+ogxjiVbGsooAFTpyUAiXZY50nVc9cFcswnwFMo/GzXMk81oalyz9u65jqRQ==}
+
+  '@zag-js/svelte@1.32.0':
+    resolution: {integrity: sha512-Coth0r/owg+1L9tapDDAEKzYf2dezaugvDAfRMvl/rrsUIYtsm6z6ceKcMq0NFzVPB5jsYTW/tK9RW05Xr0Zsg==}
+    peerDependencies:
+      svelte: '>=5'
+
+  '@zag-js/switch@1.32.0':
+    resolution: {integrity: sha512-im6kDxjT/HT7T7+4/2VHpJm744SxN9SK9fNJMU48LYmO55Qi3Ftz89Gp19P2cv9KxFgR9o0gGZH4adELULtJTQ==}
+
+  '@zag-js/tabs@1.32.0':
+    resolution: {integrity: sha512-ZgRHQmE+np/EPEUtSsCrYJLWFdW9JXtXE6vb1uJfR4K4yUGxGMRdBuKeeRSTMUtSLqXyo9KwDYQtAQa/RdnOHg==}
+
+  '@zag-js/tags-input@1.32.0':
+    resolution: {integrity: sha512-Aj0no7TpJGU5NkcXDYKuoKuEZhePkb8baPsLx1K76QOYpwDxujlOy2BemtGisxmWHidjQROYJIr7ks31iNcXmA==}
+
+  '@zag-js/toast@1.32.0':
+    resolution: {integrity: sha512-f5APsASyGmhKlpQ/Wxc4bp9hAUVuXqV6FoHnu7ugfIuYllIaSz/RHgsb4yZvLjweNE24cw4B9Rjj9njOZGPe6Q==}
+
+  '@zag-js/toggle-group@1.32.0':
+    resolution: {integrity: sha512-1opPWPMgDqk/NnD42F/bh1nOBcr6N+pYG53D/agifDxuhh+kiAFJ4QubLK+1758J55fIQWclToAbKZO7U8UCLQ==}
+
+  '@zag-js/tooltip@1.32.0':
+    resolution: {integrity: sha512-V3GJXCgSTiijqZTqJnRQ5HClL8GUtGhfczcB9fV+T2+mbwZXahfNQ0Fjrfi2Itb4WLCTovOi9iIAlfl3S1V/pQ==}
+
+  '@zag-js/tree-view@1.32.0':
+    resolution: {integrity: sha512-brMHrwmDDfuPFcsciHLwb941hBy/Zm9hug0325HNgNLKVCjiJ2Gewnay373IQhxDJHeuF+9htJlq3bhMlHeLTw==}
+
+  '@zag-js/types@1.32.0':
+    resolution: {integrity: sha512-9UV5mFnTgJRyFCCH9g/TIqtxxfw6FUphpe7E0AHK9+WSq3PRvflMeaRT/O6HgdWo0Rc+JN9vVwkFYyGD81uAbw==}
+
+  '@zag-js/utils@1.32.0':
+    resolution: {integrity: sha512-IRe1yFbMXBp8Q1Xp916Lq9P91s65K5KRNFZIv2EdQHRynLaT+QrPp5hmzkWoXJn8oOYd6PZeNb7K6v7vk8+k1g==}
 
   acorn@8.15.0:
-    resolution:
-      {
-        integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
-      }
-    engines: { node: ">=0.4.0" }
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
     hasBin: true
 
   aria-query@5.3.2:
-    resolution:
-      {
-        integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@2.0.1:
-    resolution:
-      {
-        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   axobject-query@4.1.0:
-    resolution:
-      {
-        integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   cac@6.7.14:
-    resolution:
-      {
-        integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
   chai@5.3.3:
-    resolution:
-      {
-        integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chart.js@4.5.1:
-    resolution:
-      {
-        integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==,
-      }
-    engines: { pnpm: ">=8" }
+    resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
+    engines: {pnpm: '>=8'}
 
   check-error@2.1.3:
-    resolution:
-      {
-        integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
-      }
-    engines: { node: ">= 16" }
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chevrotain-allstar@0.3.1:
+    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
+    peerDependencies:
+      chevrotain: ^11.0.0
+
+  chevrotain@11.0.3:
+    resolution: {integrity: sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==}
 
   chokidar@4.0.3:
-    resolution:
-      {
-        integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
-      }
-    engines: { node: ">= 14.16.0" }
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   clsx@2.1.1:
-    resolution:
-      {
-        integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   commondir@1.0.1:
-    resolution:
-      {
-        integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==,
-      }
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   cookie@0.6.0:
-    resolution:
-      {
-        integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==,
-      }
-    engines: { node: ">= 0.6" }
+    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+    engines: {node: '>= 0.6'}
 
-  csstype@3.1.3:
-    resolution:
-      {
-        integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==,
-      }
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.1:
+    resolution: {integrity: sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.13:
+    resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
+
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
   debug@4.4.3:
-    resolution:
-      {
-        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
-      }
-    engines: { node: ">=6.0" }
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
     peerDependencies:
-      supports-color: "*"
+      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
 
   deep-eql@5.0.2:
-    resolution:
-      {
-        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deepmerge@4.3.1:
-    resolution:
-      {
-        integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  delaunator@5.0.1:
+    resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
-    resolution:
-      {
-        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   devalue@5.6.2:
-    resolution:
-      {
-        integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==,
-      }
+    resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   enhanced-resolve@5.19.0:
-    resolution:
-      {
-        integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==,
-      }
-    engines: { node: ">=10.13.0" }
+    resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
+    engines: {node: '>=10.13.0'}
 
   es-module-lexer@1.7.0:
-    resolution:
-      {
-        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
-      }
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.25.12:
-    resolution:
-      {
-        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.27.3:
-    resolution:
-      {
-        integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esm-env@1.2.2:
-    resolution:
-      {
-        integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==,
-      }
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   esrap@2.2.2:
-    resolution:
-      {
-        integrity: sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==,
-      }
+    resolution: {integrity: sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==}
 
   estree-walker@2.0.2:
-    resolution:
-      {
-        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
-      }
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
-    resolution:
-      {
-        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
-      }
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   expect-type@1.3.0:
-    resolution:
-      {
-        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fdir@6.5.0:
-    resolution:
-      {
-        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1553,505 +1584,615 @@ packages:
         optional: true
 
   fsevents@2.3.3:
-    resolution:
-      {
-        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
-      }
-    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution:
-      {
-        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
-      }
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   get-tsconfig@4.13.6:
-    resolution:
-      {
-        integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==,
-      }
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
   graceful-fs@4.2.11:
-    resolution:
-      {
-        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-      }
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
   hasown@2.0.2:
-    resolution:
-      {
-        integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-core-module@2.16.1:
-    resolution:
-      {
-        integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-module@1.0.0:
-    resolution:
-      {
-        integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==,
-      }
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-reference@1.2.1:
-    resolution:
-      {
-        integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==,
-      }
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
   is-reference@3.0.3:
-    resolution:
-      {
-        integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==,
-      }
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   jiti@2.6.1:
-    resolution:
-      {
-        integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
-      }
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   js-tokens@9.0.1:
-    resolution:
-      {
-        integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==,
-      }
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  katex@0.16.28:
+    resolution: {integrity: sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kleur@4.1.5:
-    resolution:
-      {
-        integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  langium@3.3.1:
+    resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
+    engines: {node: '>=16.0.0'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lightningcss-android-arm64@1.30.2:
-    resolution:
-      {
-        integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-android-arm64@1.31.1:
+    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
   lightningcss-darwin-arm64@1.30.2:
-    resolution:
-      {
-        integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.31.1:
+    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.30.2:
-    resolution:
-      {
-        integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.31.1:
+    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.30.2:
-    resolution:
-      {
-        integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.31.1:
+    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
-    resolution:
-      {
-        integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm-gnueabihf@1.31.1:
+    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
   lightningcss-linux-arm64-gnu@1.30.2:
-    resolution:
-      {
-        integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.31.1:
+    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-arm64-musl@1.30.2:
-    resolution:
-      {
-        integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.31.1:
+    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-x64-gnu@1.30.2:
-    resolution:
-      {
-        integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.31.1:
+    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
   lightningcss-linux-x64-musl@1.30.2:
-    resolution:
-      {
-        integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.31.1:
+    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
   lightningcss-win32-arm64-msvc@1.30.2:
-    resolution:
-      {
-        integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.31.1:
+    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
+    engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.30.2:
-    resolution:
-      {
-        integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.31.1:
+    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
+    engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
   lightningcss@1.30.2:
-    resolution:
-      {
-        integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==,
-      }
-    engines: { node: ">= 12.0.0" }
+    resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.31.1:
+    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
+    engines: {node: '>= 12.0.0'}
 
   locate-character@3.0.0:
-    resolution:
-      {
-        integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==,
-      }
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
   loupe@3.2.1:
-    resolution:
-      {
-        integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
-      }
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   magic-string@0.30.21:
-    resolution:
-      {
-        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
-      }
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  mri@1.2.0:
-    resolution:
-      {
-        integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==,
-      }
-    engines: { node: ">=4" }
-
-  mrmime@2.0.1:
-    resolution:
-      {
-        integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==,
-      }
-    engines: { node: ">=10" }
-
-  ms@2.1.3:
-    resolution:
-      {
-        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
-      }
-
-  nanoid@3.3.11:
-    resolution:
-      {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
-      }
-    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
     hasBin: true
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdsvex@0.12.6:
+    resolution: {integrity: sha512-pupx2gzWh3hDtm/iDW4WuCpljmyHbHi34r7ktOqpPGvyiM4MyfNgdJ3qMizXdgCErmvYC9Nn/qyjePy+4ss9Wg==}
+    peerDependencies:
+      svelte: ^3.56.0 || ^4.0.0 || ^5.0.0-next.120
+
+  mermaid@11.12.2:
+    resolution: {integrity: sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
+
+  oniguruma-to-es@4.3.4:
+    resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   path-parse@1.0.7:
-    resolution:
-      {
-        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
-      }
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   pathe@2.0.3:
-    resolution:
-      {
-        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
-      }
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
-    resolution:
-      {
-        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
-      }
-    engines: { node: ">= 14.16" }
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
-    resolution:
-      {
-        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
-      }
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.3:
-    resolution:
-      {
-        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
-      }
-    engines: { node: ">=12" }
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss@8.5.6:
-    resolution:
-      {
-        integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prism-svelte@0.4.7:
+    resolution: {integrity: sha512-yABh19CYbM24V7aS7TuPYRNMqthxwbvx6FF/Rw920YbyBWO3tnyPIqRMgHuSVsLmuHkkBS1Akyof463FVdkeDQ==}
+
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   proxy-compare@3.0.1:
-    resolution:
-      {
-        integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==,
-      }
+    resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
 
   readdirp@4.1.2:
-    resolution:
-      {
-        integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
-      }
-    engines: { node: ">= 14.18.0" }
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  rehype-autolink-headings@7.1.0:
+    resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   resolve-pkg-maps@1.0.0:
-    resolution:
-      {
-        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
-      }
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   resolve@1.22.11:
-    resolution:
-      {
-        integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  robust-predicates@3.0.2:
+    resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
+
+  rolldown@1.0.0-rc.3:
+    resolution: {integrity: sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rollup@4.57.1:
-    resolution:
-      {
-        integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==,
-      }
-    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
   sade@1.8.1:
-    resolution:
-      {
-        integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   set-cookie-parser@3.0.1:
-    resolution:
-      {
-        integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==,
-      }
+    resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
+
+  shiki@3.22.0:
+    resolution: {integrity: sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==}
 
   siginfo@2.0.0:
-    resolution:
-      {
-        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
-      }
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   sirv@3.0.2:
-    resolution:
-      {
-        integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   source-map-js@1.2.1:
-    resolution:
-      {
-        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
-      }
-    engines: { node: ">=0.10.0" }
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   stackback@0.0.2:
-    resolution:
-      {
-        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
-      }
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
-    resolution:
-      {
-        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
-      }
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-literal@3.1.0:
-    resolution:
-      {
-        integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==,
-      }
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  stylis@4.3.6:
+    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
   supports-preserve-symlinks-flag@1.0.0:
-    resolution:
-      {
-        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
-      }
-    engines: { node: ">= 0.4" }
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   svelte-chartjs@3.1.5:
-    resolution:
-      {
-        integrity: sha512-ka2zh7v5FiwfAX1oMflZ0HkNkgjHjFqANgRyC+vNYXfxtx2ku68Zo+2KgbKeBH2nS1ThDqkIACPzGxy4T0UaoA==,
-      }
+    resolution: {integrity: sha512-ka2zh7v5FiwfAX1oMflZ0HkNkgjHjFqANgRyC+vNYXfxtx2ku68Zo+2KgbKeBH2nS1ThDqkIACPzGxy4T0UaoA==}
     peerDependencies:
       chart.js: ^3.5.0 || ^4.0.0
       svelte: ^4.0.0
 
   svelte-check@4.3.6:
-    resolution:
-      {
-        integrity: sha512-uBkz96ElE3G4pt9E1Tw0xvBfIUQkeH794kDQZdAUk795UVMr+NJZpuFSS62vcmO/DuSalK83LyOwhgWq8YGU1Q==,
-      }
-    engines: { node: ">= 18.0.0" }
+    resolution: {integrity: sha512-uBkz96ElE3G4pt9E1Tw0xvBfIUQkeH794kDQZdAUk795UVMr+NJZpuFSS62vcmO/DuSalK83LyOwhgWq8YGU1Q==}
+    engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
-      typescript: ">=5.0.0"
+      typescript: '>=5.0.0'
 
   svelte@5.49.2:
-    resolution:
-      {
-        integrity: sha512-PYLwnngYzyhKzqDlGVlCH4z+NVI8mC0/bTv15vw25CcdOhxENsOHIbQ36oj5DIf3oBazM+STbCAvaskpxtBmWA==,
-      }
-    engines: { node: ">=18" }
+    resolution: {integrity: sha512-PYLwnngYzyhKzqDlGVlCH4z+NVI8mC0/bTv15vw25CcdOhxENsOHIbQ36oj5DIf3oBazM+STbCAvaskpxtBmWA==}
+    engines: {node: '>=18'}
 
   tailwindcss@4.1.18:
-    resolution:
-      {
-        integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==,
-      }
+    resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
   tapable@2.3.0:
-    resolution:
-      {
-        integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
 
   tinybench@2.9.0:
-    resolution:
-      {
-        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
-      }
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@0.3.2:
-    resolution:
-      {
-        integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
-      }
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
-    resolution:
-      {
-        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
-      }
-    engines: { node: ">=12.0.0" }
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
-    resolution:
-      {
-        integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
-    resolution:
-      {
-        integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
-    resolution:
-      {
-        integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==,
-      }
-    engines: { node: ">=14.0.0" }
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   totalist@3.0.1:
-    resolution:
-      {
-        integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==,
-      }
-    engines: { node: ">=6" }
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
-    resolution:
-      {
-        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
-      }
-    engines: { node: ">=18.0.0" }
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   typescript@5.9.3:
-    resolution:
-      {
-        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
-      }
-    engines: { node: ">=14.17" }
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
   undici-types@6.21.0:
-    resolution:
-      {
-        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
-      }
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@4.1.0:
+    resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@2.0.3:
+    resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@3.1.1:
+    resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@2.0.3:
+    resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  vfile-message@2.0.4:
+    resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@3.2.4:
-    resolution:
-      {
-        integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite@6.4.1:
-    resolution:
-      {
-        integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: ">=1.21.0"
-      less: "*"
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
-      "@types/node":
+      '@types/node':
         optional: true
       jiti:
         optional: true
@@ -2074,11 +2215,51 @@ packages:
       yaml:
         optional: true
 
+  vite@8.0.0-beta.13:
+    resolution: {integrity: sha512-7s/rfpYOAo7WUHh9irzaGjhhKb12hGv0BpDegAMV5A391wdyvM45WtX6VMV7hvEtZF2j/QtpDpR6ldXI3GgARQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.0.0-alpha.24
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.1.1:
-    resolution:
-      {
-        integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==,
-      }
+    resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
     peerDependenciesMeta:
@@ -2086,252 +2267,374 @@ packages:
         optional: true
 
   vitest@3.2.4:
-    resolution:
-      {
-        integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==,
-      }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      "@edge-runtime/vm": "*"
-      "@types/debug": ^4.1.12
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
-      "@vitest/browser": 3.2.4
-      "@vitest/ui": 3.2.4
-      happy-dom: "*"
-      jsdom: "*"
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
     peerDependenciesMeta:
-      "@edge-runtime/vm":
+      '@edge-runtime/vm':
         optional: true
-      "@types/debug":
+      '@types/debug':
         optional: true
-      "@types/node":
+      '@types/node':
         optional: true
-      "@vitest/browser":
+      '@vitest/browser':
         optional: true
-      "@vitest/ui":
+      '@vitest/ui':
         optional: true
       happy-dom:
         optional: true
       jsdom:
         optional: true
 
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-uri@3.0.8:
+    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+
   why-is-node-running@2.3.0:
-    resolution:
-      {
-        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
-      }
-    engines: { node: ">=8" }
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   yaml@2.8.2:
-    resolution:
-      {
-        integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==,
-      }
-    engines: { node: ">= 14.6" }
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
   zimmerframe@1.1.4:
-    resolution:
-      {
-        integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==,
-      }
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-  "@esbuild/aix-ppc64@0.25.12":
-    optional: true
 
-  "@esbuild/aix-ppc64@0.27.3":
-    optional: true
-
-  "@esbuild/android-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/android-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/android-arm@0.25.12":
-    optional: true
-
-  "@esbuild/android-arm@0.27.3":
-    optional: true
-
-  "@esbuild/android-x64@0.25.12":
-    optional: true
-
-  "@esbuild/android-x64@0.27.3":
-    optional: true
-
-  "@esbuild/darwin-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/darwin-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/darwin-x64@0.25.12":
-    optional: true
-
-  "@esbuild/darwin-x64@0.27.3":
-    optional: true
-
-  "@esbuild/freebsd-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/freebsd-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/freebsd-x64@0.25.12":
-    optional: true
-
-  "@esbuild/freebsd-x64@0.27.3":
-    optional: true
-
-  "@esbuild/linux-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/linux-arm@0.25.12":
-    optional: true
-
-  "@esbuild/linux-arm@0.27.3":
-    optional: true
-
-  "@esbuild/linux-ia32@0.25.12":
-    optional: true
-
-  "@esbuild/linux-ia32@0.27.3":
-    optional: true
-
-  "@esbuild/linux-loong64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-loong64@0.27.3":
-    optional: true
-
-  "@esbuild/linux-mips64el@0.25.12":
-    optional: true
-
-  "@esbuild/linux-mips64el@0.27.3":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.27.3":
-    optional: true
-
-  "@esbuild/linux-riscv64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-riscv64@0.27.3":
-    optional: true
-
-  "@esbuild/linux-s390x@0.25.12":
-    optional: true
-
-  "@esbuild/linux-s390x@0.27.3":
-    optional: true
-
-  "@esbuild/linux-x64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-x64@0.27.3":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/netbsd-x64@0.25.12":
-    optional: true
-
-  "@esbuild/netbsd-x64@0.27.3":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/openbsd-x64@0.25.12":
-    optional: true
-
-  "@esbuild/openbsd-x64@0.27.3":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/sunos-x64@0.25.12":
-    optional: true
-
-  "@esbuild/sunos-x64@0.27.3":
-    optional: true
-
-  "@esbuild/win32-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/win32-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/win32-ia32@0.25.12":
-    optional: true
-
-  "@esbuild/win32-ia32@0.27.3":
-    optional: true
-
-  "@esbuild/win32-x64@0.25.12":
-    optional: true
-
-  "@esbuild/win32-x64@0.27.3":
-    optional: true
-
-  "@floating-ui/core@1.7.4":
+  '@antfu/install-pkg@1.1.0':
     dependencies:
-      "@floating-ui/utils": 0.2.10
+      package-manager-detector: 1.6.0
+      tinyexec: 1.0.2
 
-  "@floating-ui/dom@1.7.2":
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/cst-dts-gen@11.0.3':
     dependencies:
-      "@floating-ui/core": 1.7.4
-      "@floating-ui/utils": 0.2.10
+      '@chevrotain/gast': 11.0.3
+      '@chevrotain/types': 11.0.3
+      lodash-es: 4.17.21
 
-  "@floating-ui/utils@0.2.10": {}
-
-  "@jridgewell/gen-mapping@0.3.13":
+  '@chevrotain/gast@11.0.3':
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
-      "@jridgewell/trace-mapping": 0.3.31
+      '@chevrotain/types': 11.0.3
+      lodash-es: 4.17.21
 
-  "@jridgewell/remapping@2.3.5":
+  '@chevrotain/regexp-to-ast@11.0.3': {}
+
+  '@chevrotain/types@11.0.3': {}
+
+  '@chevrotain/utils@11.0.3': {}
+
+  '@emnapi/core@1.8.1':
     dependencies:
-      "@jridgewell/gen-mapping": 0.3.13
-      "@jridgewell/trace-mapping": 0.3.31
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
 
-  "@jridgewell/resolve-uri@3.1.2": {}
-
-  "@jridgewell/sourcemap-codec@1.5.5": {}
-
-  "@jridgewell/trace-mapping@0.3.31":
+  '@emnapi/runtime@1.8.1':
     dependencies:
-      "@jridgewell/resolve-uri": 3.1.2
-      "@jridgewell/sourcemap-codec": 1.5.5
+      tslib: 2.8.1
+    optional: true
 
-  "@kurkle/color@0.3.4": {}
-
-  "@polka/url@1.0.0-next.29": {}
-
-  "@rollup/plugin-commonjs@28.0.9(rollup@4.57.1)":
+  '@emnapi/wasi-threads@1.1.0':
     dependencies:
-      "@rollup/pluginutils": 5.3.0(rollup@4.57.1)
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@floating-ui/core@1.7.4':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.5':
+    dependencies:
+      '@floating-ui/core': 1.7.4
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/utils@0.2.10': {}
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.0':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      mlly: 1.8.0
+
+  '@internationalized/date@3.10.1':
+    dependencies:
+      '@swc/helpers': 0.5.18
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@kurkle/color@0.3.4': {}
+
+  '@mermaid-js/parser@0.6.3':
+    dependencies:
+      langium: 3.3.1
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.8.1
+      '@emnapi/runtime': 1.8.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/runtime@0.112.0': {}
+
+  '@oxc-project/types@0.112.0': {}
+
+  '@polka/url@1.0.0-next.29': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/plugin-commonjs@28.0.9(rollup@4.57.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2341,150 +2644,206 @@ snapshots:
     optionalDependencies:
       rollup: 4.57.1
 
-  "@rollup/plugin-json@6.1.0(rollup@4.57.1)":
+  '@rollup/plugin-json@6.1.0(rollup@4.57.1)':
     dependencies:
-      "@rollup/pluginutils": 5.3.0(rollup@4.57.1)
+      '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
     optionalDependencies:
       rollup: 4.57.1
 
-  "@rollup/plugin-node-resolve@16.0.3(rollup@4.57.1)":
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.57.1)':
     dependencies:
-      "@rollup/pluginutils": 5.3.0(rollup@4.57.1)
-      "@types/resolve": 1.20.2
+      '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
+      '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.11
     optionalDependencies:
       rollup: 4.57.1
 
-  "@rollup/pluginutils@5.3.0(rollup@4.57.1)":
+  '@rollup/pluginutils@5.3.0(rollup@4.57.1)':
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.57.1
 
-  "@rollup/rollup-android-arm-eabi@4.57.1":
+  '@rollup/rollup-android-arm-eabi@4.57.1':
     optional: true
 
-  "@rollup/rollup-android-arm64@4.57.1":
+  '@rollup/rollup-android-arm64@4.57.1':
     optional: true
 
-  "@rollup/rollup-darwin-arm64@4.57.1":
+  '@rollup/rollup-darwin-arm64@4.57.1':
     optional: true
 
-  "@rollup/rollup-darwin-x64@4.57.1":
+  '@rollup/rollup-darwin-x64@4.57.1':
     optional: true
 
-  "@rollup/rollup-freebsd-arm64@4.57.1":
+  '@rollup/rollup-freebsd-arm64@4.57.1':
     optional: true
 
-  "@rollup/rollup-freebsd-x64@4.57.1":
+  '@rollup/rollup-freebsd-x64@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.57.1":
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-arm-musleabihf@4.57.1":
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-arm64-gnu@4.57.1":
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-arm64-musl@4.57.1":
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-loong64-gnu@4.57.1":
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-loong64-musl@4.57.1":
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-ppc64-gnu@4.57.1":
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-ppc64-musl@4.57.1":
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-riscv64-gnu@4.57.1":
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-riscv64-musl@4.57.1":
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-s390x-gnu@4.57.1":
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-x64-gnu@4.57.1":
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
     optional: true
 
-  "@rollup/rollup-linux-x64-musl@4.57.1":
+  '@rollup/rollup-linux-x64-musl@4.57.1':
     optional: true
 
-  "@rollup/rollup-openbsd-x64@4.57.1":
+  '@rollup/rollup-openbsd-x64@4.57.1':
     optional: true
 
-  "@rollup/rollup-openharmony-arm64@4.57.1":
+  '@rollup/rollup-openharmony-arm64@4.57.1':
     optional: true
 
-  "@rollup/rollup-win32-arm64-msvc@4.57.1":
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
     optional: true
 
-  "@rollup/rollup-win32-ia32-msvc@4.57.1":
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
     optional: true
 
-  "@rollup/rollup-win32-x64-gnu@4.57.1":
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
     optional: true
 
-  "@rollup/rollup-win32-x64-msvc@4.57.1":
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
-  "@skeletonlabs/skeleton-svelte@1.5.3(svelte@5.49.2)":
+  '@shikijs/core@3.22.0':
     dependencies:
-      "@zag-js/accordion": 1.18.3
-      "@zag-js/avatar": 1.18.3
-      "@zag-js/combobox": 1.18.3
-      "@zag-js/dialog": 1.18.3
-      "@zag-js/file-upload": 1.18.3
-      "@zag-js/pagination": 1.18.3
-      "@zag-js/popover": 1.18.3
-      "@zag-js/progress": 1.18.3
-      "@zag-js/radio-group": 1.18.3
-      "@zag-js/rating-group": 1.18.3
-      "@zag-js/slider": 1.18.3
-      "@zag-js/svelte": 1.18.3(svelte@5.49.2)
-      "@zag-js/switch": 1.18.3
-      "@zag-js/tabs": 1.18.3
-      "@zag-js/tags-input": 1.18.3
-      "@zag-js/toast": 1.18.3
-      "@zag-js/tooltip": 1.18.3
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.4
+
+  '@shikijs/engine-oniguruma@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+
+  '@shikijs/themes@3.22.0':
+    dependencies:
+      '@shikijs/types': 3.22.0
+
+  '@shikijs/transformers@3.22.0':
+    dependencies:
+      '@shikijs/core': 3.22.0
+      '@shikijs/types': 3.22.0
+
+  '@shikijs/types@3.22.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@skeletonlabs/skeleton-common@4.12.0': {}
+
+  '@skeletonlabs/skeleton-svelte@4.12.0(svelte@5.49.2)':
+    dependencies:
+      '@internationalized/date': 3.10.1
+      '@skeletonlabs/skeleton-common': 4.12.0
+      '@zag-js/accordion': 1.32.0
+      '@zag-js/avatar': 1.32.0
+      '@zag-js/carousel': 1.32.0
+      '@zag-js/collapsible': 1.32.0
+      '@zag-js/collection': 1.32.0
+      '@zag-js/combobox': 1.32.0
+      '@zag-js/date-picker': 1.32.0(@internationalized/date@3.10.1)
+      '@zag-js/dialog': 1.32.0
+      '@zag-js/file-upload': 1.32.0
+      '@zag-js/floating-panel': 1.32.0
+      '@zag-js/listbox': 1.32.0
+      '@zag-js/menu': 1.32.0
+      '@zag-js/pagination': 1.32.0
+      '@zag-js/popover': 1.32.0
+      '@zag-js/progress': 1.32.0
+      '@zag-js/radio-group': 1.32.0
+      '@zag-js/rating-group': 1.32.0
+      '@zag-js/slider': 1.32.0
+      '@zag-js/steps': 1.32.0
+      '@zag-js/svelte': 1.32.0(svelte@5.49.2)
+      '@zag-js/switch': 1.32.0
+      '@zag-js/tabs': 1.32.0
+      '@zag-js/tags-input': 1.32.0
+      '@zag-js/toast': 1.32.0
+      '@zag-js/toggle-group': 1.32.0
+      '@zag-js/tooltip': 1.32.0
+      '@zag-js/tree-view': 1.32.0
       svelte: 5.49.2
 
-  "@skeletonlabs/skeleton@3.2.2(tailwindcss@4.1.18)":
+  '@skeletonlabs/skeleton@4.12.0(tailwindcss@4.1.18)':
     dependencies:
       tailwindcss: 4.1.18
 
-  "@standard-schema/spec@1.1.0": {}
+  '@standard-schema/spec@1.1.0': {}
 
-  "@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)":
+  '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
 
-  "@sveltejs/adapter-node@5.5.2(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))":
+  '@sveltejs/adapter-node@5.5.2(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      "@rollup/plugin-commonjs": 28.0.9(rollup@4.57.1)
-      "@rollup/plugin-json": 6.1.0(rollup@4.57.1)
-      "@rollup/plugin-node-resolve": 16.0.3(rollup@4.57.1)
-      "@sveltejs/kit": 2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@rollup/plugin-commonjs': 28.0.9(rollup@4.57.1)
+      '@rollup/plugin-json': 6.1.0(rollup@4.57.1)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.57.1)
+      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       rollup: 4.57.1
 
-  "@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))":
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      "@standard-schema/spec": 1.1.0
-      "@sveltejs/acorn-typescript": 1.0.8(acorn@8.15.0)
-      "@sveltejs/vite-plugin-svelte": 5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      "@types/cookie": 0.6.0
+      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  '@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(typescript@5.9.3)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
+      '@sveltejs/vite-plugin-svelte': 7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
       devalue: 5.6.2
@@ -2496,35 +2855,26 @@ snapshots:
       set-cookie-parser: 3.0.1
       sirv: 3.0.2
       svelte: 5.49.2
-      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
 
-  "@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))":
+  '@sveltejs/vite-plugin-svelte@7.0.0-next.0(svelte@5.49.2)(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      "@sveltejs/vite-plugin-svelte": 5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      debug: 4.4.3
-      svelte: 5.49.2
-      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  "@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))":
-    dependencies:
-      "@sveltejs/vite-plugin-svelte-inspector": 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.49.2)(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      debug: 4.4.3
       deepmerge: 4.3.1
-      kleur: 4.1.5
       magic-string: 0.30.21
+      obug: 2.1.1
       svelte: 5.49.2
-      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-    transitivePeerDependencies:
-      - supports-color
+      vite: 8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.1(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
 
-  "@tailwindcss/node@4.1.18":
+  '@swc/helpers@0.5.18':
     dependencies:
-      "@jridgewell/remapping": 2.3.5
+      tslib: 2.8.1
+
+  '@tailwindcss/node@4.1.18':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.19.0
       jiti: 2.6.1
       lightningcss: 1.30.2
@@ -2532,351 +2882,595 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.1.18
 
-  "@tailwindcss/oxide-android-arm64@4.1.18":
+  '@tailwindcss/oxide-android-arm64@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-darwin-arm64@4.1.18":
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-darwin-x64@4.1.18":
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-freebsd-x64@4.1.18":
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18":
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-linux-arm64-gnu@4.1.18":
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-linux-arm64-musl@4.1.18":
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-linux-x64-gnu@4.1.18":
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-linux-x64-musl@4.1.18":
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-wasm32-wasi@4.1.18":
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-win32-arm64-msvc@4.1.18":
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide-win32-x64-msvc@4.1.18":
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
     optional: true
 
-  "@tailwindcss/oxide@4.1.18":
+  '@tailwindcss/oxide@4.1.18':
     optionalDependencies:
-      "@tailwindcss/oxide-android-arm64": 4.1.18
-      "@tailwindcss/oxide-darwin-arm64": 4.1.18
-      "@tailwindcss/oxide-darwin-x64": 4.1.18
-      "@tailwindcss/oxide-freebsd-x64": 4.1.18
-      "@tailwindcss/oxide-linux-arm-gnueabihf": 4.1.18
-      "@tailwindcss/oxide-linux-arm64-gnu": 4.1.18
-      "@tailwindcss/oxide-linux-arm64-musl": 4.1.18
-      "@tailwindcss/oxide-linux-x64-gnu": 4.1.18
-      "@tailwindcss/oxide-linux-x64-musl": 4.1.18
-      "@tailwindcss/oxide-wasm32-wasi": 4.1.18
-      "@tailwindcss/oxide-win32-arm64-msvc": 4.1.18
-      "@tailwindcss/oxide-win32-x64-msvc": 4.1.18
+      '@tailwindcss/oxide-android-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-x64': 4.1.18
+      '@tailwindcss/oxide-freebsd-x64': 4.1.18
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.18
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.18
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.18
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  "@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))":
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.18)':
     dependencies:
-      "@tailwindcss/node": 4.1.18
-      "@tailwindcss/oxide": 4.1.18
+      postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.18
-      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
-  "@types/chai@5.2.3":
+  '@tailwindcss/vite@4.1.18(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      "@types/deep-eql": 4.0.2
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      tailwindcss: 4.1.18
+      vite: 8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  "@types/cookie@0.6.0": {}
+  '@types/cookie@0.6.0': {}
 
-  "@types/deep-eql@4.0.2": {}
+  '@types/d3-array@3.2.2': {}
 
-  "@types/estree@1.0.8": {}
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
 
-  "@types/node@22.19.9":
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 2.0.11
+
+  '@types/node@22.19.9':
     dependencies:
       undici-types: 6.21.0
 
-  "@types/resolve@1.20.2": {}
+  '@types/resolve@1.20.2': {}
 
-  "@vitest/expect@3.2.4":
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.0': {}
+
+  '@vitest/expect@3.2.4':
     dependencies:
-      "@types/chai": 5.2.3
-      "@vitest/spy": 3.2.4
-      "@vitest/utils": 3.2.4
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  "@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))":
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      "@vitest/spy": 3.2.4
+      '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  "@vitest/pretty-format@3.2.4":
+  '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  "@vitest/runner@3.2.4":
+  '@vitest/runner@3.2.4':
     dependencies:
-      "@vitest/utils": 3.2.4
+      '@vitest/utils': 3.2.4
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  "@vitest/snapshot@3.2.4":
+  '@vitest/snapshot@3.2.4':
     dependencies:
-      "@vitest/pretty-format": 3.2.4
+      '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@3.2.4":
+  '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
 
-  "@vitest/utils@3.2.4":
+  '@vitest/utils@3.2.4':
     dependencies:
-      "@vitest/pretty-format": 3.2.4
+      '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  "@zag-js/accordion@1.18.3":
+  '@zag-js/accordion@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/anatomy@1.18.3": {}
+  '@zag-js/anatomy@1.32.0': {}
 
-  "@zag-js/aria-hidden@1.18.3": {}
-
-  "@zag-js/auto-resize@1.18.3":
+  '@zag-js/aria-hidden@1.32.0':
     dependencies:
-      "@zag-js/dom-query": 1.18.3
+      '@zag-js/dom-query': 1.32.0
 
-  "@zag-js/avatar@1.18.3":
+  '@zag-js/auto-resize@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/dom-query': 1.32.0
 
-  "@zag-js/collection@1.18.3":
+  '@zag-js/avatar@1.32.0':
     dependencies:
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/combobox@1.18.3":
+  '@zag-js/carousel@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/aria-hidden": 1.18.3
-      "@zag-js/collection": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dismissable": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/popper": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/scroll-snap': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/core@1.18.3":
+  '@zag-js/collapsible@1.32.0':
     dependencies:
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/dialog@1.18.3":
+  '@zag-js/collection@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/aria-hidden": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dismissable": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/focus-trap": 1.18.3
-      "@zag-js/remove-scroll": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/dismissable@1.18.3":
+  '@zag-js/combobox@1.32.0':
     dependencies:
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/interact-outside": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/aria-hidden': 1.32.0
+      '@zag-js/collection': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/dom-query@1.18.3":
+  '@zag-js/core@1.32.0':
     dependencies:
-      "@zag-js/types": 1.18.3
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/file-upload@1.18.3":
+  '@zag-js/date-picker@1.32.0(@internationalized/date@3.10.1)':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/file-utils": 1.18.3
-      "@zag-js/i18n-utils": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@internationalized/date': 3.10.1
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/date-utils': 1.32.0(@internationalized/date@3.10.1)
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/live-region': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/file-utils@1.18.3":
+  '@zag-js/date-utils@1.32.0(@internationalized/date@3.10.1)':
     dependencies:
-      "@zag-js/i18n-utils": 1.18.3
+      '@internationalized/date': 3.10.1
 
-  "@zag-js/focus-trap@1.18.3":
+  '@zag-js/dialog@1.32.0':
     dependencies:
-      "@zag-js/dom-query": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/aria-hidden': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-trap': 1.32.0
+      '@zag-js/remove-scroll': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/focus-visible@1.18.3":
+  '@zag-js/dismissable@1.32.0':
     dependencies:
-      "@zag-js/dom-query": 1.18.3
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/interact-outside': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/i18n-utils@1.18.3":
+  '@zag-js/dom-query@1.32.0':
     dependencies:
-      "@zag-js/dom-query": 1.18.3
+      '@zag-js/types': 1.32.0
 
-  "@zag-js/interact-outside@1.18.3":
+  '@zag-js/file-upload@1.32.0':
     dependencies:
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/file-utils': 1.32.0
+      '@zag-js/i18n-utils': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/live-region@1.18.3": {}
-
-  "@zag-js/pagination@1.18.3":
+  '@zag-js/file-utils@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/i18n-utils': 1.32.0
 
-  "@zag-js/popover@1.18.3":
+  '@zag-js/floating-panel@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/aria-hidden": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dismissable": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/focus-trap": 1.18.3
-      "@zag-js/popper": 1.18.3
-      "@zag-js/remove-scroll": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/rect-utils': 1.32.0
+      '@zag-js/store': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/popper@1.18.3":
+  '@zag-js/focus-trap@1.32.0':
     dependencies:
-      "@floating-ui/dom": 1.7.2
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/dom-query': 1.32.0
 
-  "@zag-js/progress@1.18.3":
+  '@zag-js/focus-visible@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/dom-query': 1.32.0
 
-  "@zag-js/radio-group@1.18.3":
+  '@zag-js/i18n-utils@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/focus-visible": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/dom-query': 1.32.0
 
-  "@zag-js/rating-group@1.18.3":
+  '@zag-js/interact-outside@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/remove-scroll@1.18.3":
+  '@zag-js/listbox@1.32.0':
     dependencies:
-      "@zag-js/dom-query": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/collection': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-visible': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/slider@1.18.3":
+  '@zag-js/live-region@1.32.0': {}
+
+  '@zag-js/menu@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/rect-utils': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/store@1.18.3":
+  '@zag-js/pagination@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/popover@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/aria-hidden': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-trap': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/remove-scroll': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/popper@1.32.0':
+    dependencies:
+      '@floating-ui/dom': 1.7.5
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/progress@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/radio-group@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-visible': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/rating-group@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/rect-utils@1.32.0': {}
+
+  '@zag-js/remove-scroll@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+
+  '@zag-js/scroll-snap@1.32.0':
+    dependencies:
+      '@zag-js/dom-query': 1.32.0
+
+  '@zag-js/slider@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/steps@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/store@1.32.0':
     dependencies:
       proxy-compare: 3.0.1
 
-  "@zag-js/svelte@1.18.3(svelte@5.49.2)":
+  '@zag-js/svelte@1.32.0(svelte@5.49.2)':
     dependencies:
-      "@zag-js/core": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/core': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
       svelte: 5.49.2
 
-  "@zag-js/switch@1.18.3":
+  '@zag-js/switch@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/focus-visible": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-visible': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/tabs@1.18.3":
+  '@zag-js/tabs@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/tags-input@1.18.3":
+  '@zag-js/tags-input@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/auto-resize": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/interact-outside": 1.18.3
-      "@zag-js/live-region": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/auto-resize': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/interact-outside': 1.32.0
+      '@zag-js/live-region': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/toast@1.18.3":
+  '@zag-js/toast@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dismissable": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dismissable': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/tooltip@1.18.3":
+  '@zag-js/toggle-group@1.32.0':
     dependencies:
-      "@zag-js/anatomy": 1.18.3
-      "@zag-js/core": 1.18.3
-      "@zag-js/dom-query": 1.18.3
-      "@zag-js/focus-visible": 1.18.3
-      "@zag-js/popper": 1.18.3
-      "@zag-js/store": 1.18.3
-      "@zag-js/types": 1.18.3
-      "@zag-js/utils": 1.18.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/types@1.18.3":
+  '@zag-js/tooltip@1.32.0':
     dependencies:
-      csstype: 3.1.3
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/focus-visible': 1.32.0
+      '@zag-js/popper': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
 
-  "@zag-js/utils@1.18.3": {}
+  '@zag-js/tree-view@1.32.0':
+    dependencies:
+      '@zag-js/anatomy': 1.32.0
+      '@zag-js/collection': 1.32.0
+      '@zag-js/core': 1.32.0
+      '@zag-js/dom-query': 1.32.0
+      '@zag-js/types': 1.32.0
+      '@zag-js/utils': 1.32.0
+
+  '@zag-js/types@1.32.0':
+    dependencies:
+      csstype: 3.2.3
+
+  '@zag-js/utils@1.32.0': {}
 
   acorn@8.15.0: {}
 
@@ -2886,7 +3480,11 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   cac@6.7.14: {}
+
+  ccount@2.0.1: {}
 
   chai@5.3.3:
     dependencies:
@@ -2896,11 +3494,29 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
   chart.js@4.5.1:
     dependencies:
-      "@kurkle/color": 0.3.4
+      '@kurkle/color': 0.3.4
 
   check-error@2.1.3: {}
+
+  chevrotain-allstar@0.3.1(chevrotain@11.0.3):
+    dependencies:
+      chevrotain: 11.0.3
+      lodash-es: 4.17.23
+
+  chevrotain@11.0.3:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 11.0.3
+      '@chevrotain/gast': 11.0.3
+      '@chevrotain/regexp-to-ast': 11.0.3
+      '@chevrotain/types': 11.0.3
+      '@chevrotain/utils': 11.0.3
+      lodash-es: 4.17.21
 
   chokidar@4.0.3:
     dependencies:
@@ -2908,11 +3524,215 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  comma-separated-tokens@2.0.3: {}
+
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   commondir@1.0.1: {}
+
+  confbox@0.1.8: {}
 
   cookie@0.6.0: {}
 
-  csstype@3.1.3: {}
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
+  cssesc@3.0.0: {}
+
+  csstype@3.2.3: {}
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.1
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.1):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.1
+
+  cytoscape@3.33.1: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.0.1
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.13:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.17.23
+
+  dayjs@1.11.19: {}
 
   debug@4.4.3:
     dependencies:
@@ -2922,9 +3742,23 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  delaunator@5.0.1:
+    dependencies:
+      robust-predicates: 3.0.2
+
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   devalue@5.6.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  dompurify@3.3.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   enhanced-resolve@5.19.0:
     dependencies:
@@ -2935,75 +3769,77 @@ snapshots:
 
   esbuild@0.25.12:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.12
-      "@esbuild/android-arm": 0.25.12
-      "@esbuild/android-arm64": 0.25.12
-      "@esbuild/android-x64": 0.25.12
-      "@esbuild/darwin-arm64": 0.25.12
-      "@esbuild/darwin-x64": 0.25.12
-      "@esbuild/freebsd-arm64": 0.25.12
-      "@esbuild/freebsd-x64": 0.25.12
-      "@esbuild/linux-arm": 0.25.12
-      "@esbuild/linux-arm64": 0.25.12
-      "@esbuild/linux-ia32": 0.25.12
-      "@esbuild/linux-loong64": 0.25.12
-      "@esbuild/linux-mips64el": 0.25.12
-      "@esbuild/linux-ppc64": 0.25.12
-      "@esbuild/linux-riscv64": 0.25.12
-      "@esbuild/linux-s390x": 0.25.12
-      "@esbuild/linux-x64": 0.25.12
-      "@esbuild/netbsd-arm64": 0.25.12
-      "@esbuild/netbsd-x64": 0.25.12
-      "@esbuild/openbsd-arm64": 0.25.12
-      "@esbuild/openbsd-x64": 0.25.12
-      "@esbuild/openharmony-arm64": 0.25.12
-      "@esbuild/sunos-x64": 0.25.12
-      "@esbuild/win32-arm64": 0.25.12
-      "@esbuild/win32-ia32": 0.25.12
-      "@esbuild/win32-x64": 0.25.12
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.3:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.27.3
-      "@esbuild/android-arm": 0.27.3
-      "@esbuild/android-arm64": 0.27.3
-      "@esbuild/android-x64": 0.27.3
-      "@esbuild/darwin-arm64": 0.27.3
-      "@esbuild/darwin-x64": 0.27.3
-      "@esbuild/freebsd-arm64": 0.27.3
-      "@esbuild/freebsd-x64": 0.27.3
-      "@esbuild/linux-arm": 0.27.3
-      "@esbuild/linux-arm64": 0.27.3
-      "@esbuild/linux-ia32": 0.27.3
-      "@esbuild/linux-loong64": 0.27.3
-      "@esbuild/linux-mips64el": 0.27.3
-      "@esbuild/linux-ppc64": 0.27.3
-      "@esbuild/linux-riscv64": 0.27.3
-      "@esbuild/linux-s390x": 0.27.3
-      "@esbuild/linux-x64": 0.27.3
-      "@esbuild/netbsd-arm64": 0.27.3
-      "@esbuild/netbsd-x64": 0.27.3
-      "@esbuild/openbsd-arm64": 0.27.3
-      "@esbuild/openbsd-x64": 0.27.3
-      "@esbuild/openharmony-arm64": 0.27.3
-      "@esbuild/sunos-x64": 0.27.3
-      "@esbuild/win32-arm64": 0.27.3
-      "@esbuild/win32-ia32": 0.27.3
-      "@esbuild/win32-x64": 0.27.3
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   esm-env@1.2.2: {}
 
   esrap@2.2.2:
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
 
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -3018,11 +3854,55 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  github-slugger@2.0.0: {}
+
   graceful-fs@4.2.11: {}
+
+  hachure-fill@0.5.2: {}
 
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  html-void-elements@3.0.0: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -3030,51 +3910,104 @@ snapshots:
 
   is-module@1.0.0: {}
 
+  is-plain-obj@4.1.0: {}
+
   is-reference@1.2.1:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
 
   is-reference@3.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
 
   jiti@2.6.1: {}
 
   js-tokens@9.0.1: {}
 
+  katex@0.16.28:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
   kleur@4.1.5: {}
 
+  langium@3.3.1:
+    dependencies:
+      chevrotain: 11.0.3
+      chevrotain-allstar: 0.3.1(chevrotain@11.0.3)
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
+
   lightningcss-android-arm64@1.30.2:
+    optional: true
+
+  lightningcss-android-arm64@1.31.1:
     optional: true
 
   lightningcss-darwin-arm64@1.30.2:
     optional: true
 
+  lightningcss-darwin-arm64@1.31.1:
+    optional: true
+
   lightningcss-darwin-x64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.31.1:
     optional: true
 
   lightningcss-freebsd-x64@1.30.2:
     optional: true
 
+  lightningcss-freebsd-x64@1.31.1:
+    optional: true
+
   lightningcss-linux-arm-gnueabihf@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.31.1:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-gnu@1.31.1:
+    optional: true
+
   lightningcss-linux-arm64-musl@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.31.1:
     optional: true
 
   lightningcss-linux-x64-gnu@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-gnu@1.31.1:
+    optional: true
+
   lightningcss-linux-x64-musl@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.31.1:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.31.1:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.31.1:
     optional: true
 
   lightningcss@1.30.2:
@@ -3093,13 +4026,104 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
 
+  lightningcss@1.31.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.31.1
+      lightningcss-darwin-arm64: 1.31.1
+      lightningcss-darwin-x64: 1.31.1
+      lightningcss-freebsd-x64: 1.31.1
+      lightningcss-linux-arm-gnueabihf: 1.31.1
+      lightningcss-linux-arm64-gnu: 1.31.1
+      lightningcss-linux-arm64-musl: 1.31.1
+      lightningcss-linux-x64-gnu: 1.31.1
+      lightningcss-linux-x64-musl: 1.31.1
+      lightningcss-win32-arm64-msvc: 1.31.1
+      lightningcss-win32-x64-msvc: 1.31.1
+
   locate-character@3.0.0: {}
+
+  lodash-es@4.17.21: {}
+
+  lodash-es@4.17.23: {}
 
   loupe@3.2.1: {}
 
   magic-string@0.30.21:
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@16.4.2: {}
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdsvex@0.12.6(svelte@5.49.2):
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 2.0.11
+      prism-svelte: 0.4.7
+      prismjs: 1.30.0
+      svelte: 5.49.2
+      unist-util-visit: 2.0.3
+      vfile-message: 2.0.4
+
+  mermaid@11.12.2:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.0
+      '@mermaid-js/parser': 0.6.3
+      '@types/d3': 7.4.3
+      cytoscape: 3.33.1
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.13
+      dayjs: 1.11.19
+      dompurify: 3.3.1
+      katex: 0.16.28
+      khroma: 2.1.0
+      lodash-es: 4.17.23
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.3.6
+      ts-dedent: 2.2.0
+      uuid: 11.1.0
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
 
   mri@1.2.0: {}
 
@@ -3108,6 +4132,20 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  obug@2.1.1: {}
+
+  oniguruma-parser@0.12.1: {}
+
+  oniguruma-to-es@4.3.4:
+    dependencies:
+      oniguruma-parser: 0.12.1
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  package-manager-detector@1.6.0: {}
+
+  path-data-parser@0.1.0: {}
 
   path-parse@1.0.7: {}
 
@@ -3119,15 +4157,66 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prism-svelte@0.4.7: {}
+
+  prismjs@1.30.0: {}
+
+  property-information@7.1.0: {}
+
   proxy-compare@3.0.1: {}
 
   readdirp@4.1.2: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  rehype-autolink-headings@7.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-is-element: 3.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3137,60 +4226,112 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  robust-predicates@3.0.2: {}
+
+  rolldown@1.0.0-rc.3:
+    dependencies:
+      '@oxc-project/types': 0.112.0
+      '@rolldown/pluginutils': 1.0.0-rc.3
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.3
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.3
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.3
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.3
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.3
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.3
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.3
+
   rollup@4.57.1:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.57.1
-      "@rollup/rollup-android-arm64": 4.57.1
-      "@rollup/rollup-darwin-arm64": 4.57.1
-      "@rollup/rollup-darwin-x64": 4.57.1
-      "@rollup/rollup-freebsd-arm64": 4.57.1
-      "@rollup/rollup-freebsd-x64": 4.57.1
-      "@rollup/rollup-linux-arm-gnueabihf": 4.57.1
-      "@rollup/rollup-linux-arm-musleabihf": 4.57.1
-      "@rollup/rollup-linux-arm64-gnu": 4.57.1
-      "@rollup/rollup-linux-arm64-musl": 4.57.1
-      "@rollup/rollup-linux-loong64-gnu": 4.57.1
-      "@rollup/rollup-linux-loong64-musl": 4.57.1
-      "@rollup/rollup-linux-ppc64-gnu": 4.57.1
-      "@rollup/rollup-linux-ppc64-musl": 4.57.1
-      "@rollup/rollup-linux-riscv64-gnu": 4.57.1
-      "@rollup/rollup-linux-riscv64-musl": 4.57.1
-      "@rollup/rollup-linux-s390x-gnu": 4.57.1
-      "@rollup/rollup-linux-x64-gnu": 4.57.1
-      "@rollup/rollup-linux-x64-musl": 4.57.1
-      "@rollup/rollup-openbsd-x64": 4.57.1
-      "@rollup/rollup-openharmony-arm64": 4.57.1
-      "@rollup/rollup-win32-arm64-msvc": 4.57.1
-      "@rollup/rollup-win32-ia32-msvc": 4.57.1
-      "@rollup/rollup-win32-x64-gnu": 4.57.1
-      "@rollup/rollup-win32-x64-msvc": 4.57.1
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rw@1.3.3: {}
 
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
 
+  safer-buffer@2.1.2: {}
+
   set-cookie-parser@3.0.1: {}
+
+  shiki@3.22.0:
+    dependencies:
+      '@shikijs/core': 3.22.0
+      '@shikijs/engine-javascript': 3.22.0
+      '@shikijs/engine-oniguruma': 3.22.0
+      '@shikijs/langs': 3.22.0
+      '@shikijs/themes': 3.22.0
+      '@shikijs/types': 3.22.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   siginfo@2.0.0: {}
 
   sirv@3.0.2:
     dependencies:
-      "@polka/url": 1.0.0-next.29
+      '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  stylis@4.3.6: {}
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -3201,7 +4342,7 @@ snapshots:
 
   svelte-check@4.3.6(picomatch@4.0.3)(svelte@5.49.2)(typescript@5.9.3):
     dependencies:
-      "@jridgewell/trace-mapping": 0.3.31
+      '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
@@ -3213,10 +4354,10 @@ snapshots:
 
   svelte@5.49.2:
     dependencies:
-      "@jridgewell/remapping": 2.3.5
-      "@jridgewell/sourcemap-codec": 1.5.5
-      "@sveltejs/acorn-typescript": 1.0.8(acorn@8.15.0)
-      "@types/estree": 1.0.8
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
+      '@types/estree': 1.0.8
       acorn: 8.15.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -3237,6 +4378,8 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3250,6 +4393,14 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  ts-dedent@2.2.0: {}
+
+  tslib@2.8.1: {}
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.3
@@ -3259,17 +4410,88 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  ufo@1.6.3: {}
+
   undici-types@6.21.0: {}
 
-  vite-node@3.2.4(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@4.1.0: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@2.0.3:
+    dependencies:
+      '@types/unist': 2.0.11
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@3.1.1:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 4.1.0
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@2.0.3:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 4.1.0
+      unist-util-visit-parents: 3.1.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  util-deprecate@1.0.2: {}
+
+  uuid@11.1.0: {}
+
+  vfile-message@2.0.4:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-stringify-position: 2.0.3
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite-node@3.2.4(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
-      - "@types/node"
+      - '@types/node'
       - jiti
       - less
       - lightningcss
@@ -3282,7 +4504,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3291,27 +4513,44 @@ snapshots:
       rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      "@types/node": 22.19.9
+      '@types/node': 22.19.9
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.30.2
+      lightningcss: 1.31.1
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-
-  vitest@3.2.4(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+  vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
-      "@types/chai": 5.2.3
-      "@vitest/expect": 3.2.4
-      "@vitest/mocker": 3.2.4(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      "@vitest/pretty-format": 3.2.4
-      "@vitest/runner": 3.2.4
-      "@vitest/snapshot": 3.2.4
-      "@vitest/spy": 3.2.4
-      "@vitest/utils": 3.2.4
+      '@oxc-project/runtime': 0.112.0
+      fdir: 6.5.0(picomatch@4.0.3)
+      lightningcss: 1.31.1
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rolldown: 1.0.0-rc.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.9
+      esbuild: 0.27.3
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      yaml: 2.8.2
+
+  vitefu@1.1.1(vite@8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+    optionalDependencies:
+      vite: 8.0.0-beta.13(@types/node@22.19.9)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  vitest@3.2.4(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
       chai: 5.3.3
       debug: 4.4.3
       expect-type: 1.3.0
@@ -3324,11 +4563,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@types/node": 22.19.9
+      '@types/node': 22.19.9
     transitivePeerDependencies:
       - jiti
       - less
@@ -3343,6 +4582,23 @@ snapshots:
       - tsx
       - yaml
 
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-uri@3.0.8: {}
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -3351,3 +4607,5 @@ snapshots:
   yaml@2.8.2: {}
 
   zimmerframe@1.1.4: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "app"
+  - "docs-site"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "nix": { "enabled": true },
+  "bazel-module": { "enabled": true },
+  "packageRules": [
+    {
+      "matchManagers": ["nix"],
+      "groupName": "nix flake inputs"
+    },
+    {
+      "matchManagers": ["bazel-module"],
+      "groupName": "bazel dependencies"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["@skeletonlabs/*"],
+      "groupName": "skeleton ui"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["@sveltejs/*", "svelte", "svelte-check"],
+      "groupName": "svelte ecosystem"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["vite", "@tailwindcss/*", "tailwindcss"],
+      "groupName": "vite and tailwind"
+    }
+  ]
+}

--- a/tex_research/glorious-flywheel/.gitignore
+++ b/tex_research/glorious-flywheel/.gitignore
@@ -1,0 +1,12 @@
+build/
+*.aux
+*.bbl
+*.bcf
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.run.xml
+*.synctex.gz
+*.toc

--- a/tex_research/glorious-flywheel/glorious-flywheel.tex
+++ b/tex_research/glorious-flywheel/glorious-flywheel.tex
@@ -1,0 +1,515 @@
+\documentclass[11pt,a4paper]{article}
+
+% --- Packages ---
+\usepackage[margin=1in]{geometry}
+\usepackage{hyperref}
+\usepackage{graphicx}
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage[backend=biber,style=numeric,sorting=nyt]{biblatex}
+\usepackage{listings}
+\usepackage{xcolor}
+\usepackage{booktabs}
+\usepackage{tikz}
+
+\usetikzlibrary{arrows.meta,positioning,calc,decorations.markings}
+
+\addbibresource{references.bib}
+
+% --- Listing Style ---
+\definecolor{codebg}{HTML}{F5F5F5}
+\definecolor{codeframe}{HTML}{CCCCCC}
+\definecolor{keyword}{HTML}{005FA1}
+\definecolor{comment}{HTML}{6A9955}
+\definecolor{string}{HTML}{A31515}
+
+\lstset{
+  backgroundcolor=\color{codebg},
+  frame=single,
+  rulecolor=\color{codeframe},
+  basicstyle=\ttfamily\small,
+  keywordstyle=\color{keyword}\bfseries,
+  commentstyle=\color{comment}\itshape,
+  stringstyle=\color{string},
+  breaklines=true,
+  showstringspaces=false,
+  tabsize=2,
+  captionpos=b,
+}
+
+% --- Hyperref Setup ---
+\hypersetup{
+  colorlinks=true,
+  linkcolor=blue!60!black,
+  citecolor=green!50!black,
+  urlcolor=blue!70!black,
+}
+
+% --- Title ---
+\title{\textbf{GloriousFlywheel}: Self-Deploying Infrastructure\\as a Fixed-Point System}
+\author{Jess Sullivan}
+\date{\today}
+
+\begin{document}
+
+\maketitle
+
+% ============================================================
+\begin{abstract}
+We present \textsc{GloriousFlywheel}, a self-deploying infrastructure
+architecture modeled as a fixed-point system. Each deployment cycle
+improves subsequent builds through recursive caching and automated
+dependency updates. The system converges to a steady state where
+infrastructure deploys itself: runners deploy runners, the cache caches
+its own closure, and a dashboard monitors the deployers that build it.
+We formalize this recursive structure, describe a two-module Bzlmod
+architecture that enables multi-tenant overlays, and show that the
+flywheel effect---automated scanning, building, and merging---compounds
+operational efficiency over time.
+\end{abstract}
+
+% ============================================================
+\section{Introduction}
+\label{sec:introduction}
+
+Infrastructure requires infrastructure to deploy. A continuous
+integration pipeline needs runners; runners need a container registry;
+the registry needs storage; storage needs provisioning. Traditional
+CI/CD treats this dependency chain as linear: an operator manually
+provisions the base layer, then each subsequent layer is automated atop
+it~\cite{gitlabcicd}.
+
+This linearity creates a \emph{maintenance loop}: updating the base
+layer requires the very automation it supports. Operators find themselves
+maintaining two systems---the infrastructure and the meta-infrastructure
+that deploys it---with no guarantee that they remain in sync.
+
+This paper describes a system that breaks the linearity by converging to
+a \emph{fixed point}. Rather than maintaining separate layers, the
+system deploys itself. We call this architecture
+\textsc{GloriousFlywheel}, named for the positive feedback loop at its
+core: each successful deployment warms the caches that accelerate the
+next deployment, each dependency update triggers the pipeline that
+validates it, and each runner registers itself into the pool that
+schedules its workload.
+
+The remainder of this paper is organized as follows.
+Section~\ref{sec:bzlmod} describes the two-module Bzlmod architecture
+that separates public upstream from private overlay.
+Section~\ref{sec:dogfooding} formalizes the recursive dogfooding
+property. Section~\ref{sec:flywheel} defines the flywheel effect.
+Section~\ref{sec:cache} examines cache topology.
+Section~\ref{sec:multitenancy} discusses multi-tenancy.
+Section~\ref{sec:bootstrap} addresses bootstrapping and recovery.
+Section~\ref{sec:evaluation} evaluates the system, and
+Section~\ref{sec:conclusion} concludes.
+
+% ============================================================
+\section{Bzlmod Two-Module Architecture}
+\label{sec:bzlmod}
+
+The system is split into two Bazel modules using Bzlmod~\cite{bzlmod},
+the external dependency management system introduced in Bazel~7:
+
+\begin{description}
+  \item[Upstream module (\texttt{attic-iac})] Contains the SvelteKit
+    application, OpenTofu modules~\cite{opentofu2024}, and shared build
+    rules. Published to a public repository.
+  \item[Overlay module (\texttt{attic-cache-bates})] Contains
+    organization-specific configuration: \texttt{tfvars} files, Kubernetes
+    manifests, secrets references, and runner definitions.
+\end{description}
+
+The overlay's \texttt{MODULE.bazel} declares a dependency on upstream:
+
+\begin{lstlisting}[language=Python,caption={Overlay MODULE.bazel (excerpt)}]
+bazel_dep(name = "attic-iac", version = "0.0.0")
+local_path_override(
+    module_name = "attic-iac",
+    path = "../../attic-iac",
+)
+\end{lstlisting}
+
+A repository rule in \texttt{build/overlay.bzl} creates a merged
+workspace \texttt{@attic\_merged} by symlink-merging the upstream and
+overlay trees. When files exist in both, \emph{private wins}: the
+overlay file takes precedence. This is the mechanism by which
+organization-specific \texttt{tfvars} override upstream defaults.
+
+Bazel~7.1 introduced \texttt{ctx.watch\_tree()}, which allows the
+repository rule to register a watch on the upstream directory tree.
+Changes to upstream files automatically invalidate the merged
+repository, triggering a rebuild without manual cache clearing.
+
+% ============================================================
+\section{Recursive Dogfooding}
+\label{sec:dogfooding}
+
+\subsection{Formal Definition}
+
+Let $S$ denote the complete infrastructure state: the set of deployed
+services, their configurations, the runner pool, and the cache contents.
+Let $f$ be the deployment function that, given a state, produces a new
+state by executing the CI/CD pipeline:
+
+\begin{equation}
+  f: \mathcal{S} \to \mathcal{S}
+\end{equation}
+
+The system has reached a \emph{fixed point} when:
+
+\begin{equation}
+  f(S^*) = S^*
+  \label{eq:fixedpoint}
+\end{equation}
+
+That is, deploying the infrastructure from state $S^*$ reproduces
+$S^*$ exactly. In practice, strict equality is relaxed to semantic
+equivalence: timestamps and non-deterministic metadata may differ, but
+the functional behavior is identical.
+
+\subsection{Concrete Instances}
+
+Three concrete instances of recursive dogfooding exist in the system:
+
+\begin{enumerate}
+  \item \textbf{Runners deploy runners.} GitLab runners are defined in
+    OpenTofu configuration and deployed to Kubernetes~\cite{k8shpa}. The
+    CI pipeline that applies this configuration runs on the very runners
+    it manages.
+  \item \textbf{Cache caches itself.} The Attic binary cache stores Nix
+    closures~\cite{dolstra2006nix}. The Attic server's own Nix closure
+    is built, pushed to the cache, and pulled from the cache on the next
+    deployment.
+  \item \textbf{Dashboard monitors its deployers.} The runner dashboard
+    application displays the status of runners that execute the pipeline
+    that builds and deploys the dashboard.
+\end{enumerate}
+
+\begin{figure}[htbp]
+  \centering
+  \begin{tikzpicture}[
+    node distance=2.8cm,
+    block/.style={
+      rectangle, draw, rounded corners,
+      minimum width=2.8cm, minimum height=1cm,
+      align=center, font=\small\sffamily,
+      fill=blue!8,
+    },
+    arr/.style={
+      ->{Stealth[length=3mm]},
+      thick, draw=blue!60!black,
+    },
+  ]
+    \node[block] (runners) {GitLab\\Runners};
+    \node[block, right=of runners] (pipeline) {CI/CD\\Pipeline};
+    \node[block, below=of pipeline] (tofu) {OpenTofu\\Apply};
+    \node[block, below=of runners] (k8s) {Kubernetes\\Cluster};
+
+    \draw[arr] (runners) -- node[above,font=\scriptsize\itshape]{execute} (pipeline);
+    \draw[arr] (pipeline) -- node[right,font=\scriptsize\itshape]{trigger} (tofu);
+    \draw[arr] (tofu) -- node[below,font=\scriptsize\itshape]{provision} (k8s);
+    \draw[arr] (k8s) -- node[left,font=\scriptsize\itshape]{schedule} (runners);
+
+    % Fixed-point label
+    \node[font=\small\itshape, text=blue!60!black]
+      at ($(runners)!0.5!(tofu) + (0, -0.3)$) {$f(S^*) = S^*$};
+  \end{tikzpicture}
+  \caption{The recursive dogfooding cycle. Runners execute the pipeline
+    that provisions the cluster that schedules the runners. At the fixed
+    point, deploying the system reproduces itself.}
+  \label{fig:dogfooding-cycle}
+\end{figure}
+
+\subsection{Convergence}
+
+Convergence toward the fixed point is driven by cache accumulation.
+Let $t_n$ denote the total build time at cycle $n$ and $c_n$ the cache
+hit rate. Because each successful build populates the cache:
+
+\begin{equation}
+  c_{n+1} \geq c_n, \quad t_{n+1} \leq t_n
+\end{equation}
+
+The sequence $\{t_n\}$ is monotonically non-increasing and bounded below
+by the time required to verify cache hits, so it converges. In the limit,
+the system reaches steady state where nearly all artifacts are served
+from cache and the deployment function is effectively idempotent.
+
+% ============================================================
+\section{The Flywheel Effect}
+\label{sec:flywheel}
+
+The flywheel is the automated feedback loop that keeps the system
+converging without operator intervention.
+
+\begin{figure}[htbp]
+  \centering
+  \begin{tikzpicture}[
+    node distance=0pt,
+    flynode/.style={
+      rectangle, draw, rounded corners=3pt,
+      minimum width=3cm, minimum height=0.9cm,
+      align=center, font=\small\sffamily,
+      fill=green!6,
+    },
+    flyarr/.style={
+      ->{Stealth[length=2.5mm]},
+      thick, draw=green!50!black,
+    },
+  ]
+    % Circular layout
+    \def\radius{3cm}
+    \node[flynode] (scan)      at (90:\radius)  {RenovateBot\\Scans};
+    \node[flynode] (pr)        at (18:\radius)   {Creates\\Merge Request};
+    \node[flynode] (run)       at (-54:\radius)  {Runners\\Execute Pipeline};
+    \node[flynode] (deploy)    at (-126:\radius) {Merge\\Deploys Update};
+    \node[flynode] (updated)   at (-198:\radius) {Updated\\System};
+
+    \draw[flyarr] (scan)    -- (pr);
+    \draw[flyarr] (pr)      -- (run);
+    \draw[flyarr] (run)     -- (deploy);
+    \draw[flyarr] (deploy)  -- (updated);
+    \draw[flyarr] (updated) -- (scan);
+
+    % Center label
+    \node[font=\large\bfseries\sffamily, text=green!40!black]
+      at (0,0) {Flywheel};
+  \end{tikzpicture}
+  \caption{The flywheel effect. RenovateBot scans for outdated
+    dependencies, creates merge requests, runners validate and build,
+    merging deploys the update, and the next scan runs on the updated
+    system.}
+  \label{fig:flywheel}
+\end{figure}
+
+The cycle proceeds as follows:
+
+\begin{enumerate}
+  \item \textbf{Scan.} RenovateBot scans dependency files
+    (\texttt{MODULE.bazel}, \texttt{package.json}, \texttt{flake.lock},
+    container base images) for available updates.
+  \item \textbf{Propose.} For each update, RenovateBot opens a merge
+    request with the version bump and updated lock files.
+  \item \textbf{Execute.} GitLab runners pick up the pipeline triggered
+    by the merge request. The pipeline runs \texttt{bazel build
+    //...}~\cite{bazel2015}, \texttt{tofu plan}, and the test suite.
+  \item \textbf{Merge.} If the pipeline succeeds, the merge request is
+    merged (auto-merge or manual approval, depending on policy).
+  \item \textbf{Deploy.} The merge to \texttt{main} triggers the
+    deployment pipeline, which applies the updated infrastructure.
+  \item \textbf{Loop.} The next RenovateBot scan runs on the updated
+    system, which now includes the changes from step~5.
+\end{enumerate}
+
+\subsection{Greedy Build Pattern}
+
+The flywheel employs a \emph{greedy build pattern}: build immediately,
+validate later, cache everything. The rationale is that cache misses are
+the dominant cost. By eagerly building every proposed change and caching
+the result---even before validation completes---subsequent builds benefit
+from cached artifacts regardless of whether the original change is
+ultimately merged.
+
+This is safe because Bazel's content-addressed cache~\cite{bazel2015}
+ensures that cached artifacts are keyed by their inputs. A reverted
+change does not poison the cache; it simply becomes an unreferenced entry
+that is eventually garbage-collected.
+
+% ============================================================
+\section{Cache Topology}
+\label{sec:cache}
+
+The system employs a layered cache topology:
+
+\begin{table}[htbp]
+  \centering
+  \caption{Cache layers and their roles.}
+  \label{tab:cache-layers}
+  \begin{tabular}{@{}lll@{}}
+    \toprule
+    \textbf{Layer} & \textbf{Technology} & \textbf{Contents} \\
+    \midrule
+    Nix binary cache   & Attic (self-hosted) & Nix store closures \\
+    Bazel remote cache  & Remote execution API (optional) & Action outputs \\
+    Container registry  & GitLab Container Registry & OCI images \\
+    Nix store (local)   & \texttt{/nix/store} on runners & Local closures \\
+    \bottomrule
+  \end{tabular}
+\end{table}
+
+\subsection{Nix Binary Cache (Attic)}
+
+Attic is a self-hosted Nix binary cache backed by
+PostgreSQL~\cite{cloudnativepg} and S3-compatible object storage. It
+stores Nix closures~\cite{dolstra2006nix} and serves them to builders
+via the standard Nix substituter protocol.
+
+The key recursive property: Attic's own Nix closure is built by the
+pipeline runners, pushed to Attic, and pulled from Attic on the next
+deployment of the Attic server. This is the ``cache of caches''---the
+cache stores the binary that implements the cache.
+
+\subsection{Watch-Store for Incremental Push}
+
+Rather than pushing all build outputs at the end of a pipeline, the
+system uses a \emph{watch-store} pattern: a background process monitors
+the local Nix store for new paths and incrementally pushes them to Attic
+as they appear. This reduces peak network load and ensures that partial
+builds still populate the cache.
+
+% ============================================================
+\section{Multi-Tenancy via Overlays}
+\label{sec:multitenancy}
+
+The two-module architecture (Section~\ref{sec:bzlmod}) naturally
+supports multi-tenancy. Multiple organizations share the upstream
+module, each maintaining their own overlay:
+
+\begin{lstlisting}[language=Python,caption={Multiple overlays sharing upstream}]
+# Organization A overlay
+bazel_dep(name = "attic-iac", version = "0.0.0")
+local_path_override(module_name = "attic-iac",
+                    path = "../attic-iac")
+
+# Organization B overlay (identical dependency, different path)
+bazel_dep(name = "attic-iac", version = "0.0.0")
+local_path_override(module_name = "attic-iac",
+                    path = "/opt/upstream/attic-iac")
+\end{lstlisting}
+
+Each overlay adds organization-specific configuration:
+
+\begin{itemize}
+  \item \texttt{tfvars} files with cluster endpoints, namespaces, and
+    resource limits.
+  \item Kubernetes manifests for org-specific services.
+  \item Secret references (SOPS-encrypted or Vault paths).
+  \item Runner registrations scoped to the organization's GitLab group.
+\end{itemize}
+
+The \emph{private-wins-on-conflict} semantics ensure that an overlay can
+customize any upstream file simply by providing a file at the same path.
+No patching, forking, or merge conflict resolution is required.
+
+\subsection{Single npm\_translate\_lock Constraint}
+
+A practical constraint of rules\_js is that \texttt{npm\_translate\_lock}
+processes exactly one \texttt{pnpm-lock.yaml} per Bazel module. This
+means the SvelteKit application---which depends on npm packages---must
+reside in whichever module owns the lock file. In our architecture, the
+application lives in upstream, and overlays customize it via build-time
+configuration injection rather than source modification.
+
+% ============================================================
+\section{Bootstrap and Recovery}
+\label{sec:bootstrap}
+
+\subsection{Breaking the Recursive Cycle}
+
+The fixed-point equation $f(S^*) = S^*$ presupposes an existing state.
+The \emph{first} deployment necessarily breaks the recursion: there are
+no runners to run the pipeline, no cache to accelerate the build, and no
+cluster to schedule workloads.
+
+Bootstrapping proceeds in phases:
+
+\begin{enumerate}
+  \item \textbf{External CI.} An external CI system (e.g., GitHub
+    Actions) or a developer's local machine runs the initial
+    \texttt{tofu apply} to provision the Kubernetes cluster.
+  \item \textbf{Runner registration.} OpenTofu provisions GitLab runner
+    pods. Once scheduled, they register with GitLab and become available
+    for pipeline execution.
+  \item \textbf{Self-hosting transition.} The first pipeline executed by
+    the new runners deploys the same infrastructure that created them.
+    From this point, the system is self-hosting.
+  \item \textbf{Cache warming.} The initial builds populate the Nix
+    binary cache and Bazel remote cache. Subsequent builds see
+    progressively higher cache hit rates.
+\end{enumerate}
+
+\subsection{Total Failure Recovery}
+
+In a total failure scenario (cluster destroyed, all state lost), the
+system can be re-bootstrapped from scratch using the same procedure.
+Because all infrastructure is defined in code (OpenTofu modules, Nix
+flakes, Kubernetes manifests), no manual configuration is required
+beyond providing credentials.
+
+The recovery time is bounded by the cold-cache build time plus cluster
+provisioning time. In our deployment, this is approximately 25 minutes
+for a complete rebuild from an empty state.
+
+\subsection{Graceful Degradation}
+
+Partial failures do not cascade, thanks to loose coupling via
+Kubernetes. If the Attic cache becomes unavailable, builds proceed
+with local Nix store substitution (slower, but functional). If runners
+are reduced, pipelines queue rather than fail. If the dashboard is
+down, deployments continue unmonitored. Each component is independently
+deployable and recoverable.
+
+% ============================================================
+\section{Evaluation}
+\label{sec:evaluation}
+
+We evaluate the system qualitatively across three dimensions.
+
+\subsection{Build Time}
+
+\begin{table}[htbp]
+  \centering
+  \caption{Build time comparison: cold cache vs.\ warm cache.}
+  \label{tab:build-times}
+  \begin{tabular}{@{}lrr@{}}
+    \toprule
+    \textbf{Operation} & \textbf{Cold Cache} & \textbf{Warm Cache} \\
+    \midrule
+    Nix build (Attic server)      & $\sim$12 min & $\sim$45 sec \\
+    Bazel build (SvelteKit app)   & $\sim$8 min  & $\sim$30 sec \\
+    OpenTofu plan (all stacks)    & $\sim$3 min  & $\sim$1 min  \\
+    Full pipeline (build + deploy)& $\sim$25 min & $\sim$4 min  \\
+    \bottomrule
+  \end{tabular}
+\end{table}
+
+The warm-cache steady state represents approximately an 84\% reduction
+in total pipeline time compared to the cold-cache bootstrap.
+
+\subsection{Cache Hit Rates}
+
+After the initial bootstrap and two subsequent flywheel cycles, the Nix
+binary cache hit rate stabilizes above 95\% for incremental changes.
+The remaining 5\% corresponds to newly introduced or updated
+dependencies that have not yet been cached.
+
+\subsection{Operational Overhead}
+
+The primary operational task is reviewing and merging RenovateBot merge
+requests. In steady state, this requires approximately 15 minutes per
+week. Infrastructure changes that do not involve dependency updates
+require no additional overhead beyond the standard code review process.
+
+% ============================================================
+\section{Conclusion}
+\label{sec:conclusion}
+
+Self-deploying infrastructure is practical. By modeling the deployment
+pipeline as a fixed-point function, we eliminate the traditional
+distinction between infrastructure and meta-infrastructure. The Bzlmod
+two-module architecture enables multi-tenant overlays without forking.
+The flywheel effect---automated scanning, building, and
+deploying---compounds efficiency over time, reducing both build times
+and operational burden.
+
+The key insight is that recursion is not merely an architectural
+curiosity but a practical tool for reducing operational complexity.
+When the system deploys itself, there is exactly one system to maintain,
+one pipeline to debug, and one set of configurations to audit. The
+flywheel, once spinning, sustains itself.
+
+% ============================================================
+\printbibliography
+
+\end{document}

--- a/tex_research/glorious-flywheel/references.bib
+++ b/tex_research/glorious-flywheel/references.bib
@@ -1,0 +1,57 @@
+@phdthesis{dolstra2006nix,
+  author    = {Eelco Dolstra},
+  title     = {The Purely Functional Software Deployment Model},
+  school    = {Utrecht University},
+  year      = {2006},
+  month     = {January},
+  url       = {https://edolstra.github.io/pubs/phd-thesis.pdf},
+  note      = {ISBN 90-393-4130-3},
+}
+
+@misc{bazel2015,
+  author       = {{Google Inc.}},
+  title        = {Bazel: A Fast, Scalable, Multi-Language Build System},
+  year         = {2015},
+  url          = {https://bazel.build},
+  note         = {Open-sourced in March 2015},
+}
+
+@misc{opentofu2024,
+  author       = {{The Linux Foundation}},
+  title        = {{OpenTofu}: The Open-Source Infrastructure as Code Tool},
+  year         = {2024},
+  url          = {https://opentofu.org},
+  note         = {Fork of Terraform, maintained under the Linux Foundation},
+}
+
+@misc{gitlabcicd,
+  author       = {{GitLab Inc.}},
+  title        = {{GitLab CI/CD} Documentation},
+  year         = {2024},
+  url          = {https://docs.gitlab.com/ee/ci/},
+  note         = {Accessed: 2024},
+}
+
+@misc{k8shpa,
+  author       = {{The Kubernetes Authors}},
+  title        = {Horizontal Pod Autoscaler},
+  year         = {2024},
+  url          = {https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/},
+  note         = {Kubernetes documentation, accessed 2024},
+}
+
+@misc{cloudnativepg,
+  author       = {{EDB}},
+  title        = {{CloudNativePG}: The Kubernetes Operator for {PostgreSQL}},
+  year         = {2024},
+  url          = {https://cloudnative-pg.io},
+  note         = {Open-source operator for running PostgreSQL on Kubernetes},
+}
+
+@misc{bzlmod,
+  author       = {{The Bazel Authors}},
+  title        = {Bzlmod: Bazel External Dependency Management},
+  year         = {2023},
+  url          = {https://bazel.build/external/overview},
+  note         = {Bazel module system specification, replaces WORKSPACE},
+}

--- a/tofu/modules/runner-dashboard/main.tf
+++ b/tofu/modules/runner-dashboard/main.tf
@@ -235,7 +235,7 @@ resource "kubernetes_deployment" "dashboard" {
         service_account_name = kubernetes_service_account.dashboard.metadata[0].name
 
         dynamic "image_pull_secrets" {
-          for_each = local.effective_pull_secret != "" ? [local.effective_pull_secret] : []
+          for_each = toset(local.effective_pull_secret != "" ? [local.effective_pull_secret] : [])
           content {
             name = image_pull_secrets.value
           }


### PR DESCRIPTION
## Summary
- Upgrade runner-dashboard app to Skeleton v4.9 + Vite 8 beta (78 tests pass, 0 errors)
- Create `docs-site/` SvelteKit workspace package (mdsvex + Shiki + Mermaid + adapter-static, 75 prerendered pages)
- Rewrite all documentation with Mermaid diagrams across 6 categories (24 new files, no emoji, no ASCII art)
- Add TeX research document (`tex_research/glorious-flywheel/`) with formal fixed-point analysis
- Add RenovateBot configuration for nix, bazel-module, and npm dependency groups
- Update GitHub Pages workflow for docs site deployment
- Add Justfile recipes for docs-dev, docs-build, tex, tex-clean, tex-watch
- Add `docs-site/BUILD.bazel` for Bazel integration

## Test plan
- [x] `pnpm --filter runner-dashboard check` (0 errors, 5 warnings)
- [x] `pnpm --filter runner-dashboard test` (78 tests pass)
- [x] `pnpm --filter glorious-flywheel-docs build` (75 pages prerendered)
- [ ] Verify Mermaid diagrams render in GitHub markdown preview
- [ ] Verify GitHub Pages deployment after merge