### PR TITLE
feat(bazel): integrate vitest with Bazel test cache and greedy CI

### DIFF
--- a/.gitlab/ci/jobs/bazel-build.gitlab-ci.yml
+++ b/.gitlab/ci/jobs/bazel-build.gitlab-ci.yml
@@ -76,6 +76,7 @@ bazel:format:
 # Build all Bazel targets (validation and bundling)
 bazel:build:
   extends: .bazel-base
+  needs: []  # Greedy: run immediately, don't wait for validate stage
   script:
     - echo "Building Bazel targets..."
     # Build deployment bundle and manifests
@@ -98,9 +99,10 @@ bazel:build:
 bazel:test:
   extends: .bazel-base
   stage: test
+  needs: []  # Greedy: run immediately, don't wait for validate stage
   script:
     - echo "Running Bazel tests..."
-    - nix develop .#ci --command bazel test //tests:config_validation --test_output=all
+    - nix develop .#ci --command bazel test //tests:config_validation //app:unit_tests --test_output=all
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,11 +1,15 @@
 # Attic IaC - Root BUILD file
 
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 # Package visibility
 package(default_visibility = ["//visibility:public"])
+
+# Link npm packages at root (required for transitive dep resolution)
+npm_link_all_packages(name = "node_modules")
 
 # Export files needed by sub-packages and downstream modules
 exports_files([

--- a/app/BUILD.bazel
+++ b/app/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_js//js:defs.bzl", "js_run_binary", "js_run_devserver")
+load("@aspect_rules_js//js:defs.bzl", "js_run_binary", "js_run_devserver", "js_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@rules_img//img:defs.bzl", "image_layer", "image_manifest", "image_push")
 
@@ -17,6 +17,27 @@ filegroup(
         "tsconfig.json",
         "vite.config.ts",
     ],
+)
+
+# Test filegroup (excluded from :srcs)
+filegroup(
+    name = "test_srcs",
+    srcs = glob(["src/**/*.test.ts"]),
+)
+
+# Vitest test runner — cached by Bazel remote cache
+# Uses wrapper script to avoid ArtifactPrefixConflict with node_modules/vitest
+js_test(
+    name = "unit_tests",
+    chdir = package_name(),
+    data = [
+        ":node_modules",
+        ":srcs",
+        ":test_srcs",
+        "vitest.config.ts",
+    ],
+    entry_point = "run-vitest.mjs",
+    tags = ["vitest"],
 )
 
 # Production build via Vite

--- a/app/run-vitest.mjs
+++ b/app/run-vitest.mjs
@@ -1,0 +1,7 @@
+import { startVitest } from "vitest/node";
+
+const vitest = await startVitest("test", [], { reporter: ["verbose"] });
+if (!vitest) process.exit(1);
+await vitest.close();
+const failed = vitest.state.getCountOfFailedTests();
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add `js_test` target `//app:unit_tests` wrapping vitest via `run-vitest.mjs` wrapper script
- Add `npm_link_all_packages` to root `BUILD.bazel` for transitive npm dep resolution
- Add `needs: []` to `bazel:build:` and `bazel:test:` CI jobs (greedy pattern — matches nix jobs)
- Add `//app:unit_tests` to CI test pipeline alongside `//tests:config_validation`

## Test plan
- [x] `bazel query //app:unit_tests` resolves
- [x] `bazel test //app:unit_tests --test_output=all` — 98 tests pass
- [x] Second run shows `(cached) PASSED` in 0.2s
- [x] `pnpm check` — 0 errors, 5 warnings (unchanged)