### PR TITLE
fix(auth): clear session cookie on logout

### DIFF
--- a/app/src/lib/server/auth/session.ts
+++ b/app/src/lib/server/auth/session.ts
@@ -40,5 +40,9 @@ export function setSession(cookies: Cookies, session: Session) {
 }
 
 export function clearSession(cookies: Cookies) {
-  cookies.delete(SESSION_COOKIE, { path: "/" });
+  cookies.delete(SESSION_COOKIE, {
+    path: "/",
+    secure: true,
+    sameSite: "lax",
+  });
 }

--- a/app/src/routes/auth/logout/+server.ts
+++ b/app/src/routes/auth/logout/+server.ts
@@ -4,5 +4,5 @@ import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ cookies }) => {
   clearSession(cookies);
-  redirect(302, "/");
+  redirect(302, "/auth/login");
 };


### PR DESCRIPTION
## Summary
- Match `secure` and `sameSite` attributes in `cookies.delete()` so the browser actually clears the session cookie
- Redirect to `/auth/login` after logout instead of `/` to avoid immediate re-auth redirect loop

## Test plan
- [x] `pnpm test` — 78 tests pass
- [ ] Login on beehive, then click logout — session should be fully cleared