### PR TITLE
fix(auth): force full-page navigation on logout

### DIFF
--- a/app/src/routes/settings/+page.svelte
+++ b/app/src/routes/settings/+page.svelte
@@ -62,6 +62,7 @@
 		<h3 class="font-semibold text-error-600 dark:text-error-400 mb-3">Session</h3>
 		<a
 			href="/auth/logout"
+			data-sveltekit-reload
 			class="px-4 py-2 rounded border border-error-500 text-error-600 dark:text-error-400 text-sm hover:bg-error-50 dark:hover:bg-error-900/20 transition-colors"
 		>
 			Sign Out


### PR DESCRIPTION
## Summary
SvelteKit's client-side router intercepts `<a>` clicks and uses `fetch()` internally. `Set-Cookie` headers from `fetch()` responses are ignored by the browser, so the session cookie was never cleared on logout.

Adding `data-sveltekit-reload` forces a real browser navigation, ensuring the `Set-Cookie: Max-Age=0` header is processed.

## Test plan
- [x] `pnpm test` — 78 tests pass
- [ ] Click Sign Out on beehive — should clear cookie and land on login page