### PR TITLE
feat: nav footer with commit SHAs, repo links, and docs branding

### DIFF
--- a/app/scripts/generate-environments.ts
+++ b/app/scripts/generate-environments.ts
@@ -38,6 +38,11 @@ interface OrganizationConfig {
 			all: string;
 		};
 	};
+	links?: {
+		upstream_repo: string;
+		pages_url: string;
+		source_repo: string;
+	};
 }
 
 interface EnvironmentConfig {
@@ -104,6 +109,25 @@ async function main() {
 		environments.forEach((env) => {
 			console.log(`   - ${env.name}: ${env.domain} (${env.role})`);
 		});
+
+		// Read version from package.json
+		const pkgPath = resolve(__dirname, '../package.json');
+		const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+
+		// Generate app-config.json
+		const appConfig = {
+			organization: orgConfig.organization.full_name,
+			version: pkg.version,
+			links: orgConfig.links ?? {
+				upstream_repo: '',
+				pages_url: '',
+				source_repo: ''
+			}
+		};
+
+		const appConfigPath = resolve(__dirname, '../src/lib/config/app-config.json');
+		writeFileSync(appConfigPath, JSON.stringify(appConfig, null, 2) + '\n');
+		console.log(`✅ Generated app config to: ${appConfigPath}`);
 	} catch (error) {
 		console.error('❌ Failed to generate environments.json:');
 		console.error(error);

--- a/app/src/lib/components/nav/Sidebar.svelte
+++ b/app/src/lib/components/nav/Sidebar.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import EnvBadge from './EnvBadge.svelte';
+	import type { AppConfig } from '$lib/types/environment';
+
+	let { appConfig }: { appConfig?: AppConfig } = $props();
 
 	const navItems = [
 		{ href: '/', label: 'Dashboard', icon: 'H' },
@@ -51,5 +54,73 @@
 		</ul>
 	</nav>
 
-	<div class="p-4 border-t border-surface-300-600 text-xs text-surface-500">v0.1.0</div>
+	{#if appConfig?.links}
+		<div class="p-2 border-t border-surface-300-600 space-y-1">
+			{#if appConfig.links.pages_url}
+				<a
+					href={appConfig.links.pages_url}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="flex items-center gap-2 px-2 py-1 text-xs text-surface-500 hover:text-primary-400 transition-colors"
+				>
+					<span class="w-5 h-5 flex items-center justify-center rounded bg-surface-200-700 text-[10px] font-bold">D</span>
+					<span>Docs</span>
+				</a>
+			{/if}
+			{#if appConfig.links.source_repo}
+				<a
+					href={appConfig.links.source_repo}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="flex items-center gap-2 px-2 py-1 text-xs text-surface-500 hover:text-primary-400 transition-colors"
+				>
+					<span class="w-5 h-5 flex items-center justify-center rounded bg-surface-200-700 text-[10px] font-bold">S</span>
+					<span>Source</span>
+				</a>
+			{/if}
+			{#if appConfig.links.upstream_repo}
+				<a
+					href={appConfig.links.upstream_repo}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="flex items-center gap-2 px-2 py-1 text-xs text-surface-500 hover:text-primary-400 transition-colors"
+				>
+					<span class="w-5 h-5 flex items-center justify-center rounded bg-surface-200-700 text-[10px] font-bold">U</span>
+					<span>Upstream</span>
+				</a>
+			{/if}
+		</div>
+	{/if}
+
+	<div class="p-4 border-t border-surface-300-600 text-xs text-surface-500 space-y-1">
+		<div>v{appConfig?.version ?? '0.1.0'}</div>
+		{#if appConfig?.commits}
+			<div class="flex gap-2">
+				<span class="text-surface-400">overlay</span>
+				{#if appConfig.links?.source_repo && appConfig.commits.overlay !== 'dev'}
+					<a
+						href="{appConfig.links.source_repo}/-/commit/{appConfig.commits.overlay}"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="font-mono hover:text-primary-400 transition-colors"
+					>{appConfig.commits.overlay.slice(0, 7)}</a>
+				{:else}
+					<span class="font-mono">{appConfig.commits.overlay.slice(0, 7)}</span>
+				{/if}
+			</div>
+			<div class="flex gap-2">
+				<span class="text-surface-400">upstream</span>
+				{#if appConfig.links?.upstream_repo && appConfig.commits.upstream !== 'dev'}
+					<a
+						href="{appConfig.links.upstream_repo}/commit/{appConfig.commits.upstream}"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="font-mono hover:text-primary-400 transition-colors"
+					>{appConfig.commits.upstream.slice(0, 7)}</a>
+				{:else}
+					<span class="font-mono">{appConfig.commits.upstream.slice(0, 7)}</span>
+				{/if}
+			</div>
+		{/if}
+	</div>
 </aside>

--- a/app/src/lib/config/app-config.json
+++ b/app/src/lib/config/app-config.json
@@ -1,0 +1,9 @@
+{
+  "organization": "My Organization",
+  "version": "0.1.0",
+  "links": {
+    "upstream_repo": "https://github.com/Jesssullivan/GloriousFlywheel",
+    "pages_url": "",
+    "source_repo": ""
+  }
+}

--- a/app/src/lib/config/environments.json
+++ b/app/src/lib/config/environments.json
@@ -1,22 +1,22 @@
 [
   {
     "name": "dev",
-    "label": "Development",
+    "label": "Dev (Dev)",
     "domain": "dev.example.com",
     "namespace": "gitlab-runners",
     "gitlab_url": "https://gitlab.com",
-    "gitlab_project_id": "",
+    "gitlab_project_id": "YOUR_PROJECT_ID",
     "role": "development",
-    "context": ""
+    "context": "mygroup/kubernetes/agents:dev"
   },
   {
     "name": "prod",
-    "label": "Production",
+    "label": "Prod (Prod)",
     "domain": "prod.example.com",
     "namespace": "gitlab-runners",
     "gitlab_url": "https://gitlab.com",
-    "gitlab_project_id": "",
+    "gitlab_project_id": "YOUR_PROJECT_ID",
     "role": "production",
-    "context": ""
+    "context": "mygroup/kubernetes/agents:prod"
   }
 ]

--- a/app/src/lib/server/config.ts
+++ b/app/src/lib/server/config.ts
@@ -1,9 +1,11 @@
 import { readFileSync, existsSync } from 'fs';
 import { env } from '$env/dynamic/private';
-import type { EnvironmentConfig } from '$lib/types/environment';
+import type { EnvironmentConfig, AppConfig } from '$lib/types/environment';
 import fallbackConfig from '$lib/config/environments.json';
+import fallbackAppConfig from '$lib/config/app-config.json';
 
 let cachedEnvironments: EnvironmentConfig[] | null = null;
+let cachedAppConfig: AppConfig | null = null;
 
 export function getEnvironments(): EnvironmentConfig[] {
 	if (cachedEnvironments) return cachedEnvironments;
@@ -16,4 +18,18 @@ export function getEnvironments(): EnvironmentConfig[] {
 		cachedEnvironments = fallbackConfig as EnvironmentConfig[];
 	}
 	return cachedEnvironments!;
+}
+
+export function getAppConfig(): AppConfig {
+	if (cachedAppConfig) return cachedAppConfig;
+
+	const base = fallbackAppConfig as Omit<AppConfig, 'commits'>;
+	cachedAppConfig = {
+		...base,
+		commits: {
+			overlay: env.OVERLAY_COMMIT_SHA || 'dev',
+			upstream: env.UPSTREAM_COMMIT_SHA || 'dev'
+		}
+	};
+	return cachedAppConfig;
 }

--- a/app/src/lib/types/environment.ts
+++ b/app/src/lib/types/environment.ts
@@ -26,3 +26,17 @@ export function buildEnvironmentLookups(configs: EnvironmentConfig[]) {
 }
 
 export type Environment = string;
+
+export interface AppConfig {
+	organization: string;
+	version: string;
+	links: {
+		upstream_repo: string;
+		pages_url: string;
+		source_repo: string;
+	};
+	commits: {
+		overlay: string;
+		upstream: string;
+	};
+}

--- a/app/src/routes/+layout.server.ts
+++ b/app/src/routes/+layout.server.ts
@@ -1,9 +1,10 @@
 import type { LayoutServerLoad } from "./$types";
-import { getEnvironments } from "$lib/server/config";
+import { getEnvironments, getAppConfig } from "$lib/server/config";
 
 export const load: LayoutServerLoad = async ({ locals }) => {
   return {
     user: locals.user ?? null,
     environments: getEnvironments(),
+    appConfig: getAppConfig(),
   };
 };

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <div class="h-full flex">
-	<Sidebar />
+	<Sidebar appConfig={data.appConfig} />
 
 	<main class="flex-1 overflow-auto p-6">
 		<Breadcrumb />

--- a/config/organization.example.yaml
+++ b/config/organization.example.yaml
@@ -31,3 +31,8 @@ namespaces:
 network:
   proxy_host: null # Optional SOCKS proxy
   proxy_port: null
+
+links:
+  upstream_repo: "https://github.com/Jesssullivan/GloriousFlywheel"
+  pages_url: ""      # Org-specific GitLab Pages URL
+  source_repo: ""    # Org-specific overlay source repo

--- a/docs-site/mdsvex.config.js
+++ b/docs-site/mdsvex.config.js
@@ -20,7 +20,7 @@ const shikiHighlighter = await createHighlighter({
   langs: [
     'javascript', 'typescript', 'svelte', 'html', 'css', 'json', 'yaml', 'markdown',
     'bash', 'shell', 'python', 'rust', 'go', 'java', 'c', 'cpp', 'sql', 'graphql',
-    'dockerfile', 'nginx', 'toml', 'xml', 'diff', 'hcl', 'nix',
+    'dockerfile', 'nginx', 'toml', 'xml', 'diff', 'hcl', 'nix', 'ini',
     'plaintext', 'text'
   ]
 });

--- a/docs-site/src/app.css
+++ b/docs-site/src/app.css
@@ -44,6 +44,33 @@ body {
 article.prose pre {
   border-radius: 0.5rem;
   border: 1px solid var(--color-surface-600);
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* Shiki dual-theme: show dark by default, light if user prefers */
+.shiki,
+.shiki span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+}
+
+@media (prefers-color-scheme: light) {
+  .shiki,
+  .shiki span {
+    color: var(--shiki-light) !important;
+    background-color: var(--shiki-light-bg) !important;
+  }
+}
+
+/* TOC scrollbar */
+nav::-webkit-scrollbar {
+  width: 3px;
+}
+
+nav::-webkit-scrollbar-thumb {
+  background: var(--color-surface-600);
+  border-radius: 3px;
 }
 
 /* Table styling */

--- a/docs-site/src/lib/components/TableOfContents.svelte
+++ b/docs-site/src/lib/components/TableOfContents.svelte
@@ -37,14 +37,14 @@
 </script>
 
 {#if headings.length > 0}
-	<nav class="hidden xl:block sticky top-6 w-56 shrink-0">
+	<nav class="hidden xl:block sticky top-8 w-56 shrink-0 max-h-[calc(100vh-4rem)] overflow-y-auto">
 		<h4 class="text-xs font-semibold uppercase text-surface-500 mb-3">On this page</h4>
-		<ul class="space-y-1 text-sm">
+		<ul class="space-y-1 text-sm border-l border-surface-700 pl-3">
 			{#each headings as heading}
 				<li class="{heading.level === 3 ? 'ml-3' : ''}">
 					<a
 						href="#{heading.id}"
-						class="block py-0.5 {activeId === heading.id
+						class="block py-0.5 transition-colors {activeId === heading.id
 							? 'text-primary-500 font-medium'
 							: 'text-surface-500 hover:text-surface-300'}"
 					>

--- a/docs-site/src/routes/+layout.svelte
+++ b/docs-site/src/routes/+layout.svelte
@@ -51,7 +51,17 @@
 		></button>
 	{/if}
 
-	<main class="flex-1 overflow-auto p-8 md:p-8 pt-14 md:pt-8">
-		{@render children()}
+	<main class="flex-1 overflow-auto p-4 sm:p-6 md:p-8 lg:p-10 pt-14 md:pt-8 flex flex-col">
+		<div class="flex-1">
+			{@render children()}
+		</div>
+
+		<footer class="mt-16 border-t border-surface-700 py-6 text-center text-xs text-surface-500 space-y-1">
+			<p>
+				A <a href="https://tinyland.dev" target="_blank" rel="noopener noreferrer" class="hover:text-surface-300 transition-colors">Tinyland.dev, Inc</a> project
+				&middot;
+				built with <a href="https://xoxd.ai" target="_blank" rel="noopener noreferrer" class="text-primary-500 hover:text-primary-400 transition-colors">xoxd.ai</a> ^w^
+			</p>
+		</footer>
 	</main>
 </div>

--- a/docs-site/src/routes/+page.svelte
+++ b/docs-site/src/routes/+page.svelte
@@ -30,7 +30,7 @@
 	<title>GloriousFlywheel - Documentation</title>
 </svelte:head>
 
-<div class="max-w-4xl mx-auto">
+<div class="max-w-6xl mx-auto">
 	<!-- Hero -->
 	<div class="text-center mb-10">
 		<h1 class="text-5xl font-bold mb-3">GloriousFlywheel</h1>
@@ -73,5 +73,23 @@
 			<h3 class="font-semibold mb-2">GitLab OAuth</h3>
 			<p class="text-sm text-surface-400">Set up SSO for the runner dashboard.</p>
 		</a>
+	</div>
+
+	<!-- Branding -->
+	<div class="mt-16 border-t border-surface-700 pt-10 space-y-8 text-center">
+		<div>
+			<p class="text-sm font-semibold text-surface-400 uppercase tracking-wide">A Tinyland.dev, Inc project</p>
+			<p class="mt-2 text-surface-500 max-w-2xl mx-auto">
+				Building brutally resilient infrastructure at the intersection of individual authenticity and communal security.
+			</p>
+		</div>
+		<div>
+			<p class="text-sm text-surface-400">
+				built with <a href="https://xoxd.ai" target="_blank" rel="noopener noreferrer" class="font-semibold text-primary-500 hover:text-primary-400 transition-colors">xoxd.ai</a>
+			</p>
+			<p class="mt-2 text-surface-500 max-w-2xl mx-auto">
+				Orchestrating massively parallel, provable agent infrastructure at the intersection of autonomous scale and cryptographic integrity. xoxd.ai ^w^
+			</p>
+		</div>
 	</div>
 </div>

--- a/docs-site/src/routes/docs/[...slug]/+page.svelte
+++ b/docs-site/src/routes/docs/[...slug]/+page.svelte
@@ -9,7 +9,7 @@
 </svelte:head>
 
 <div class="flex gap-8">
-	<div class="flex-1 min-w-0 max-w-4xl">
+	<div class="flex-1 min-w-0 max-w-none 2xl:max-w-5xl">
 		{#if data.error}
 			<div class="text-error-500">
 				<h1 class="text-2xl font-bold mb-2">Page not found</h1>


### PR DESCRIPTION
## Summary
- Dashboard sidebar: version + linked overlay/upstream commit SHAs + external links (Docs, Source, Upstream)
- Docs site: sticky independently-scrollable TOC, wider content breakpoints, Shiki dual-theme CSS
- Homepage/footer: Tinyland.dev + xoxd.ai branding banners
- New `app-config.json` generated at prebuild from `organization.yaml` (org name, version, repo links)
- Commit SHAs injected at runtime via `OVERLAY_COMMIT_SHA` / `UPSTREAM_COMMIT_SHA` env vars

## Test plan
- [x] `pnpm check` — 0 errors, 5 warnings (unchanged)
- [x] `pnpm test` — 78/78 pass
- [x] `pnpm build` — success (both app and docs-site)
- [ ] Visual verification of sidebar footer with env vars set
- [ ] Overlay deployments pick up links from org config