### PR TITLE
fix(auth): prevent logout-to-reauth loop

### DIFF
--- a/app/src/hooks.server.ts
+++ b/app/src/hooks.server.ts
@@ -7,6 +7,7 @@ const PUBLIC_PATHS = [
   "/auth/login",
   "/auth/callback",
   "/auth/logout",
+  "/auth/logged-out",
 ];
 
 export const handle: Handle = async ({ event, resolve }) => {

--- a/app/src/routes/auth/logged-out/+page.svelte
+++ b/app/src/routes/auth/logged-out/+page.svelte
@@ -1,0 +1,16 @@
+<svelte:head>
+	<title>Logged Out - Runner Dashboard</title>
+</svelte:head>
+
+<div class="flex items-center justify-center h-full">
+	<div class="text-center space-y-4">
+		<h1 class="text-2xl font-bold">Logged out</h1>
+		<p class="text-surface-400">Your session has been cleared.</p>
+		<a
+			href="/auth/login"
+			class="inline-block px-4 py-2 rounded bg-primary-500 hover:bg-primary-600 text-white transition-colors"
+		>
+			Log in again
+		</a>
+	</div>
+</div>

--- a/app/src/routes/auth/logout/+server.ts
+++ b/app/src/routes/auth/logout/+server.ts
@@ -4,5 +4,5 @@ import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ cookies }) => {
   clearSession(cookies);
-  redirect(302, "/auth/login");
+  redirect(302, "/auth/logged-out");
 };


### PR DESCRIPTION
## Summary
- Logout redirected to `/auth/login` which auto-started OAuth flow
- If user had active GitLab session, they were instantly re-authenticated
- Now redirects to `/auth/logged-out` landing page with manual login link

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm test` — 78/78 pass
- [ ] Logout → see "Logged out" page, not instant re-login