### PR TITLE
fix(auth): revoke GitLab OAuth token on logout

### DIFF
--- a/app/src/lib/server/auth/gitlab-oauth.ts
+++ b/app/src/lib/server/auth/gitlab-oauth.ts
@@ -78,6 +78,23 @@ export async function refreshAccessToken(refreshToken: string): Promise<{
   return response.json();
 }
 
+export async function revokeToken(token: string): Promise<void> {
+  const config = getConfig();
+  try {
+    await fetch(`${config.gitlabUrl}/oauth/revoke`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+        token,
+      }),
+    });
+  } catch {
+    // Best-effort revocation; don't block logout
+  }
+}
+
 export async function getUserInfo(
   accessToken: string,
   gitlabUrl?: string,

--- a/app/src/routes/auth/logout/+server.ts
+++ b/app/src/routes/auth/logout/+server.ts
@@ -1,8 +1,13 @@
 import { redirect } from "@sveltejs/kit";
-import { clearSession } from "$lib/server/auth/session";
+import { getSession, clearSession } from "$lib/server/auth/session";
+import { revokeToken } from "$lib/server/auth/gitlab-oauth";
 import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ cookies }) => {
+  const session = getSession(cookies);
+  if (session?.access_token) {
+    await revokeToken(session.access_token);
+  }
   clearSession(cookies);
   redirect(302, "/auth/logged-out");
 };


### PR DESCRIPTION
## Summary
- Revokes the GitLab OAuth access token on logout via `/oauth/revoke` endpoint
- Prevents the logout-to-reauth loop where GitLab auto-approves the OAuth flow for users with an active GitLab session
- Best-effort revocation (doesn't block logout on failure)

## Test plan
- [ ] Log in via GitLab OAuth
- [ ] Click Sign Out
- [ ] Verify landing on /auth/logged-out page
- [ ] Click "Log in again" — should show GitLab consent screen, not auto-login