### PR TITLE
feat(dashboard): live data, config persistence, and link fixes

### DIFF
--- a/app/src/lib/config/app-config.json
+++ b/app/src/lib/config/app-config.json
@@ -1,9 +1,9 @@
 {
-  "organization": "My Organization",
+  "organization": "Bates College",
   "version": "0.1.0",
   "links": {
     "upstream_repo": "https://github.com/Jesssullivan/GloriousFlywheel",
-    "pages_url": "",
-    "source_repo": ""
+    "pages_url": "https://bates-ils.gitlab.io/people/jsullivan2/attic-cache",
+    "source_repo": "https://gitlab.com/bates-ils/people/jsullivan2/attic-cache"
   }
 }

--- a/app/src/lib/config/environments.json
+++ b/app/src/lib/config/environments.json
@@ -1,22 +1,22 @@
 [
   {
-    "name": "dev",
-    "label": "Dev (Dev)",
-    "domain": "dev.example.com",
-    "namespace": "gitlab-runners",
+    "name": "beehive",
+    "label": "Beehive (Dev)",
+    "domain": "beehive.bates.edu",
+    "namespace": "bates-ils-runners",
     "gitlab_url": "https://gitlab.com",
-    "gitlab_project_id": "YOUR_PROJECT_ID",
+    "gitlab_project_id": "78189586",
     "role": "development",
-    "context": "mygroup/kubernetes/agents:dev"
+    "context": "bates-ils/projects/kubernetes/gitlab-agents:beehive"
   },
   {
-    "name": "prod",
-    "label": "Prod (Prod)",
-    "domain": "prod.example.com",
-    "namespace": "gitlab-runners",
+    "name": "rigel",
+    "label": "Rigel (Prod)",
+    "domain": "rigel.bates.edu",
+    "namespace": "bates-ils-runners",
     "gitlab_url": "https://gitlab.com",
-    "gitlab_project_id": "YOUR_PROJECT_ID",
+    "gitlab_project_id": "78189586",
     "role": "production",
-    "context": "mygroup/kubernetes/agents:prod"
+    "context": "bates-ils/projects/kubernetes/gitlab-agents:rigel"
   }
 ]

--- a/app/src/routes/api/gitops/submit/+server.ts
+++ b/app/src/routes/api/gitops/submit/+server.ts
@@ -1,0 +1,22 @@
+import { json, error } from "@sveltejs/kit";
+import { submitChanges } from "$lib/server/gitops/pipeline";
+import type { RequestHandler } from "./$types";
+
+export const POST: RequestHandler = async ({ request }) => {
+  const body = await request.json();
+  const { changes, description, environment } = body;
+
+  if (!changes || !description) {
+    error(400, "Missing changes or description");
+  }
+
+  try {
+    const result = await submitChanges({ changes, description }, environment);
+    return json(result);
+  } catch (e) {
+    error(
+      500,
+      `GitOps submit failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+};

--- a/tofu/modules/runner-dashboard/variables.tf
+++ b/tofu/modules/runner-dashboard/variables.tf
@@ -82,6 +82,34 @@ variable "session_secret" {
 }
 
 # =============================================================================
+# GitLab Project/Group IDs
+# =============================================================================
+
+variable "gitlab_group_id" {
+  description = "GitLab group ID for runner status queries"
+  type        = string
+  default     = ""
+}
+
+variable "gitlab_project_id" {
+  description = "GitLab project ID for GitOps operations"
+  type        = string
+  default     = ""
+}
+
+variable "runner_stack_name" {
+  description = "Name of the runner tofu stack (for GitOps tfvars path)"
+  type        = string
+  default     = "gitlab-runners"
+}
+
+variable "default_env" {
+  description = "Default environment name for GitOps operations"
+  type        = string
+  default     = "dev"
+}
+
+# =============================================================================
 # Prometheus Configuration
 # =============================================================================
 

--- a/tofu/stacks/runner-dashboard/main.tf
+++ b/tofu/stacks/runner-dashboard/main.tf
@@ -17,6 +17,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.24"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 }
 
@@ -48,6 +52,12 @@ module "runner_dashboard" {
   gitlab_url                 = var.gitlab_url
   gitlab_token               = var.gitlab_token
   session_secret             = var.session_secret
+
+  # GitLab IDs
+  gitlab_group_id   = var.gitlab_group_id
+  gitlab_project_id = var.gitlab_project_id
+  runner_stack_name = var.runner_stack_name
+  default_env       = var.default_env
 
   # Prometheus
   prometheus_url = var.prometheus_url

--- a/tofu/stacks/runner-dashboard/variables.tf
+++ b/tofu/stacks/runner-dashboard/variables.tf
@@ -76,6 +76,34 @@ variable "session_secret" {
 }
 
 # =============================================================================
+# GitLab Project/Group IDs
+# =============================================================================
+
+variable "gitlab_group_id" {
+  description = "GitLab group ID for runner status queries"
+  type        = string
+  default     = ""
+}
+
+variable "gitlab_project_id" {
+  description = "GitLab project ID for GitOps operations"
+  type        = string
+  default     = ""
+}
+
+variable "runner_stack_name" {
+  description = "Name of the runner tofu stack (for GitOps tfvars path)"
+  type        = string
+  default     = "gitlab-runners"
+}
+
+variable "default_env" {
+  description = "Default environment name for GitOps operations"
+  type        = string
+  default     = "dev"
+}
+
+# =============================================================================
 # Prometheus
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- Regenerate app-config.json with correct org name and sidebar links from organization.yaml
- Add missing env vars to ConfigMap (GITLAB_GROUP_ID, GITLAB_PROJECT_ID, K8S_NAMESPACE, RUNNER_STACK_NAME, ATTIC_DEFAULT_ENV) so dashboard APIs return live data instead of mocks
- Auto-generate SESSION_SECRET via random_password when not explicitly provided
- Add `/api/gitops/submit` POST endpoint wired to existing GitOps pipeline (creates branch + MR)
- Replace `handleConfigSave` TODO stub with real implementation that maps RunnerConfig to tfvars keys and submits via GitOps flow
- Show MR link on successful config save, error banner on failure

## Test plan
- [x] `pnpm check` — 0 errors, 5 warnings (unchanged)
- [x] `pnpm build` — success
- [x] `pnpm test` — 78/78 pass
- [x] `tofu validate` — module and stack both pass
- [ ] Deploy to beehive and verify live API data
- [ ] Verify sidebar shows correct org name and links
- [ ] Test config edit -> save -> MR creation flow