### PR TITLE
fix(dashboard): set NODE_EXTRA_CA_CERTS for in-cluster K8s API

### DIFF
--- a/tofu/modules/runner-dashboard/main.tf
+++ b/tofu/modules/runner-dashboard/main.tf
@@ -356,6 +356,12 @@ resource "kubernetes_deployment" "dashboard" {
             }
           }
 
+          # Trust K8s cluster CA for in-cluster API calls
+          env {
+            name  = "NODE_EXTRA_CA_CERTS"
+            value = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+          }
+
           security_context {
             allow_privilege_escalation = false
             read_only_root_filesystem  = true


### PR DESCRIPTION
## Summary
- Add `NODE_EXTRA_CA_CERTS=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` env var to dashboard container
- Without this, Node.js rejects the K8s API server TLS cert, causing pods/HPA endpoints to silently fall back to mock data

## Test plan
- [x] Verified on beehive: `/api/k8s/pods` returns `available: true` with 5 live runner pods
- [x] `/api/k8s/hpa` returns `available: true` with 5 HPAs