### PR TITLE
fix(runner): upgrade chart, fix attach strategy and runner API

### DIFF
--- a/app/src/lib/server/gitlab/runners.ts
+++ b/app/src/lib/server/gitlab/runners.ts
@@ -33,7 +33,7 @@ export async function listGroupRunners(
   client: GitLabClient = gitlab,
 ): Promise<GitLabRunner[]> {
   return client.request<GitLabRunner[]>(`/groups/${groupId}/runners`, {
-    params: { per_page: "100" },
+    params: { per_page: "100", type: "group_type" },
   });
 }
 

--- a/tofu/modules/gitlab-runner/variables.tf
+++ b/tofu/modules/gitlab-runner/variables.tf
@@ -73,7 +73,7 @@ variable "create_namespace" {
 variable "chart_version" {
   description = "GitLab Runner Helm chart version"
   type        = string
-  default     = "0.71.0"
+  default     = "0.78.0"
 }
 
 variable "privileged" {
@@ -192,6 +192,12 @@ variable "docker_version" {
   description = "Docker version for DinD service"
   type        = string
   default     = "27-dind"
+}
+
+variable "dind_sidecar_in_toml" {
+  description = "Inject DinD service sidecar via runner TOML config. Disable if CI jobs provide their own DinD service to avoid port conflicts."
+  type        = bool
+  default     = false
 }
 
 # =============================================================================
@@ -332,6 +338,30 @@ variable "bazel_cache_endpoint" {
 # =============================================================================
 # Additional Configuration
 # =============================================================================
+
+variable "use_legacy_exec_strategy" {
+  description = "Use legacy Kubernetes exec strategy instead of attach. Disabled by default: the exec strategy is broken with service containers in Runner <=17.8. Chart 0.78.0+ (Runner 17.9) adds informer-based pod detection that fixes the attach strategy race condition."
+  type        = bool
+  default     = false
+}
+
+variable "print_pod_events" {
+  description = "Print Kubernetes pod events in job logs for debugging"
+  type        = bool
+  default     = true
+}
+
+variable "poll_timeout" {
+  description = "Timeout in seconds for waiting for pod to be running"
+  type        = number
+  default     = 600
+}
+
+variable "poll_interval" {
+  description = "Interval in seconds between pod status checks"
+  type        = number
+  default     = 3
+}
 
 variable "additional_values" {
   description = "Additional Helm values in YAML format"


### PR DESCRIPTION
## Summary
- Upgrade GitLab Runner Helm chart from 0.71.0 to 0.78.0 (Runner 18.1.0) which includes the informer-based pod watcher that replaces polling for pod status detection
- Switch from legacy exec strategy to attach strategy — the exec strategy is broken with service containers in Runner <=17.8, causing jobs to hang at "Preparing environment"
- Add `dind_sidecar_in_toml` variable (default `false`) to prevent duplicate DinD services causing port 2375 conflicts
- Filter `/api/runners` by `type=group_type` to exclude instance shared runners from dashboard

## Test plan
- [x] Deployed chart 0.78.0 to beehive cluster, all 5 runners online (Runner 18.1.0)
- [x] build:dashboard CI job succeeded in 45s with attach strategy + CI-defined DinD service
- [x] All dashboard APIs return live data (runners, K8s pods, Prometheus metrics)
- [x] Verified runner TOML config has correct feature flags and no DinD sidecar