### PR TITLE
fix(docs): shorten xoxd.ai tagline, add footer to dashboard

### DIFF
--- a/app/src/lib/components/nav/Sidebar.svelte
+++ b/app/src/lib/components/nav/Sidebar.svelte
@@ -122,5 +122,8 @@
 				{/if}
 			</div>
 		{/if}
+		<div class="pt-1">
+			built with <a href="https://xoxd.ai" target="_blank" rel="noopener noreferrer" class="font-semibold text-primary-500 hover:text-primary-400 transition-colors">xoxd.ai</a> ^w^
+		</div>
 	</div>
 </aside>

--- a/docs-site/src/routes/+page.svelte
+++ b/docs-site/src/routes/+page.svelte
@@ -88,7 +88,7 @@
 				built with <a href="https://xoxd.ai" target="_blank" rel="noopener noreferrer" class="font-semibold text-primary-500 hover:text-primary-400 transition-colors">xoxd.ai</a>
 			</p>
 			<p class="mt-2 text-surface-500 max-w-2xl mx-auto">
-				Orchestrating massively parallel, provable agent infrastructure at the intersection of autonomous scale and cryptographic integrity. xoxd.ai ^w^
+				Orchestrating massively parallel, provable agent infrastructure. xoxd.ai ^w^
 			</p>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

- Shorten xoxd.ai tagline on docs-site landing page (remove "at the intersection of autonomous scale and cryptographic integrity")
- Add "built with xoxd.ai ^w^" footer to the runner dashboard sidebar

## Test plan

- [x] `pnpm check` — 0 errors
- [ ] Verify footer appears in dashboard sidebar after deploy
- [ ] Verify docs-site landing page shows shortened tagline