### PR TITLE
feat(runners): pod self-healing via feature flags and cleanup tuning

### DIFF
--- a/tofu/modules/gitlab-runner/locals.tf
+++ b/tofu/modules/gitlab-runner/locals.tf
@@ -169,6 +169,8 @@ locals {
       [runners.feature_flags]
         FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY = ${var.use_legacy_exec_strategy}
         FF_PRINT_POD_EVENTS = ${var.print_pod_events}
+        FF_USE_POD_ACTIVE_DEADLINE_SECONDS = ${var.use_active_deadline}
+        FF_CLEANUP_FAILED_CACHE_EXTRACT = ${var.cleanup_failed_cache_extract}
       [runners.kubernetes]
         namespace = "${var.namespace}"
         image = "${local.default_image}"
@@ -204,6 +206,7 @@ locals {
         memory_limit = "${var.job_memory_limit}"
         %{if var.cleanup_enabled~}
         pod_termination_grace_period_seconds = ${var.cleanup_grace_seconds}
+        cleanup_grace_period_seconds = ${var.cleanup_grace_period_seconds}
         %{endif~}
   TOML
 }

--- a/tofu/modules/gitlab-runner/variables.tf
+++ b/tofu/modules/gitlab-runner/variables.tf
@@ -425,7 +425,25 @@ variable "cleanup_enabled" {
 }
 
 variable "cleanup_grace_seconds" {
-  description = "Grace period before deleting completed pods"
+  description = "Kubernetes terminationGracePeriodSeconds for job pods (seconds before SIGKILL after termination signal)"
   type        = number
-  default     = 3600
+  default     = 30
+}
+
+variable "cleanup_grace_period_seconds" {
+  description = "Seconds the runner waits after job completes before deleting the pod"
+  type        = number
+  default     = 10
+}
+
+variable "use_active_deadline" {
+  description = "Set activeDeadlineSeconds on job pods (= job_timeout + 1). Kubernetes marks pods as Failed when deadline expires, preventing infinite hangs."
+  type        = bool
+  default     = true
+}
+
+variable "cleanup_failed_cache_extract" {
+  description = "Clean up job pods where cache extraction failed"
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
## Summary
- Enable `FF_USE_POD_ACTIVE_DEADLINE_SECONDS` (default true): Kubernetes marks job pods as Failed when `activeDeadlineSeconds` expires, preventing infinite hangs that exhaust ResourceQuota
- Enable `FF_CLEANUP_FAILED_CACHE_EXTRACT` (default true): clean up pods where cache extraction failed
- Reduce `pod_termination_grace_period_seconds` default from 3600 to 30: pods get 30s after SIGTERM before SIGKILL instead of 1 hour
- Add `cleanup_grace_period_seconds` (default 10): runner waits 10s after job completes before deleting the pod

## Context
Orphaned Terminating pods were clogging the `bates-ils-runners` namespace, exhausting the 4 CPU / 8Gi ResourceQuota and blocking new job pods with `Insufficient cpu` errors. Root cause: `pod_termination_grace_period_seconds` defaulted to 3600 (1 hour), and without `activeDeadlineSeconds`, hung jobs never got cleaned up by Kubernetes.

## Test plan
- [x] `tofu validate` passes on gitlab-runner module
- [x] `tofu validate` passes on bates-ils-runners overlay stack
- [x] All 78 app tests pass
- [ ] Deploy to beehive and verify Terminating pods clear within 30s
- [ ] Verify `activeDeadlineSeconds` is set on new job pods via `kubectl get pod -o yaml`