### PR TITLE
feat(runners): self-healing tier 2 + dashboard 500 fix

### DIFF
--- a/app/src/lib/server/gitlab/runners.ts
+++ b/app/src/lib/server/gitlab/runners.ts
@@ -1,6 +1,6 @@
 import { gitlab, type GitLabClient } from "./client";
 
-interface GitLabRunner {
+export interface GitLabRunner {
   id: number;
   description: string;
   active: boolean;

--- a/app/src/lib/server/gitlab/transform.ts
+++ b/app/src/lib/server/gitlab/transform.ts
@@ -1,0 +1,116 @@
+import type { GitLabRunner } from "./runners";
+import type { RunnerInfo, RunnerType, RunnerStatus, RunnerConfig } from "$lib/types/runner";
+import {
+  RUNNER_TYPES,
+  RUNNER_TYPE_DEFAULT_TAGS,
+  RUNNER_TYPE_DEFAULT_IMAGES,
+} from "$lib/types/runner";
+
+/** Detect RunnerType from GitLab tag_list. Falls back to "docker". */
+function detectRunnerType(tagList: string[]): RunnerType {
+  const tags = tagList.map((t) => t.toLowerCase());
+  if (tags.includes("dind")) return "dind";
+  if (tags.includes("rocky8") || tags.includes("rhel8")) return "rocky8";
+  if (tags.includes("rocky9") || tags.includes("rhel9")) return "rocky9";
+  if (tags.includes("nix") || tags.includes("flakes")) return "nix";
+  if (tags.includes("docker")) return "docker";
+  // Check description-based fallback isn't needed since we check tags first
+  return "docker";
+}
+
+/** Map GitLab runner status fields to our RunnerStatus. */
+function mapStatus(runner: GitLabRunner): RunnerStatus {
+  if (runner.paused) return "paused";
+  if (runner.online) return "online";
+  if (runner.status === "online") return "online";
+  return "offline";
+}
+
+/** Default resource spec for manager pods by runner type. */
+function defaultManagerResources() {
+  return {
+    cpu_request: "100m",
+    memory_request: "128Mi",
+    cpu_limit: "500m",
+    memory_limit: "512Mi",
+  };
+}
+
+/** Default resource spec for job pods by runner type. */
+function defaultJobResources(type: RunnerType) {
+  if (type === "dind") {
+    return {
+      cpu_request: "100m",
+      memory_request: "512Mi",
+      cpu_limit: "2",
+      memory_limit: "4Gi",
+    };
+  }
+  if (type === "nix") {
+    return {
+      cpu_request: "100m",
+      memory_request: "512Mi",
+      cpu_limit: "2",
+      memory_limit: "4Gi",
+    };
+  }
+  return {
+    cpu_request: "100m",
+    memory_request: "256Mi",
+    cpu_limit: "2",
+    memory_limit: "2Gi",
+  };
+}
+
+/** Synthesize a RunnerConfig from type defaults. */
+function buildDefaultConfig(name: string, type: RunnerType, tags: string[]): RunnerConfig {
+  return {
+    name,
+    type,
+    tags,
+    concurrent_jobs: type === "docker" ? 8 : 4,
+    run_untagged: false,
+    protected: false,
+    default_image: RUNNER_TYPE_DEFAULT_IMAGES[type],
+    privileged: type === "dind",
+    manager_resources: defaultManagerResources(),
+    job_resources: defaultJobResources(type),
+    hpa: {
+      enabled: false,
+      min_replicas: 1,
+      max_replicas: 5,
+      cpu_target: 70,
+      memory_target: 80,
+      scale_up_window: 15,
+      scale_down_window: 300,
+    },
+    pdb_enabled: false,
+    pdb_min_available: 1,
+    metrics_enabled: true,
+    service_monitor_enabled: false,
+  };
+}
+
+/** Transform a GitLab API runner to our RunnerInfo shape. */
+export function gitlabRunnerToRunnerInfo(runner: GitLabRunner): RunnerInfo {
+  const type = detectRunnerType(runner.tag_list);
+  const name = runner.description;
+  const tags = runner.tag_list;
+
+  return {
+    id: runner.id,
+    name,
+    type,
+    status: mapStatus(runner),
+    tags,
+    config: buildDefaultConfig(name, type, tags),
+    version: runner.version || undefined,
+    ip_address: runner.ip_address || undefined,
+    contacted_at: runner.contacted_at || undefined,
+  };
+}
+
+/** Transform a list of GitLab runners to RunnerInfo[]. */
+export function gitlabRunnersToRunnerInfoList(runners: GitLabRunner[]): RunnerInfo[] {
+  return runners.map(gitlabRunnerToRunnerInfo);
+}

--- a/app/src/routes/api/runners/+server.ts
+++ b/app/src/routes/api/runners/+server.ts
@@ -1,6 +1,7 @@
 import { json } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
 import { listGroupRunners } from "$lib/server/gitlab/runners";
+import { gitlabRunnersToRunnerInfoList } from "$lib/server/gitlab/transform";
 import { MOCK_RUNNERS } from "$lib/mocks";
 import type { RequestHandler } from "./$types";
 
@@ -10,7 +11,8 @@ export const GET: RequestHandler = async () => {
   }
 
   try {
-    const runners = await listGroupRunners(env.GITLAB_GROUP_ID);
+    const rawRunners = await listGroupRunners(env.GITLAB_GROUP_ID);
+    const runners = gitlabRunnersToRunnerInfoList(rawRunners);
     return json(runners);
   } catch {
     return json(MOCK_RUNNERS);

--- a/app/src/routes/api/runners/[name]/+server.ts
+++ b/app/src/routes/api/runners/[name]/+server.ts
@@ -1,8 +1,24 @@
 import { json, error } from "@sveltejs/kit";
+import { env } from "$env/dynamic/private";
+import { listGroupRunners } from "$lib/server/gitlab/runners";
+import { gitlabRunnersToRunnerInfoList } from "$lib/server/gitlab/transform";
 import { MOCK_RUNNER_MAP } from "$lib/mocks";
 import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ params }) => {
+  if (env.GITLAB_TOKEN && env.GITLAB_GROUP_ID) {
+    try {
+      const rawRunners = await listGroupRunners(env.GITLAB_GROUP_ID);
+      const runners = gitlabRunnersToRunnerInfoList(rawRunners);
+      const runner = runners.find((r) => r.name === params.name);
+      if (runner) {
+        return json(runner);
+      }
+    } catch {
+      // Fall through to mock lookup
+    }
+  }
+
   const runner = MOCK_RUNNER_MAP[params.name];
   if (!runner) {
     error(404, `Runner "${params.name}" not found`);

--- a/tofu/modules/gitlab-runner/locals.tf
+++ b/tofu/modules/gitlab-runner/locals.tf
@@ -204,6 +204,9 @@ locals {
         memory_request = "${var.job_memory_request}"
         cpu_limit = "${var.job_cpu_limit}"
         memory_limit = "${var.job_memory_limit}"
+        %{if var.job_priority_class_name != ""~}
+        pod_priority_class_name = "${var.job_priority_class_name}"
+        %{endif~}
         %{if var.cleanup_enabled~}
         pod_termination_grace_period_seconds = ${var.cleanup_grace_seconds}
         cleanup_grace_period_seconds = ${var.cleanup_grace_period_seconds}

--- a/tofu/modules/gitlab-runner/main.tf
+++ b/tofu/modules/gitlab-runner/main.tf
@@ -116,6 +116,15 @@ resource "helm_release" "gitlab_runner" {
     value = var.memory_limit
   }
 
+  # Manager pod priority class
+  dynamic "set" {
+    for_each = var.manager_priority_class_name != "" ? [var.manager_priority_class_name] : []
+    content {
+      name  = "priorityClassName"
+      value = set.value
+    }
+  }
+
   # Metrics
   set {
     name  = "metrics.enabled"

--- a/tofu/modules/gitlab-runner/variables.tf
+++ b/tofu/modules/gitlab-runner/variables.tf
@@ -447,3 +447,19 @@ variable "cleanup_failed_cache_extract" {
   type        = bool
   default     = true
 }
+
+# =============================================================================
+# PriorityClass Configuration
+# =============================================================================
+
+variable "manager_priority_class_name" {
+  description = "PriorityClass name for runner manager pod"
+  type        = string
+  default     = ""
+}
+
+variable "job_priority_class_name" {
+  description = "PriorityClass name for CI job pods"
+  type        = string
+  default     = ""
+}

--- a/tofu/modules/runner-cleanup/main.tf
+++ b/tofu/modules/runner-cleanup/main.tf
@@ -1,0 +1,198 @@
+# Runner Cleanup Module
+#
+# CronJob that reaps orphaned/stuck pods in the runner namespace.
+# Handles: Terminating pods, Completed pods, Failed pods.
+
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+  }
+}
+
+locals {
+  common_labels = {
+    "app.kubernetes.io/name"       = "runner-cleanup"
+    "app.kubernetes.io/managed-by" = "opentofu"
+    "app.kubernetes.io/component"  = "cleanup"
+  }
+
+  cleanup_script = <<-BASH
+    set -euo pipefail
+
+    NS="${var.namespace}"
+    echo "=== Runner Cleanup Job ==="
+    echo "Namespace: $NS"
+    echo "Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo ""
+
+    # Force-delete pods stuck in Terminating
+    echo "Force-deleting pods stuck in Terminating > ${var.terminating_threshold_seconds}s..."
+    TERMINATING=$(kubectl get pods -n "$NS" --field-selector=metadata.deletionTimestamp!='' \
+      -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.deletionTimestamp}{"\n"}{end}' 2>/dev/null || echo "")
+    TERM_COUNT=0
+    if [ -n "$TERMINATING" ]; then
+      while IFS=' ' read -r POD TS; do
+        [ -z "$POD" ] && continue
+        CREATED_EPOCH=$(date -d "$TS" +%s 2>/dev/null || echo 0)
+        NOW_EPOCH=$(date +%s)
+        AGE=$(( NOW_EPOCH - CREATED_EPOCH ))
+        if [ "$AGE" -gt ${var.terminating_threshold_seconds} ]; then
+          echo "  Force-deleting: $POD (stuck $${AGE}s)"
+          kubectl delete pod "$POD" -n "$NS" --grace-period=0 --force --ignore-not-found || true
+          TERM_COUNT=$((TERM_COUNT + 1))
+        fi
+      done <<< "$TERMINATING"
+    fi
+    echo "  Force-deleted $TERM_COUNT pods"
+    echo ""
+
+    # Delete Completed pods
+    echo "Deleting Completed pods older than ${var.completed_threshold_seconds}s..."
+    COMPLETED=$(kubectl get pods -n "$NS" --field-selector=status.phase==Succeeded \
+      -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.creationTimestamp}{"\n"}{end}' 2>/dev/null || echo "")
+    COMP_COUNT=0
+    if [ -n "$COMPLETED" ]; then
+      while IFS=' ' read -r POD TS; do
+        [ -z "$POD" ] && continue
+        CREATED_EPOCH=$(date -d "$TS" +%s 2>/dev/null || echo 0)
+        NOW_EPOCH=$(date +%s)
+        AGE=$(( NOW_EPOCH - CREATED_EPOCH ))
+        if [ "$AGE" -gt ${var.completed_threshold_seconds} ]; then
+          echo "  Deleting completed: $POD (age: $${AGE}s)"
+          kubectl delete pod "$POD" -n "$NS" --ignore-not-found || true
+          COMP_COUNT=$((COMP_COUNT + 1))
+        fi
+      done <<< "$COMPLETED"
+    fi
+    echo "  Deleted $COMP_COUNT completed pods"
+    echo ""
+
+    # Delete Failed pods
+    echo "Deleting Failed pods older than ${var.failed_threshold_seconds}s..."
+    FAILED=$(kubectl get pods -n "$NS" --field-selector=status.phase==Failed \
+      -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.creationTimestamp}{"\n"}{end}' 2>/dev/null || echo "")
+    FAIL_COUNT=0
+    if [ -n "$FAILED" ]; then
+      while IFS=' ' read -r POD TS; do
+        [ -z "$POD" ] && continue
+        CREATED_EPOCH=$(date -d "$TS" +%s 2>/dev/null || echo 0)
+        NOW_EPOCH=$(date +%s)
+        AGE=$(( NOW_EPOCH - CREATED_EPOCH ))
+        if [ "$AGE" -gt ${var.failed_threshold_seconds} ]; then
+          echo "  Deleting failed: $POD (age: $${AGE}s)"
+          kubectl delete pod "$POD" -n "$NS" --ignore-not-found || true
+          FAIL_COUNT=$((FAIL_COUNT + 1))
+        fi
+      done <<< "$FAILED"
+    fi
+    echo "  Deleted $FAIL_COUNT failed pods"
+    echo ""
+    echo "=== Cleanup complete ==="
+  BASH
+}
+
+# =============================================================================
+# RBAC
+# =============================================================================
+
+resource "kubernetes_service_account_v1" "cleanup" {
+  metadata {
+    name      = "runner-cleanup"
+    namespace = var.namespace
+    labels    = local.common_labels
+  }
+}
+
+resource "kubernetes_role_v1" "cleanup" {
+  metadata {
+    name      = "runner-cleanup"
+    namespace = var.namespace
+    labels    = local.common_labels
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["get", "list", "delete"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "cleanup" {
+  metadata {
+    name      = "runner-cleanup"
+    namespace = var.namespace
+    labels    = local.common_labels
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.cleanup.metadata[0].name
+    namespace = var.namespace
+  }
+
+  role_ref {
+    kind      = "Role"
+    name      = kubernetes_role_v1.cleanup.metadata[0].name
+    api_group = "rbac.authorization.k8s.io"
+  }
+}
+
+# =============================================================================
+# CronJob
+# =============================================================================
+
+resource "kubernetes_cron_job_v1" "cleanup" {
+  metadata {
+    name      = "runner-cleanup"
+    namespace = var.namespace
+    labels    = local.common_labels
+  }
+
+  spec {
+    schedule                      = var.schedule
+    concurrency_policy            = "Forbid"
+    successful_jobs_history_limit = 3
+    failed_jobs_history_limit     = 3
+
+    job_template {
+      metadata {
+        labels = local.common_labels
+      }
+
+      spec {
+        ttl_seconds_after_finished = 3600
+
+        template {
+          metadata {
+            labels = local.common_labels
+          }
+
+          spec {
+            service_account_name = kubernetes_service_account_v1.cleanup.metadata[0].name
+            restart_policy       = "OnFailure"
+
+            container {
+              name    = "cleanup"
+              image   = var.kubectl_image
+              command = ["/bin/bash", "-c", local.cleanup_script]
+
+              resources {
+                requests = {
+                  cpu    = "50m"
+                  memory = "64Mi"
+                }
+                limits = {
+                  cpu    = "100m"
+                  memory = "128Mi"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tofu/modules/runner-cleanup/variables.tf
+++ b/tofu/modules/runner-cleanup/variables.tf
@@ -1,0 +1,36 @@
+# Runner Cleanup Module - Variables
+
+variable "namespace" {
+  description = "Kubernetes namespace where runners operate"
+  type        = string
+}
+
+variable "schedule" {
+  description = "CronJob schedule expression"
+  type        = string
+  default     = "*/5 * * * *"
+}
+
+variable "terminating_threshold_seconds" {
+  description = "Force-delete pods stuck in Terminating longer than this (seconds)"
+  type        = number
+  default     = 300
+}
+
+variable "completed_threshold_seconds" {
+  description = "Delete Completed pods older than this (seconds)"
+  type        = number
+  default     = 600
+}
+
+variable "failed_threshold_seconds" {
+  description = "Delete Failed pods older than this (seconds)"
+  type        = number
+  default     = 1800
+}
+
+variable "kubectl_image" {
+  description = "Container image for kubectl"
+  type        = string
+  default     = "bitnami/kubectl:1.29"
+}

--- a/tofu/modules/runner-security/outputs.tf
+++ b/tofu/modules/runner-security/outputs.tf
@@ -1,0 +1,11 @@
+# Runner Security Module - Outputs
+
+output "manager_priority_class_name" {
+  description = "PriorityClass name for runner manager pods"
+  value       = var.priority_classes_enabled ? kubernetes_priority_class_v1.manager[0].metadata[0].name : ""
+}
+
+output "job_priority_class_name" {
+  description = "PriorityClass name for CI job pods"
+  value       = var.priority_classes_enabled ? kubernetes_priority_class_v1.job[0].metadata[0].name : ""
+}

--- a/tofu/modules/runner-security/priority-classes.tf
+++ b/tofu/modules/runner-security/priority-classes.tf
@@ -1,0 +1,30 @@
+# Runner Security Module - PriorityClasses
+#
+# Ensures runner manager pods survive node-pressure eviction while
+# CI job pods remain preemptible.
+
+resource "kubernetes_priority_class_v1" "manager" {
+  count = var.priority_classes_enabled ? 1 : 0
+
+  metadata {
+    name   = "${var.namespace}-manager"
+    labels = local.common_labels
+  }
+
+  value          = 1000
+  global_default = false
+  description    = "Priority for GitLab Runner manager pods"
+}
+
+resource "kubernetes_priority_class_v1" "job" {
+  count = var.priority_classes_enabled ? 1 : 0
+
+  metadata {
+    name   = "${var.namespace}-job"
+    labels = local.common_labels
+  }
+
+  value          = 100
+  global_default = false
+  description    = "Priority for CI job pods (preemptible)"
+}

--- a/tofu/modules/runner-security/variables.tf
+++ b/tofu/modules/runner-security/variables.tf
@@ -58,3 +58,9 @@ variable "limit_max_memory" {
   type        = string
   default     = "8Gi"
 }
+
+variable "priority_classes_enabled" {
+  description = "Create PriorityClasses for runner manager and job pods"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

- Fix `/api/runners` 500 error by adding a GitLab→RunnerInfo transform layer (maps `description`→`name`, detects `RunnerType` from `tag_list`, synthesizes default `RunnerConfig`)
- Add `/api/runners/[name]` live data lookup with mock fallback
- Add PriorityClasses (`runner-manager`=1000, `ci-job`=100) to runner-security module so manager pods survive node-pressure eviction
- Wire PriorityClasses into gitlab-runner module (Helm `priorityClassName` for manager, TOML `pod_priority_class_name` for jobs)
- Add `runner-cleanup` module: CronJob + RBAC that reaps Terminating pods >5min, Completed >10min, Failed >30min on a 5-minute schedule

## Test plan

- [x] `pnpm check` — 0 errors, 5 warnings (unchanged)
- [x] `pnpm test` — 78 tests pass (9 files)
- [x] `pnpm build` — success
- [x] `tofu validate` — runner-security, gitlab-runner, runner-cleanup all pass
- [ ] Deploy to beehive and verify:
  - `/runners` page loads without 500
  - `kubectl get priorityclass | grep bates` shows both classes
  - `kubectl get cronjob -n bates-ils-runners` shows runner-cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)