### PR TITLE
fix(cleanup): use bitnami/kubectl:latest

### DIFF
--- a/tofu/modules/runner-cleanup/variables.tf
+++ b/tofu/modules/runner-cleanup/variables.tf
@@ -32,5 +32,5 @@ variable "failed_threshold_seconds" {
 variable "kubectl_image" {
   description = "Container image for kubectl"
   type        = string
-  default     = "bitnami/kubectl:1.29"
+  default     = "bitnami/kubectl:latest"
 }


### PR DESCRIPTION
Bitnami removed versioned tags from bitnami/kubectl. The `:1.29` tag no longer exists, causing ImagePullBackOff on the cleanup CronJob.

Switch default to `:latest`.