### PR TITLE
Fix GitOps MR title exceeding 255 chars

### DIFF
--- a/app/src/lib/server/gitops/__tests__/pipeline.test.ts
+++ b/app/src/lib/server/gitops/__tests__/pipeline.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ConfigDiff } from "$lib/types";
+
+// Mock $env/dynamic/private
+vi.mock("$env/dynamic/private", () => ({
+  env: {
+    RUNNER_STACK_NAME: "gitlab-runners",
+    ATTIC_DEFAULT_ENV: "dev",
+  },
+}));
+
+// Mock repository functions
+const mockReadFile = vi.fn();
+const mockCreateBranch = vi.fn();
+const mockCommitFile = vi.fn();
+const mockCreateMergeRequest = vi.fn();
+
+vi.mock("../repository", () => ({
+  readFile: (...args: unknown[]) => mockReadFile(...args),
+  createBranch: (...args: unknown[]) => mockCreateBranch(...args),
+  commitFile: (...args: unknown[]) => mockCommitFile(...args),
+  createMergeRequest: (...args: unknown[]) => mockCreateMergeRequest(...args),
+}));
+
+import { buildMrTitle, submitChanges } from "../pipeline";
+
+const SAMPLE_TFVARS = `hpa_cpu_target = 70
+docker_concurrent_jobs = 8
+deploy_nix_runner = true
+nix_job_cpu_limit = "500m"`;
+
+describe("buildMrTitle", () => {
+  it("should return keys when title fits within 255 chars", () => {
+    const diffs: ConfigDiff[] = [
+      { key: "hpa_cpu_target", old_value: "70", new_value: "80", type: "changed" },
+    ];
+    expect(buildMrTitle(diffs)).toBe("Update runner config: hpa_cpu_target");
+  });
+
+  it("should return fallback for empty diffs", () => {
+    expect(buildMrTitle([])).toBe("Update runner configuration");
+  });
+
+  it("should include multiple keys when they fit", () => {
+    const diffs: ConfigDiff[] = [
+      { key: "hpa_cpu_target", old_value: "70", new_value: "80", type: "changed" },
+      { key: "docker_concurrent_jobs", old_value: "8", new_value: "12", type: "changed" },
+    ];
+    const title = buildMrTitle(diffs);
+    expect(title).toBe("Update runner config: hpa_cpu_target, docker_concurrent_jobs");
+    expect(title.length).toBeLessThanOrEqual(255);
+  });
+
+  it("should fall back to count when keys exceed 255 chars", () => {
+    // Generate enough long keys to exceed 255 chars
+    const diffs: ConfigDiff[] = Array.from({ length: 20 }, (_, i) => ({
+      key: `very_long_runner_configuration_key_name_${i}`,
+      old_value: "old",
+      new_value: "new",
+      type: "changed" as const,
+    }));
+
+    const title = buildMrTitle(diffs);
+    expect(title).toBe("Update runner config: 20 settings");
+    expect(title.length).toBeLessThanOrEqual(255);
+  });
+
+  it("should always produce titles within the 255-char limit", () => {
+    // Worst case: many keys just barely over the limit
+    for (let count = 1; count <= 50; count++) {
+      const diffs: ConfigDiff[] = Array.from({ length: count }, (_, i) => ({
+        key: `docker_job_memory_limit_setting_${i}`,
+        old_value: "old",
+        new_value: "new",
+        type: "changed" as const,
+      }));
+      const title = buildMrTitle(diffs);
+      expect(title.length).toBeLessThanOrEqual(255);
+    }
+  });
+});
+
+describe("submitChanges", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockReadFile.mockReset();
+    mockCreateBranch.mockReset();
+    mockCommitFile.mockReset();
+    mockCreateMergeRequest.mockReset();
+  });
+
+  it("should execute the full GitOps flow", async () => {
+    mockReadFile.mockResolvedValue(SAMPLE_TFVARS);
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockCommitFile.mockResolvedValue(undefined);
+    mockCreateMergeRequest.mockResolvedValue({
+      iid: 42,
+      web_url: "https://gitlab.com/test/project/-/merge_requests/42",
+    });
+
+    const result = await submitChanges({
+      changes: { hpa_cpu_target: 80 },
+      description: "Raise CPU target",
+    });
+
+    expect(result.mr_iid).toBe(42);
+    expect(result.mr_url).toContain("merge_requests/42");
+    expect(result.branch).toMatch(/^dashboard\/runner-config-\d+$/);
+    expect(result.diffs).toHaveLength(1);
+    expect(result.diffs[0].key).toBe("hpa_cpu_target");
+    expect(result.diffs[0].old_value).toBe("70");
+    expect(result.diffs[0].new_value).toBe("80");
+    expect(result.unified_diff).toContain("-hpa_cpu_target = 70");
+    expect(result.unified_diff).toContain("+hpa_cpu_target = 80");
+  });
+
+  it("should read from the correct tfvars path", async () => {
+    mockReadFile.mockResolvedValue(SAMPLE_TFVARS);
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockCommitFile.mockResolvedValue(undefined);
+    mockCreateMergeRequest.mockResolvedValue({ iid: 1, web_url: "" });
+
+    await submitChanges({
+      changes: { hpa_cpu_target: 80 },
+      description: "test",
+    });
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      "tofu/stacks/gitlab-runners/dev.tfvars",
+    );
+  });
+
+  it("should use environment override for tfvars path", async () => {
+    mockReadFile.mockResolvedValue(SAMPLE_TFVARS);
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockCommitFile.mockResolvedValue(undefined);
+    mockCreateMergeRequest.mockResolvedValue({ iid: 1, web_url: "" });
+
+    await submitChanges(
+      { changes: { hpa_cpu_target: 80 }, description: "test" },
+      "beehive",
+    );
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      "tofu/stacks/gitlab-runners/beehive.tfvars",
+    );
+  });
+
+  it("should create a timestamped branch", async () => {
+    mockReadFile.mockResolvedValue(SAMPLE_TFVARS);
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockCommitFile.mockResolvedValue(undefined);
+    mockCreateMergeRequest.mockResolvedValue({ iid: 1, web_url: "" });
+
+    await submitChanges({
+      changes: { hpa_cpu_target: 80 },
+      description: "test",
+    });
+
+    expect(mockCreateBranch).toHaveBeenCalledWith(
+      expect.stringMatching(/^dashboard\/runner-config-\d+$/),
+    );
+  });
+
+  it("should commit with conventional commit message", async () => {
+    mockReadFile.mockResolvedValue(SAMPLE_TFVARS);
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockCommitFile.mockResolvedValue(undefined);
+    mockCreateMergeRequest.mockResolvedValue({ iid: 1, web_url: "" });
+
+    await submitChanges({
+      changes: { hpa_cpu_target: 80 },
+      description: "Raise CPU target",
+    });
+
+    expect(mockCommitFile).toHaveBeenCalledWith(
+      "tofu/stacks/gitlab-runners/dev.tfvars",
+      expect.stringContaining("hpa_cpu_target = 80"),
+      expect.stringContaining("feat(runners): update hpa_cpu_target"),
+      expect.stringMatching(/^dashboard\/runner-config-\d+$/),
+    );
+
+    // Commit message should include description
+    const commitMsg = mockCommitFile.mock.calls[0][2];
+    expect(commitMsg).toContain("Raise CPU target");
+  });
+
+  it("should create MR with title within 255-char limit", async () => {
+    mockReadFile.mockResolvedValue(SAMPLE_TFVARS);
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockCommitFile.mockResolvedValue(undefined);
+    mockCreateMergeRequest.mockResolvedValue({ iid: 1, web_url: "" });
+
+    await submitChanges({
+      changes: { hpa_cpu_target: 80, docker_concurrent_jobs: 12 },
+      description: "test",
+    });
+
+    const mrTitle = mockCreateMergeRequest.mock.calls[0][1];
+    expect(mrTitle.length).toBeLessThanOrEqual(255);
+    expect(mrTitle).toContain("hpa_cpu_target");
+    expect(mrTitle).toContain("docker_concurrent_jobs");
+  });
+
+  it("should include change details in MR description", async () => {
+    mockReadFile.mockResolvedValue(SAMPLE_TFVARS);
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockCommitFile.mockResolvedValue(undefined);
+    mockCreateMergeRequest.mockResolvedValue({ iid: 1, web_url: "" });
+
+    await submitChanges({
+      changes: { hpa_cpu_target: 80 },
+      description: "Raise CPU target",
+    });
+
+    const mrDescription = mockCreateMergeRequest.mock.calls[0][2];
+    expect(mrDescription).toContain("## Runner Configuration Changes");
+    expect(mrDescription).toContain("**hpa_cpu_target**: 70 -> 80");
+    expect(mrDescription).toContain("```diff");
+    expect(mrDescription).toContain("Raise CPU target");
+  });
+
+  it("should propagate readFile errors", async () => {
+    mockReadFile.mockRejectedValue(new Error("GitLab API error: 404"));
+
+    await expect(
+      submitChanges({
+        changes: { hpa_cpu_target: 80 },
+        description: "test",
+      }),
+    ).rejects.toThrow("404");
+  });
+
+  it("should propagate createBranch errors", async () => {
+    mockReadFile.mockResolvedValue(SAMPLE_TFVARS);
+    mockCreateBranch.mockRejectedValue(new Error("Branch already exists"));
+
+    await expect(
+      submitChanges({
+        changes: { hpa_cpu_target: 80 },
+        description: "test",
+      }),
+    ).rejects.toThrow("Branch already exists");
+  });
+
+  it("should propagate createMergeRequest errors", async () => {
+    mockReadFile.mockResolvedValue(SAMPLE_TFVARS);
+    mockCreateBranch.mockResolvedValue(undefined);
+    mockCommitFile.mockResolvedValue(undefined);
+    mockCreateMergeRequest.mockRejectedValue(
+      new Error('GitLab API error: 400 - {"message":{"title":["is too long"]}}'),
+    );
+
+    await expect(
+      submitChanges({
+        changes: { hpa_cpu_target: 80 },
+        description: "test",
+      }),
+    ).rejects.toThrow("400");
+  });
+});

--- a/app/src/lib/server/gitops/__tests__/repository.test.ts
+++ b/app/src/lib/server/gitops/__tests__/repository.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock $env/dynamic/private
+vi.mock("$env/dynamic/private", () => ({
+  env: {
+    GITLAB_URL: "https://gitlab.com",
+    GITLAB_TOKEN: "test-token",
+    GITLAB_PROJECT_ID: "12345",
+  },
+}));
+
+// Mock the gitlab client
+const mockRequest = vi.fn();
+vi.mock("$lib/server/gitlab/client", () => ({
+  gitlab: { request: (...args: unknown[]) => mockRequest(...args) },
+}));
+
+import { readFile, createBranch, commitFile, createMergeRequest } from "../repository";
+
+describe("readFile", () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it("should decode base64 content", async () => {
+    const encoded = Buffer.from("hpa_cpu_target = 70").toString("base64");
+    mockRequest.mockResolvedValue({ content: encoded, encoding: "base64" });
+
+    const result = await readFile("tofu/stacks/runners/dev.tfvars");
+
+    expect(result).toBe("hpa_cpu_target = 70");
+    expect(mockRequest).toHaveBeenCalledWith(
+      "/projects/12345/repository/files/tofu%2Fstacks%2Frunners%2Fdev.tfvars",
+      { params: { ref: "main" } },
+    );
+  });
+
+  it("should return raw content for non-base64 encoding", async () => {
+    mockRequest.mockResolvedValue({ content: "raw content", encoding: "text" });
+
+    const result = await readFile("file.txt");
+    expect(result).toBe("raw content");
+  });
+
+  it("should use custom ref", async () => {
+    mockRequest.mockResolvedValue({ content: "", encoding: "text" });
+
+    await readFile("file.txt", "feature-branch");
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      { params: { ref: "feature-branch" } },
+    );
+  });
+
+  it("should encode file paths with slashes", async () => {
+    mockRequest.mockResolvedValue({ content: "", encoding: "text" });
+
+    await readFile("tofu/stacks/gitlab-runners/beehive.tfvars");
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      "/projects/12345/repository/files/tofu%2Fstacks%2Fgitlab-runners%2Fbeehive.tfvars",
+      expect.any(Object),
+    );
+  });
+});
+
+describe("createBranch", () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it("should create branch from main by default", async () => {
+    mockRequest.mockResolvedValue({});
+
+    await createBranch("dashboard/runner-config-123");
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      "/projects/12345/repository/branches",
+      {
+        method: "POST",
+        body: { branch: "dashboard/runner-config-123", ref: "main" },
+      },
+    );
+  });
+
+  it("should create branch from custom ref", async () => {
+    mockRequest.mockResolvedValue({});
+
+    await createBranch("feature/test", "develop");
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      "/projects/12345/repository/branches",
+      {
+        method: "POST",
+        body: { branch: "feature/test", ref: "develop" },
+      },
+    );
+  });
+});
+
+describe("commitFile", () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it("should commit file with correct parameters", async () => {
+    mockRequest.mockResolvedValue({});
+
+    await commitFile(
+      "tofu/stacks/runners/dev.tfvars",
+      "hpa_cpu_target = 80",
+      "feat(runners): update hpa_cpu_target",
+      "dashboard/runner-config-123",
+    );
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      "/projects/12345/repository/files/tofu%2Fstacks%2Frunners%2Fdev.tfvars",
+      {
+        method: "PUT",
+        body: {
+          branch: "dashboard/runner-config-123",
+          content: "hpa_cpu_target = 80",
+          commit_message: "feat(runners): update hpa_cpu_target",
+          encoding: "text",
+        },
+      },
+    );
+  });
+});
+
+describe("createMergeRequest", () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it("should create MR with correct parameters", async () => {
+    mockRequest.mockResolvedValue({
+      iid: 42,
+      web_url: "https://gitlab.com/test/-/merge_requests/42",
+    });
+
+    const result = await createMergeRequest(
+      "dashboard/runner-config-123",
+      "Update runner config: hpa_cpu_target",
+      "## Changes\n- hpa_cpu_target: 70 -> 80",
+    );
+
+    expect(result.iid).toBe(42);
+    expect(result.web_url).toContain("merge_requests/42");
+    expect(mockRequest).toHaveBeenCalledWith(
+      "/projects/12345/merge_requests",
+      {
+        method: "POST",
+        body: {
+          source_branch: "dashboard/runner-config-123",
+          target_branch: "main",
+          title: "Update runner config: hpa_cpu_target",
+          description: "## Changes\n- hpa_cpu_target: 70 -> 80",
+          squash: true,
+          remove_source_branch: true,
+        },
+      },
+    );
+  });
+
+  it("should use custom target branch", async () => {
+    mockRequest.mockResolvedValue({ iid: 1, web_url: "" });
+
+    await createMergeRequest("feature/test", "Title", "Desc", "develop");
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          target_branch: "develop",
+        }),
+      }),
+    );
+  });
+
+  it("should set squash and remove_source_branch", async () => {
+    mockRequest.mockResolvedValue({ iid: 1, web_url: "" });
+
+    await createMergeRequest("branch", "Title", "Desc");
+
+    const body = mockRequest.mock.calls[0][1].body;
+    expect(body.squash).toBe(true);
+    expect(body.remove_source_branch).toBe(true);
+  });
+});

--- a/docs/runners/README.md
+++ b/docs/runners/README.md
@@ -40,3 +40,5 @@ through `organization.yaml`.
 - [Security Model](security-model.md) -- privilege and access boundaries
 - [Troubleshooting](troubleshooting.md) -- common issues and fixes
 - [Runbook](runbook.md) -- operational procedures
+- [Project Onboarding](project-onboarding.md) -- enroll a project on the runner pool
+- [Resource Limits](resource-limits.md) -- job pod resource limits reference

--- a/docs/runners/project-onboarding.md
+++ b/docs/runners/project-onboarding.md
@@ -1,0 +1,100 @@
+# Project Onboarding Guide
+
+Step-by-step guide for enrolling a GitLab project on the shared HPA runner pool.
+
+## Prerequisites
+
+1. **Project location**: Your project must be in a group where runners are registered.
+   Runners only propagate *downward* in the GitLab group hierarchy. If your project
+   is in a sibling subgroup, you need additional runner registrations scoped to your
+   group (see [Bates-specific enrollment](https://gitlab.com/bates-ils/people/jsullivan2/attic-cache/-/blob/main/docs/bates-runner-enrollment.md) for an example).
+
+2. **CI variables**: Nix jobs require `ATTIC_TOKEN` (masked, protected) for cache access.
+   Deployment jobs may need `CI_SSH_PRIVATE_KEY` and environment-specific variables.
+
+3. **Runner visibility**: Verify runners appear in your project under
+   **Settings > CI/CD > Runners**. If they don't, the runner group scope needs updating.
+
+## Step 1: Choose Runners
+
+Use the [Runner Selection Guide](runner-selection.md) to map each CI job to a runner type:
+
+| Workload | Runner | Tag |
+|----------|--------|-----|
+| Python lint/test | docker | `docker` |
+| Nix flake builds | nix | `nix` |
+| Container image builds | dind | `dind` |
+| RHEL 8 packaging | rocky8 | `rocky8` |
+| RHEL 9 packaging | rocky9 | `rocky9` |
+
+## Step 2: Add Tags to Jobs
+
+Add `tags:` to each job in your `.gitlab-ci.yml`:
+
+**Before:**
+```yaml
+lint:python:
+  stage: validate
+  image: python:3.11-slim
+  script:
+    - ruff check src/
+```
+
+**After:**
+```yaml
+lint:python:
+  stage: validate
+  tags: [docker]
+  image: python:3.11-slim
+  script:
+    - ruff check src/
+```
+
+Jobs without `tags:` continue running on GitLab SaaS shared runners.
+
+## Step 3: Configure Cache (Nix Jobs)
+
+Nix runners inject `ATTIC_SERVER` and `ATTIC_CACHE` environment variables for the
+cluster-local Attic cache. If your project uses its own Attic cache, set these
+variables at the job level — job-level variables override runner-injected values:
+
+```yaml
+build:nix:
+  tags: [nix]
+  extends: .nix-attic
+  variables:
+    ATTIC_SERVER: "https://your-cache.example.com"
+    ATTIC_CACHE: "your-cache-name"
+```
+
+## Step 4: Verify Pipeline
+
+1. Push your branch and check the pipeline
+2. Click on a tagged job — the runner name should show `bates-docker`, `bates-nix`, etc.
+3. Check job duration against baseline (SaaS runner times)
+4. For Nix jobs, verify cache hits in the build log
+
+## Worked Example: upgrading-dw
+
+The `upgrading-dw` project migrated all CI jobs to dedicated runners:
+
+| Job | Runner Tag | Notes |
+|-----|-----------|-------|
+| lint:python, typecheck:python, test:python | `docker` | Fast Python jobs |
+| test:e2e, test:integration | `docker` | Pipeline validation |
+| lint:ansible, test:smoke-configs | `docker` | Ansible validation |
+| test:molecule | `dind` | Needs Docker-in-Docker |
+| validate-docs, test-docs, pages | `docker` | MkDocs builds |
+| validate:nix-flake, check:orchestrator-nix | `nix` | Flake validation |
+| check:haskell-format, lint:haskell | `nix` | Haskell code quality |
+| test:haskell-quickcheck | `nix` | Property tests |
+| build:orchestrator-nix, build:orchestrator-nix-release | `nix` | Haskell builds |
+| build:orchestrator-nix-static, build:orchestrator-nix-musl-upx | `nix` | MUSL static builds |
+| build:orchestrator (buildah fallback) | `dind` | Container builds |
+| package:fpm:el8 | `rocky8` | EL8 RPM packaging |
+| package:fpm:el9 | `rocky9` | EL9 RPM packaging |
+| deploy:repo | `mgr` | PVE node (unchanged) |
+| deploy:dev | `docker` | SSH-based deployment |
+
+The project keeps its own Attic cache (`nix-cache.fuzzy-dev.tinyland.dev / dw-cache`)
+via job-level `ATTIC_SERVER` / `ATTIC_CACHE` variables that override the runner defaults.

--- a/docs/runners/resource-limits.md
+++ b/docs/runners/resource-limits.md
@@ -1,0 +1,49 @@
+# Resource Limits Reference
+
+Default resource limits for CI job pods, by runner type.
+
+## Default Job Pod Limits
+
+These are the module defaults. Overlay deployments (e.g., Bates) override these
+values in their `*.tfvars` files.
+
+| Runner | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|--------|------------|-----------|----------------|--------------|
+| docker | 100m | 2 | 256Mi | 2Gi |
+| dind | 500m | 4 | 1Gi | 8Gi |
+| rocky8 | 100m | 2 | 256Mi | 2Gi |
+| rocky9 | 100m | 2 | 256Mi | 2Gi |
+| nix | 500m | 4 | 1Gi | 8Gi |
+
+## Typical Workload Profiles
+
+| Workload | CPU (typical) | Memory (typical) | Recommended Runner |
+|----------|--------------|------------------|-------------------|
+| Python lint (ruff) | 50-200m | 128-256Mi | docker |
+| Python tests (pytest) | 100-500m | 256-512Mi | docker |
+| Nix flake check | 200-500m | 256-512Mi | nix |
+| GHC build (warm cache) | 500m-1 | 512Mi-1Gi | nix |
+| GHC build (cold cache) | 2-4 | 2-4Gi | nix |
+| MUSL static build | 1-2 | 1-2Gi | nix |
+| FPM RPM packaging | 100-500m | 256-512Mi | rocky8/rocky9 |
+| Docker image build | 500m-2 | 512Mi-2Gi | dind |
+
+## Namespace Quota
+
+The runner namespace has a total resource quota shared across all concurrent job pods:
+
+| Resource | Default | Description |
+|----------|---------|-------------|
+| CPU requests | 16 | Total CPU requests across all pods |
+| Memory requests | 32Gi | Total memory requests across all pods |
+| Max pods | 50 | Maximum concurrent pods |
+
+## Requesting Limit Increases
+
+If your jobs are being OOM-killed or throttled:
+
+1. Check pod resource usage: `kubectl top pods -n <runner-namespace>`
+2. Review the job logs for OOM or throttling messages
+3. Update the overlay `*.tfvars` file with higher limits for the relevant runner type
+4. Run `tofu plan` and `tofu apply` to apply changes
+5. The runner Helm release will be updated with new pod resource templates

--- a/docs/runners/runner-selection.md
+++ b/docs/runners/runner-selection.md
@@ -49,6 +49,21 @@ Use these tags in your `.gitlab-ci.yml` to select a runner:
 | rocky9 | `rocky9` |
 | nix | `nix`, `flakes` |
 
+## Tag Semantics
+
+Each tag maps to exactly one runner type. Use the **primary tag** for runner selection:
+
+| Primary Tag | Runner | When to Use |
+|-------------|--------|-------------|
+| `docker` | bates-docker | Default for most jobs |
+| `dind` | bates-dind | Jobs requiring Docker daemon |
+| `rocky8` | bates-rocky8 | RHEL 8 / EL8 packaging |
+| `rocky9` | bates-rocky9 | RHEL 9 / EL9 packaging |
+| `nix` | bates-nix | Nix flake builds |
+
+Additional tags (`kubernetes`, `linux`, `amd64`, `flakes`, `privileged`, `rhel8`, `rhel9`)
+are available for finer matching but the primary tag is sufficient for most use cases.
+
 ## Performance Tip
 
 Always use the smallest runner that meets your needs. The `docker` runner

--- a/docs/runners/self-service-enrollment.md
+++ b/docs/runners/self-service-enrollment.md
@@ -153,3 +153,8 @@ Each job runs in an ephemeral `ci-job-*` Kubernetes namespace with:
 This applies to `docker`, `rocky8`, `rocky9`, and `nix` runners. The `dind`
 runner is the exception -- it uses a shared namespace with privileged access.
 See [security-model.md](security-model.md) for full details.
+
+## See Also
+
+- [Project Onboarding Guide](project-onboarding.md) -- step-by-step enrollment for new projects
+- [Resource Limits Reference](resource-limits.md) -- job pod resource limits and workload profiles


### PR DESCRIPTION
## Summary
- Fix: `buildMrTitle()` caps MR title to 255 chars, falling back to count summary when changed keys don't fit
- Tests: 25 new tests for `submitChanges` pipeline and repository functions (78 → 103 total)

## Problem
When editing multiple runner settings via the dashboard, the MR title concatenated all changed key names (`Update runner config: hpa_cpu_target, docker_concurrent_jobs, ...`), easily exceeding GitLab's 255-character limit and causing a 400 error.

## Fix
`buildMrTitle()` tries to list keys in the title; when they don't fit, falls back to `Update runner config: N settings`. All change details remain in the MR description body.

## Test plan
- [x] `buildMrTitle` with 0, 1, 2, and 20+ keys
- [x] Stress test: titles always ≤ 255 chars for 1-50 diffs
- [x] Full `submitChanges` flow with mocked repository
- [x] Error propagation (readFile, createBranch, createMergeRequest failures)
- [x] Repository functions (readFile base64 decode, createBranch, commitFile, createMergeRequest)
- [x] All 103 tests pass