### PR TITLE
fix(runners): remove kubernetes tag from self-hosted runner defaults

### DIFF
--- a/docs/runners/self-service-enrollment.md
+++ b/docs/runners/self-service-enrollment.md
@@ -154,6 +154,27 @@ This applies to `docker`, `rocky8`, `rocky9`, and `nix` runners. The `dind`
 runner is the exception -- it uses a shared namespace with privileged access.
 See [security-model.md](security-model.md) for full details.
 
+## Tag Strategy: Why No `kubernetes` Tag
+
+Self-hosted runners intentionally **exclude** the `kubernetes` tag from their
+registrations. Overlay CI pipelines use `default: tags: [kubernetes]` to target
+GitLab SaaS shared runners for jobs that need internet access (e.g., cloning
+the upstream repo from GitHub, downloading kubectl).
+
+Including `kubernetes` on self-hosted runners causes them to grab overlay CI
+jobs. On restricted networks (e.g., institutional clusters that can reach
+gitlab.com but not github.com), this causes failures when jobs try to clone
+from GitHub.
+
+**Rule of thumb:** self-hosted runners should only be tagged with their
+workload type (`docker`, `nix`, `rocky8`, etc). Projects request specific
+runners by matching these workload tags. Generic infrastructure jobs stay on
+SaaS shared runners.
+
+This was discovered during the first non-dogfooding deployment of
+flywheel-derived runners, where the Bates beehive cluster runners were
+unexpectedly picking up overlay pipeline jobs.
+
 ## See Also
 
 - [Project Onboarding Guide](project-onboarding.md) -- step-by-step enrollment for new projects

--- a/tofu/modules/gitlab-runner/locals.tf
+++ b/tofu/modules/gitlab-runner/locals.tf
@@ -35,14 +35,19 @@ locals {
   }
 
   # Default tags per runner type (merged with user tags)
-  # All runners share the "kubernetes" tag to enable the recursive dogfooding
-  # pattern where self-hosted runners execute the pipeline that deploys themselves.
+  # NOTE: The "kubernetes" tag is intentionally EXCLUDED. Self-hosted runners
+  # should only match jobs that explicitly request their workload type (docker,
+  # nix, etc). Overlay CI pipelines use tags: [kubernetes] to target SaaS
+  # shared runners for jobs that need internet access (e.g., cloning upstream
+  # from GitHub). Including "kubernetes" here causes self-hosted runners on
+  # restricted networks to grab those jobs and fail.
+  # See: docs/runners/tag-strategy.md
   runner_type_default_tags = {
-    docker = ["kubernetes", "docker", "linux", "amd64"]
-    dind   = ["kubernetes", "docker", "dind", "privileged"]
-    rocky8 = ["kubernetes", "rocky8", "rhel8", "linux"]
-    rocky9 = ["kubernetes", "rocky9", "rhel9", "linux"]
-    nix    = ["kubernetes", "nix", "flakes"]
+    docker = ["docker", "linux", "amd64"]
+    dind   = ["docker", "dind", "privileged"]
+    rocky8 = ["rocky8", "rhel8", "linux"]
+    rocky9 = ["rocky9", "rhel9", "linux"]
+    nix    = ["nix", "flakes"]
   }
 
   # =============================================================================


### PR DESCRIPTION
## Summary

- Remove `kubernetes` from `runner_type_default_tags` in the gitlab-runner module
- Self-hosted runners on restricted networks were grabbing overlay CI jobs that need internet access (GitHub clone)
- First non-dogfooding deployment (Bates beehive) exposed this tag collision
- Document tag strategy in `docs/runners/self-service-enrollment.md`

## Context

The `kubernetes` tag was originally added for a dogfooding pattern where self-hosted runners deploy themselves. Overlay CI uses `default: tags: [kubernetes]` — when self-hosted runners also have this tag, they pick up jobs that `git clone` upstream from GitHub. On restricted networks that can only reach gitlab.com, these jobs fail.

Fix: self-hosted runners use workload-specific tags only (docker, nix, rocky8, etc). Overlay CI falls back to GitLab SaaS shared runners which have full internet access and can still deploy via the K8s agent proxy (kas.gitlab.com).