### PR TITLE
feat(dashboard): Caddy mTLS/Tailscale reverse proxy sidecar

### DIFF
--- a/app/caddy/Dockerfile
+++ b/app/caddy/Dockerfile
@@ -1,0 +1,5 @@
+FROM caddy:2.10-builder AS builder
+RUN xcaddy build --with github.com/tailscale/caddy-tailscale
+
+FROM caddy:2.10-alpine
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/tofu/modules/runner-dashboard/templates/Caddyfile.tpl
+++ b/tofu/modules/runner-dashboard/templates/Caddyfile.tpl
@@ -1,0 +1,73 @@
+%{ if mode == "passthrough" ~}
+# Passthrough mode — simple reverse proxy
+:${port} {
+  reverse_proxy localhost:${backend_port}
+}
+%{ endif ~}
+
+%{ if mode == "mtls_only" ~}
+# mTLS mode — require client certificate
+:${port} {
+  tls {
+    client_auth {
+      mode ${mtls_client_auth_mode}
+      trust_pool file /etc/caddy/mtls/ca.pem
+    }
+  }
+
+  header_up X-Client-Cert-CN {tls_client_subject}
+  header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}
+  header_up X-Webauth-User {tls_client_subject}
+
+  reverse_proxy localhost:${backend_port}
+}
+%{ endif ~}
+
+%{ if mode == "tailscale_only" ~}
+# Tailscale mode — bind to Tailscale network only
+{
+  tailscale {
+    auth_key {env.TS_AUTHKEY}
+  }
+}
+
+:${port} {
+  bind tailscale/${tailscale_hostname}
+
+  @tailscale_auth {
+    remote_ip 100.64.0.0/10
+  }
+
+  header_up X-Webauth-User {http.auth.user.tailscale_user}
+  header_up X-Webauth-Email {http.auth.user.tailscale_user}
+
+  reverse_proxy localhost:${backend_port}
+}
+%{ endif ~}
+
+%{ if mode == "mtls_and_tailscale" ~}
+# Combined mTLS + Tailscale mode
+{
+  tailscale {
+    auth_key {env.TS_AUTHKEY}
+  }
+}
+
+:${port} {
+  bind tailscale/${tailscale_hostname}
+
+  tls {
+    client_auth {
+      mode ${mtls_client_auth_mode}
+      trust_pool file /etc/caddy/mtls/ca.pem
+    }
+  }
+
+  header_up X-Client-Cert-CN {tls_client_subject}
+  header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}
+  header_up X-Webauth-User {tls_client_subject}
+  header_up X-Webauth-Email {http.auth.user.tailscale_user}
+
+  reverse_proxy localhost:${backend_port}
+}
+%{ endif ~}

--- a/tofu/modules/runner-dashboard/variables.tf
+++ b/tofu/modules/runner-dashboard/variables.tf
@@ -319,3 +319,115 @@ variable "environments_config" {
   type        = string
   default     = ""
 }
+
+# =============================================================================
+# Caddy Reverse Proxy Sidecar (mTLS / Tailscale)
+# =============================================================================
+
+variable "enable_caddy_proxy" {
+  description = "Enable Caddy reverse proxy sidecar for mTLS/Tailscale"
+  type        = bool
+  default     = false
+}
+
+variable "caddy_mode" {
+  description = "Caddy proxy mode: passthrough, mtls_only, tailscale_only, mtls_and_tailscale"
+  type        = string
+  default     = "passthrough"
+
+  validation {
+    condition     = contains(["passthrough", "mtls_only", "tailscale_only", "mtls_and_tailscale"], var.caddy_mode)
+    error_message = "caddy_mode must be one of: passthrough, mtls_only, tailscale_only, mtls_and_tailscale"
+  }
+}
+
+variable "caddy_image" {
+  description = "Container image for Caddy with Tailscale plugin"
+  type        = string
+  default     = "ghcr.io/jesssullivan/caddy-tailscale:latest"
+}
+
+variable "caddy_port" {
+  description = "Port Caddy listens on"
+  type        = number
+  default     = 8443
+}
+
+variable "caddy_mtls_ca_cert" {
+  description = "PEM-encoded CA certificate for mTLS client verification"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "caddy_mtls_client_auth_mode" {
+  description = "mTLS client auth mode (require_and_verify, request, require)"
+  type        = string
+  default     = "require_and_verify"
+}
+
+variable "caddy_tailscale_auth_key" {
+  description = "Tailscale auth key (ephemeral, reusable)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "caddy_tailscale_hostname" {
+  description = "Tailscale MagicDNS hostname for the dashboard"
+  type        = string
+  default     = "runner-dashboard"
+}
+
+variable "caddy_cpu_request" {
+  description = "CPU request for Caddy sidecar"
+  type        = string
+  default     = "10m"
+}
+
+variable "caddy_cpu_limit" {
+  description = "CPU limit for Caddy sidecar"
+  type        = string
+  default     = "100m"
+}
+
+variable "caddy_memory_request" {
+  description = "Memory request for Caddy sidecar"
+  type        = string
+  default     = "32Mi"
+}
+
+variable "caddy_memory_limit" {
+  description = "Memory limit for Caddy sidecar"
+  type        = string
+  default     = "64Mi"
+}
+
+variable "trust_proxy_headers" {
+  description = "Trust X-Webauth-* identity headers from Caddy proxy"
+  type        = bool
+  default     = false
+}
+
+# =============================================================================
+# WebAuthn / FIDO2 Configuration
+# =============================================================================
+
+variable "webauthn_rp_id" {
+  description = "WebAuthn Relying Party ID (must match the domain users access)"
+  type        = string
+  default     = ""
+}
+
+variable "webauthn_rp_name" {
+  description = "WebAuthn Relying Party display name"
+  type        = string
+  default     = "Runner Dashboard"
+}
+
+variable "database_url" {
+  description = "PostgreSQL connection URL for WebAuthn credential storage"
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/tofu/stacks/runner-dashboard/main.tf
+++ b/tofu/stacks/runner-dashboard/main.tf
@@ -101,6 +101,26 @@ module "runner_dashboard" {
 
   # Runtime environment config
   environments_config = var.environments_config
+
+  # Caddy proxy sidecar
+  enable_caddy_proxy          = var.enable_caddy_proxy
+  caddy_mode                  = var.caddy_mode
+  caddy_image                 = var.caddy_image
+  caddy_port                  = var.caddy_port
+  caddy_mtls_ca_cert          = var.caddy_mtls_ca_cert
+  caddy_mtls_client_auth_mode = var.caddy_mtls_client_auth_mode
+  caddy_tailscale_auth_key    = var.caddy_tailscale_auth_key
+  caddy_tailscale_hostname    = var.caddy_tailscale_hostname
+  caddy_cpu_request           = var.caddy_cpu_request
+  caddy_cpu_limit             = var.caddy_cpu_limit
+  caddy_memory_request        = var.caddy_memory_request
+  caddy_memory_limit          = var.caddy_memory_limit
+  trust_proxy_headers         = var.trust_proxy_headers
+
+  # WebAuthn / FIDO2
+  webauthn_rp_id   = var.webauthn_rp_id
+  webauthn_rp_name = var.webauthn_rp_name
+  database_url     = var.database_url
 }
 
 # =============================================================================

--- a/tofu/stacks/runner-dashboard/variables.tf
+++ b/tofu/stacks/runner-dashboard/variables.tf
@@ -266,3 +266,110 @@ variable "environments_config" {
   type        = string
   default     = ""
 }
+
+# =============================================================================
+# Caddy Reverse Proxy Sidecar
+# =============================================================================
+
+variable "enable_caddy_proxy" {
+  description = "Enable Caddy reverse proxy sidecar for mTLS/Tailscale"
+  type        = bool
+  default     = false
+}
+
+variable "caddy_mode" {
+  description = "Caddy proxy mode: passthrough, mtls_only, tailscale_only, mtls_and_tailscale"
+  type        = string
+  default     = "passthrough"
+}
+
+variable "caddy_image" {
+  description = "Container image for Caddy with Tailscale plugin"
+  type        = string
+  default     = "ghcr.io/jesssullivan/caddy-tailscale:latest"
+}
+
+variable "caddy_port" {
+  description = "Port Caddy listens on"
+  type        = number
+  default     = 8443
+}
+
+variable "caddy_mtls_ca_cert" {
+  description = "PEM-encoded CA certificate for mTLS client verification"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "caddy_mtls_client_auth_mode" {
+  description = "mTLS client auth mode"
+  type        = string
+  default     = "require_and_verify"
+}
+
+variable "caddy_tailscale_auth_key" {
+  description = "Tailscale auth key (ephemeral, reusable)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "caddy_tailscale_hostname" {
+  description = "Tailscale MagicDNS hostname for the dashboard"
+  type        = string
+  default     = "runner-dashboard"
+}
+
+variable "caddy_cpu_request" {
+  description = "CPU request for Caddy sidecar"
+  type        = string
+  default     = "10m"
+}
+
+variable "caddy_cpu_limit" {
+  description = "CPU limit for Caddy sidecar"
+  type        = string
+  default     = "100m"
+}
+
+variable "caddy_memory_request" {
+  description = "Memory request for Caddy sidecar"
+  type        = string
+  default     = "32Mi"
+}
+
+variable "caddy_memory_limit" {
+  description = "Memory limit for Caddy sidecar"
+  type        = string
+  default     = "64Mi"
+}
+
+variable "trust_proxy_headers" {
+  description = "Trust X-Webauth-* identity headers from Caddy proxy"
+  type        = bool
+  default     = false
+}
+
+# =============================================================================
+# WebAuthn / FIDO2 Configuration
+# =============================================================================
+
+variable "webauthn_rp_id" {
+  description = "WebAuthn Relying Party ID (must match the domain)"
+  type        = string
+  default     = ""
+}
+
+variable "webauthn_rp_name" {
+  description = "WebAuthn Relying Party display name"
+  type        = string
+  default     = "Runner Dashboard"
+}
+
+variable "database_url" {
+  description = "PostgreSQL connection URL for WebAuthn credential storage"
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- Add feature-flagged Caddy sidecar to runner-dashboard module (`enable_caddy_proxy`, off by default)
- Support 4 proxy modes: `passthrough`, `mtls_only`, `tailscale_only`, `mtls_and_tailscale`
- Generate mode-specific Caddyfile via templatefile (`templates/Caddyfile.tpl`)
- Add conditional Kubernetes resources: ConfigMap (Caddyfile), Secret (CA cert + TS auth key), sidecar container
- SvelteKit binds to loopback (`HOST=127.0.0.1`) when Caddy enabled; Service targets Caddy port
- Parse Tailscale/mTLS identity headers in hooks.server.ts when `TRUST_PROXY_HEADERS=true`
- Create implicit viewer sessions from proxy identity (auth_method: "tailscale" or "mtls")
- Add custom Caddy Dockerfile with xcaddy + tailscale/caddy-tailscale plugin
- Pass all new variables through stack layer

Depends on #PR_A (feat/logout-fix) for multi-auth session foundations.

## Test plan
- [x] `tofu validate` passes on runner-dashboard module
- [x] `pnpm check` passes (0 errors)
- [ ] `tofu plan` with `enable_caddy_proxy=false` shows no sidecar resources
- [ ] `tofu plan` with `enable_caddy_proxy=true` shows ConfigMap, Secret, sidecar container
- [ ] Caddyfile template renders correctly for all 4 modes
- [ ] `docker build -t caddy-tailscale app/caddy/` builds successfully