### PR TITLE
feat(dashboard): Caddy mTLS/Tailscale reverse proxy sidecar

### DIFF
--- a/app/caddy/Dockerfile
+++ b/app/caddy/Dockerfile
@@ -1,0 +1,5 @@
+FROM caddy:2.10-builder AS builder
+RUN xcaddy build --with github.com/tailscale/caddy-tailscale
+
+FROM caddy:2.10-alpine
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/tofu/modules/runner-dashboard/main.tf
+++ b/tofu/modules/runner-dashboard/main.tf
@@ -335,7 +335,7 @@ resource "kubernetes_deployment" "dashboard" {
 
         # Caddy reverse proxy sidecar container
         dynamic "container" {
-          for_each = var.enable_caddy_proxy ? ["enabled"] : []
+          for_each = var.enable_caddy_proxy ? toset(["enabled"]) : toset([])
           content {
             name  = "caddy-proxy"
             image = var.caddy_image
@@ -353,7 +353,7 @@ resource "kubernetes_deployment" "dashboard" {
             }
 
             dynamic "volume_mount" {
-              for_each = var.caddy_mtls_ca_cert != "" ? ["enabled"] : []
+              for_each = var.caddy_mtls_ca_cert != "" ? toset(["enabled"]) : toset([])
               content {
                 name       = "caddy-mtls"
                 mount_path = "/etc/caddy/mtls"
@@ -362,7 +362,7 @@ resource "kubernetes_deployment" "dashboard" {
             }
 
             dynamic "env" {
-              for_each = var.caddy_tailscale_auth_key != "" ? ["enabled"] : []
+              for_each = var.caddy_tailscale_auth_key != "" ? toset(["enabled"]) : toset([])
               content {
                 name = "TS_AUTHKEY"
                 value_from {
@@ -463,7 +463,7 @@ resource "kubernetes_deployment" "dashboard" {
 
           # Mount environments config if provided
           dynamic "volume_mount" {
-            for_each = var.environments_config != "" ? ["enabled"] : []
+            for_each = var.environments_config != "" ? toset(["enabled"]) : toset([])
             content {
               name       = "environments-config"
               mount_path = "/etc/dashboard"
@@ -473,7 +473,7 @@ resource "kubernetes_deployment" "dashboard" {
 
           # Set config path env var when ConfigMap is mounted
           dynamic "env" {
-            for_each = var.environments_config != "" ? ["enabled"] : []
+            for_each = var.environments_config != "" ? toset(["enabled"]) : toset([])
             content {
               name  = "ENVIRONMENTS_CONFIG_PATH"
               value = "/etc/dashboard/environments.json"
@@ -488,7 +488,7 @@ resource "kubernetes_deployment" "dashboard" {
 
           # Bind SvelteKit to loopback when Caddy proxy is in front
           dynamic "env" {
-            for_each = var.enable_caddy_proxy ? ["enabled"] : []
+            for_each = var.enable_caddy_proxy ? toset(["enabled"]) : toset([])
             content {
               name  = "HOST"
               value = "127.0.0.1"
@@ -506,7 +506,7 @@ resource "kubernetes_deployment" "dashboard" {
 
         # Volume for environments ConfigMap
         dynamic "volume" {
-          for_each = var.environments_config != "" ? ["enabled"] : []
+          for_each = var.environments_config != "" ? toset(["enabled"]) : toset([])
           content {
             name = "environments-config"
             config_map {
@@ -517,7 +517,7 @@ resource "kubernetes_deployment" "dashboard" {
 
         # Volume for Caddyfile ConfigMap
         dynamic "volume" {
-          for_each = var.enable_caddy_proxy ? ["enabled"] : []
+          for_each = var.enable_caddy_proxy ? toset(["enabled"]) : toset([])
           content {
             name = "caddyfile"
             config_map {
@@ -528,7 +528,7 @@ resource "kubernetes_deployment" "dashboard" {
 
         # Volume for mTLS CA cert
         dynamic "volume" {
-          for_each = var.enable_caddy_proxy && var.caddy_mtls_ca_cert != "" ? ["enabled"] : []
+          for_each = var.enable_caddy_proxy && var.caddy_mtls_ca_cert != "" ? toset(["enabled"]) : toset([])
           content {
             name = "caddy-mtls"
             secret {
@@ -603,7 +603,7 @@ resource "kubernetes_ingress_v1" "dashboard" {
     ingress_class_name = var.ingress_class
 
     dynamic "tls" {
-      for_each = var.enable_tls ? ["enabled"] : []
+      for_each = var.enable_tls ? toset(["enabled"]) : toset([])
       content {
         hosts       = [var.ingress_host]
         secret_name = "${var.name}-tls"

--- a/tofu/modules/runner-dashboard/main.tf
+++ b/tofu/modules/runner-dashboard/main.tf
@@ -335,7 +335,7 @@ resource "kubernetes_deployment" "dashboard" {
 
         # Caddy reverse proxy sidecar container
         dynamic "container" {
-          for_each = var.enable_caddy_proxy ? [1] : []
+          for_each = var.enable_caddy_proxy ? ["enabled"] : []
           content {
             name  = "caddy-proxy"
             image = var.caddy_image
@@ -353,7 +353,7 @@ resource "kubernetes_deployment" "dashboard" {
             }
 
             dynamic "volume_mount" {
-              for_each = var.caddy_mtls_ca_cert != "" ? [1] : []
+              for_each = var.caddy_mtls_ca_cert != "" ? ["enabled"] : []
               content {
                 name       = "caddy-mtls"
                 mount_path = "/etc/caddy/mtls"
@@ -362,7 +362,7 @@ resource "kubernetes_deployment" "dashboard" {
             }
 
             dynamic "env" {
-              for_each = var.caddy_tailscale_auth_key != "" ? [1] : []
+              for_each = var.caddy_tailscale_auth_key != "" ? ["enabled"] : []
               content {
                 name = "TS_AUTHKEY"
                 value_from {
@@ -463,7 +463,7 @@ resource "kubernetes_deployment" "dashboard" {
 
           # Mount environments config if provided
           dynamic "volume_mount" {
-            for_each = var.environments_config != "" ? [1] : []
+            for_each = var.environments_config != "" ? ["enabled"] : []
             content {
               name       = "environments-config"
               mount_path = "/etc/dashboard"
@@ -473,7 +473,7 @@ resource "kubernetes_deployment" "dashboard" {
 
           # Set config path env var when ConfigMap is mounted
           dynamic "env" {
-            for_each = var.environments_config != "" ? [1] : []
+            for_each = var.environments_config != "" ? ["enabled"] : []
             content {
               name  = "ENVIRONMENTS_CONFIG_PATH"
               value = "/etc/dashboard/environments.json"
@@ -488,7 +488,7 @@ resource "kubernetes_deployment" "dashboard" {
 
           # Bind SvelteKit to loopback when Caddy proxy is in front
           dynamic "env" {
-            for_each = var.enable_caddy_proxy ? [1] : []
+            for_each = var.enable_caddy_proxy ? ["enabled"] : []
             content {
               name  = "HOST"
               value = "127.0.0.1"
@@ -506,7 +506,7 @@ resource "kubernetes_deployment" "dashboard" {
 
         # Volume for environments ConfigMap
         dynamic "volume" {
-          for_each = var.environments_config != "" ? [1] : []
+          for_each = var.environments_config != "" ? ["enabled"] : []
           content {
             name = "environments-config"
             config_map {
@@ -517,7 +517,7 @@ resource "kubernetes_deployment" "dashboard" {
 
         # Volume for Caddyfile ConfigMap
         dynamic "volume" {
-          for_each = var.enable_caddy_proxy ? [1] : []
+          for_each = var.enable_caddy_proxy ? ["enabled"] : []
           content {
             name = "caddyfile"
             config_map {
@@ -528,7 +528,7 @@ resource "kubernetes_deployment" "dashboard" {
 
         # Volume for mTLS CA cert
         dynamic "volume" {
-          for_each = var.enable_caddy_proxy && var.caddy_mtls_ca_cert != "" ? [1] : []
+          for_each = var.enable_caddy_proxy && var.caddy_mtls_ca_cert != "" ? ["enabled"] : []
           content {
             name = "caddy-mtls"
             secret {
@@ -603,7 +603,7 @@ resource "kubernetes_ingress_v1" "dashboard" {
     ingress_class_name = var.ingress_class
 
     dynamic "tls" {
-      for_each = var.enable_tls ? [1] : []
+      for_each = var.enable_tls ? ["enabled"] : []
       content {
         hosts       = [var.ingress_host]
         secret_name = "${var.name}-tls"

--- a/tofu/modules/runner-dashboard/main.tf
+++ b/tofu/modules/runner-dashboard/main.tf
@@ -353,7 +353,7 @@ resource "kubernetes_deployment" "dashboard" {
             }
 
             dynamic "volume_mount" {
-              for_each = var.caddy_mtls_ca_cert != "" ? toset(["enabled"]) : toset([])
+              for_each = { for k in ["mtls"] : k => k if var.caddy_mtls_ca_cert != "" }
               content {
                 name       = "caddy-mtls"
                 mount_path = "/etc/caddy/mtls"
@@ -362,7 +362,7 @@ resource "kubernetes_deployment" "dashboard" {
             }
 
             dynamic "env" {
-              for_each = var.caddy_tailscale_auth_key != "" ? toset(["enabled"]) : toset([])
+              for_each = { for k in ["ts"] : k => k if var.caddy_tailscale_auth_key != "" }
               content {
                 name = "TS_AUTHKEY"
                 value_from {

--- a/tofu/modules/runner-dashboard/templates/Caddyfile.tpl
+++ b/tofu/modules/runner-dashboard/templates/Caddyfile.tpl
@@ -1,0 +1,73 @@
+%{ if mode == "passthrough" ~}
+# Passthrough mode — simple reverse proxy
+:${port} {
+  reverse_proxy localhost:${backend_port}
+}
+%{ endif ~}
+
+%{ if mode == "mtls_only" ~}
+# mTLS mode — require client certificate
+:${port} {
+  tls {
+    client_auth {
+      mode ${mtls_client_auth_mode}
+      trust_pool file /etc/caddy/mtls/ca.pem
+    }
+  }
+
+  header_up X-Client-Cert-CN {tls_client_subject}
+  header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}
+  header_up X-Webauth-User {tls_client_subject}
+
+  reverse_proxy localhost:${backend_port}
+}
+%{ endif ~}
+
+%{ if mode == "tailscale_only" ~}
+# Tailscale mode — bind to Tailscale network only
+{
+  tailscale {
+    auth_key {env.TS_AUTHKEY}
+  }
+}
+
+:${port} {
+  bind tailscale/${tailscale_hostname}
+
+  @tailscale_auth {
+    remote_ip 100.64.0.0/10
+  }
+
+  header_up X-Webauth-User {http.auth.user.tailscale_user}
+  header_up X-Webauth-Email {http.auth.user.tailscale_user}
+
+  reverse_proxy localhost:${backend_port}
+}
+%{ endif ~}
+
+%{ if mode == "mtls_and_tailscale" ~}
+# Combined mTLS + Tailscale mode
+{
+  tailscale {
+    auth_key {env.TS_AUTHKEY}
+  }
+}
+
+:${port} {
+  bind tailscale/${tailscale_hostname}
+
+  tls {
+    client_auth {
+      mode ${mtls_client_auth_mode}
+      trust_pool file /etc/caddy/mtls/ca.pem
+    }
+  }
+
+  header_up X-Client-Cert-CN {tls_client_subject}
+  header_up X-Client-Cert-Fingerprint {tls_client_fingerprint}
+  header_up X-Webauth-User {tls_client_subject}
+  header_up X-Webauth-Email {http.auth.user.tailscale_user}
+
+  reverse_proxy localhost:${backend_port}
+}
+%{ endif ~}

--- a/tofu/modules/runner-dashboard/variables.tf
+++ b/tofu/modules/runner-dashboard/variables.tf
@@ -319,3 +319,115 @@ variable "environments_config" {
   type        = string
   default     = ""
 }
+
+# =============================================================================
+# Caddy Reverse Proxy Sidecar (mTLS / Tailscale)
+# =============================================================================
+
+variable "enable_caddy_proxy" {
+  description = "Enable Caddy reverse proxy sidecar for mTLS/Tailscale"
+  type        = bool
+  default     = false
+}
+
+variable "caddy_mode" {
+  description = "Caddy proxy mode: passthrough, mtls_only, tailscale_only, mtls_and_tailscale"
+  type        = string
+  default     = "passthrough"
+
+  validation {
+    condition     = contains(["passthrough", "mtls_only", "tailscale_only", "mtls_and_tailscale"], var.caddy_mode)
+    error_message = "caddy_mode must be one of: passthrough, mtls_only, tailscale_only, mtls_and_tailscale"
+  }
+}
+
+variable "caddy_image" {
+  description = "Container image for Caddy with Tailscale plugin"
+  type        = string
+  default     = "ghcr.io/jesssullivan/caddy-tailscale:latest"
+}
+
+variable "caddy_port" {
+  description = "Port Caddy listens on"
+  type        = number
+  default     = 8443
+}
+
+variable "caddy_mtls_ca_cert" {
+  description = "PEM-encoded CA certificate for mTLS client verification"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "caddy_mtls_client_auth_mode" {
+  description = "mTLS client auth mode (require_and_verify, request, require)"
+  type        = string
+  default     = "require_and_verify"
+}
+
+variable "caddy_tailscale_auth_key" {
+  description = "Tailscale auth key (ephemeral, reusable)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "caddy_tailscale_hostname" {
+  description = "Tailscale MagicDNS hostname for the dashboard"
+  type        = string
+  default     = "runner-dashboard"
+}
+
+variable "caddy_cpu_request" {
+  description = "CPU request for Caddy sidecar"
+  type        = string
+  default     = "10m"
+}
+
+variable "caddy_cpu_limit" {
+  description = "CPU limit for Caddy sidecar"
+  type        = string
+  default     = "100m"
+}
+
+variable "caddy_memory_request" {
+  description = "Memory request for Caddy sidecar"
+  type        = string
+  default     = "32Mi"
+}
+
+variable "caddy_memory_limit" {
+  description = "Memory limit for Caddy sidecar"
+  type        = string
+  default     = "64Mi"
+}
+
+variable "trust_proxy_headers" {
+  description = "Trust X-Webauth-* identity headers from Caddy proxy"
+  type        = bool
+  default     = false
+}
+
+# =============================================================================
+# WebAuthn / FIDO2 Configuration
+# =============================================================================
+
+variable "webauthn_rp_id" {
+  description = "WebAuthn Relying Party ID (must match the domain users access)"
+  type        = string
+  default     = ""
+}
+
+variable "webauthn_rp_name" {
+  description = "WebAuthn Relying Party display name"
+  type        = string
+  default     = "Runner Dashboard"
+}
+
+variable "database_url" {
+  description = "PostgreSQL connection URL for WebAuthn credential storage"
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/tofu/stacks/runner-dashboard/main.tf
+++ b/tofu/stacks/runner-dashboard/main.tf
@@ -101,6 +101,26 @@ module "runner_dashboard" {
 
   # Runtime environment config
   environments_config = var.environments_config
+
+  # Caddy proxy sidecar
+  enable_caddy_proxy          = var.enable_caddy_proxy
+  caddy_mode                  = var.caddy_mode
+  caddy_image                 = var.caddy_image
+  caddy_port                  = var.caddy_port
+  caddy_mtls_ca_cert          = var.caddy_mtls_ca_cert
+  caddy_mtls_client_auth_mode = var.caddy_mtls_client_auth_mode
+  caddy_tailscale_auth_key    = var.caddy_tailscale_auth_key
+  caddy_tailscale_hostname    = var.caddy_tailscale_hostname
+  caddy_cpu_request           = var.caddy_cpu_request
+  caddy_cpu_limit             = var.caddy_cpu_limit
+  caddy_memory_request        = var.caddy_memory_request
+  caddy_memory_limit          = var.caddy_memory_limit
+  trust_proxy_headers         = var.trust_proxy_headers
+
+  # WebAuthn / FIDO2
+  webauthn_rp_id   = var.webauthn_rp_id
+  webauthn_rp_name = var.webauthn_rp_name
+  database_url     = var.database_url
 }
 
 # =============================================================================

--- a/tofu/stacks/runner-dashboard/variables.tf
+++ b/tofu/stacks/runner-dashboard/variables.tf
@@ -266,3 +266,110 @@ variable "environments_config" {
   type        = string
   default     = ""
 }
+
+# =============================================================================
+# Caddy Reverse Proxy Sidecar
+# =============================================================================
+
+variable "enable_caddy_proxy" {
+  description = "Enable Caddy reverse proxy sidecar for mTLS/Tailscale"
+  type        = bool
+  default     = false
+}
+
+variable "caddy_mode" {
+  description = "Caddy proxy mode: passthrough, mtls_only, tailscale_only, mtls_and_tailscale"
+  type        = string
+  default     = "passthrough"
+}
+
+variable "caddy_image" {
+  description = "Container image for Caddy with Tailscale plugin"
+  type        = string
+  default     = "ghcr.io/jesssullivan/caddy-tailscale:latest"
+}
+
+variable "caddy_port" {
+  description = "Port Caddy listens on"
+  type        = number
+  default     = 8443
+}
+
+variable "caddy_mtls_ca_cert" {
+  description = "PEM-encoded CA certificate for mTLS client verification"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "caddy_mtls_client_auth_mode" {
+  description = "mTLS client auth mode"
+  type        = string
+  default     = "require_and_verify"
+}
+
+variable "caddy_tailscale_auth_key" {
+  description = "Tailscale auth key (ephemeral, reusable)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "caddy_tailscale_hostname" {
+  description = "Tailscale MagicDNS hostname for the dashboard"
+  type        = string
+  default     = "runner-dashboard"
+}
+
+variable "caddy_cpu_request" {
+  description = "CPU request for Caddy sidecar"
+  type        = string
+  default     = "10m"
+}
+
+variable "caddy_cpu_limit" {
+  description = "CPU limit for Caddy sidecar"
+  type        = string
+  default     = "100m"
+}
+
+variable "caddy_memory_request" {
+  description = "Memory request for Caddy sidecar"
+  type        = string
+  default     = "32Mi"
+}
+
+variable "caddy_memory_limit" {
+  description = "Memory limit for Caddy sidecar"
+  type        = string
+  default     = "64Mi"
+}
+
+variable "trust_proxy_headers" {
+  description = "Trust X-Webauth-* identity headers from Caddy proxy"
+  type        = bool
+  default     = false
+}
+
+# =============================================================================
+# WebAuthn / FIDO2 Configuration
+# =============================================================================
+
+variable "webauthn_rp_id" {
+  description = "WebAuthn Relying Party ID (must match the domain)"
+  type        = string
+  default     = ""
+}
+
+variable "webauthn_rp_name" {
+  description = "WebAuthn Relying Party display name"
+  type        = string
+  default     = "Runner Dashboard"
+}
+
+variable "database_url" {
+  description = "PostgreSQL connection URL for WebAuthn credential storage"
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- Adds feature-flagged Caddy sidecar container to runner-dashboard module
- Supports 4 modes: `passthrough`, `mtls_only`, `tailscale_only`, `mtls_and_tailscale`
- Off by default (`enable_caddy_proxy = false`) — zero impact on existing deployments
- Includes Caddyfile template, mTLS CA cert handling, Tailscale auth key management
- Adds `trust_proxy_headers` for X-Webauth-* identity header passthrough

## Test plan
- [ ] `tofu validate` passes on runner-dashboard module
- [ ] `tofu plan` with `enable_caddy_proxy=false` shows no sidecar resources
- [ ] `tofu plan` with `enable_caddy_proxy=true` shows init_container, ConfigMap, Secret
- [ ] Existing Bates deployment unaffected (caddy disabled by default)

Replaces #35 (auto-closed when base branch was squash-merged).
