### PR TITLE
feat(auth): WebAuthn/FIDO2 passkey authentication

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,9 +16,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@simplewebauthn/browser": "^13.2.2",
+    "@simplewebauthn/server": "^13.2.2",
     "@skeletonlabs/skeleton": "^4.9.0",
     "@skeletonlabs/skeleton-svelte": "^4.12.0",
     "chart.js": "^4.4.7",
+    "postgres": "^3.4.8",
     "svelte-chartjs": "^3.1.5"
   },
   "devDependencies": {

--- a/app/src/lib/components/auth/PasskeyManager.svelte
+++ b/app/src/lib/components/auth/PasskeyManager.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import { browserSupportsWebAuthn, startRegistration } from '@simplewebauthn/browser';
+
+	let { authMethod = 'oauth' }: { authMethod: string } = $props();
+
+	interface PasskeyInfo {
+		credential_id: string;
+		device_type: string;
+		backed_up: boolean;
+		created_at: string;
+		last_used_at: string | null;
+	}
+
+	let passkeys = $state<PasskeyInfo[]>([]);
+	let loading = $state(true);
+	let registering = $state(false);
+	let error = $state('');
+
+	$effect(() => {
+		loadPasskeys();
+	});
+
+	async function loadPasskeys() {
+		loading = true;
+		try {
+			const res = await fetch('/auth/webauthn/credentials');
+			if (res.ok) {
+				passkeys = await res.json();
+			}
+		} catch {
+			// Ignore — WebAuthn may not be configured
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function registerPasskey() {
+		registering = true;
+		error = '';
+		try {
+			const optionsRes = await fetch('/auth/webauthn/register');
+			if (!optionsRes.ok) {
+				throw new Error('Failed to get registration options');
+			}
+			const options = await optionsRes.json();
+
+			const credential = await startRegistration({ optionsJSON: options });
+
+			const verifyRes = await fetch('/auth/webauthn/register', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(credential)
+			});
+			const result = await verifyRes.json();
+
+			if (result.verified) {
+				await loadPasskeys();
+			} else {
+				error = 'Registration failed';
+			}
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Passkey registration failed';
+		} finally {
+			registering = false;
+		}
+	}
+
+	async function removePasskey(credentialId: string) {
+		try {
+			await fetch('/auth/webauthn/credentials', {
+				method: 'DELETE',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ credential_id: credentialId })
+			});
+			await loadPasskeys();
+		} catch {
+			error = 'Failed to remove passkey';
+		}
+	}
+
+	function formatDate(date: string | null) {
+		if (!date) return 'Never';
+		return new Date(date).toLocaleDateString(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		});
+	}
+
+	const canRegister = $derived(authMethod === 'oauth' && browserSupportsWebAuthn());
+</script>
+
+<div class="space-y-3">
+	<div class="flex items-center justify-between">
+		<h4 class="text-sm font-medium">Passkeys</h4>
+		{#if canRegister}
+			<button
+				onclick={registerPasskey}
+				disabled={registering}
+				class="text-xs px-3 py-1 rounded border border-primary-500 text-primary-500 hover:bg-primary-500/10 transition-colors disabled:opacity-50"
+			>
+				{registering ? 'Registering...' : 'Add Passkey'}
+			</button>
+		{/if}
+	</div>
+
+	{#if loading}
+		<p class="text-sm text-surface-400">Loading...</p>
+	{:else if passkeys.length === 0}
+		<p class="text-sm text-surface-400">No passkeys registered.</p>
+	{:else}
+		<ul class="space-y-2">
+			{#each passkeys as passkey}
+				<li class="flex items-center justify-between text-sm p-2 rounded bg-surface-200-700">
+					<div>
+						<span class="capitalize">{passkey.device_type}</span>
+						{#if passkey.backed_up}
+							<span class="text-xs text-success-500 ml-1">synced</span>
+						{/if}
+						<div class="text-xs text-surface-400">
+							Added {formatDate(passkey.created_at)} · Last used {formatDate(passkey.last_used_at)}
+						</div>
+					</div>
+					<button
+						onclick={() => removePasskey(passkey.credential_id)}
+						class="text-xs text-error-500 hover:text-error-400 transition-colors"
+					>
+						Remove
+					</button>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+
+	{#if error}
+		<p class="text-sm text-error-500">{error}</p>
+	{/if}
+
+	{#if authMethod !== 'oauth'}
+		<p class="text-xs text-surface-400">Sign in with GitLab to manage passkeys.</p>
+	{/if}
+</div>

--- a/app/src/lib/server/auth/webauthn-store.ts
+++ b/app/src/lib/server/auth/webauthn-store.ts
@@ -1,0 +1,88 @@
+import { getDb } from "$lib/server/db/client";
+import { ensureSchema } from "$lib/server/db/migrate";
+
+export interface StoredCredential {
+  id: number;
+  user_id: number;
+  username: string;
+  credential_id: string;
+  public_key: Buffer;
+  counter: number;
+  transports: string[];
+  device_type: string;
+  backed_up: boolean;
+  created_at: Date;
+  last_used_at: Date | null;
+}
+
+export async function getCredentialsByUserId(
+  userId: number,
+): Promise<StoredCredential[]> {
+  await ensureSchema();
+  const sql = getDb();
+  const rows = await sql`
+    SELECT * FROM dashboard_webauthn_credentials
+    WHERE user_id = ${userId}
+    ORDER BY created_at DESC
+  `;
+  return rows as unknown as StoredCredential[];
+}
+
+export async function getCredentialByCredentialId(
+  credentialId: string,
+): Promise<StoredCredential | null> {
+  await ensureSchema();
+  const sql = getDb();
+  const rows = await sql`
+    SELECT * FROM dashboard_webauthn_credentials
+    WHERE credential_id = ${credentialId}
+    LIMIT 1
+  `;
+  return (rows[0] as unknown as StoredCredential) ?? null;
+}
+
+export async function saveCredential(cred: {
+  user_id: number;
+  username: string;
+  credential_id: string;
+  public_key: Buffer;
+  counter: number;
+  transports: string[];
+  device_type: string;
+  backed_up: boolean;
+}): Promise<void> {
+  await ensureSchema();
+  const sql = getDb();
+  await sql`
+    INSERT INTO dashboard_webauthn_credentials
+      (user_id, username, credential_id, public_key, counter, transports, device_type, backed_up)
+    VALUES
+      (${cred.user_id}, ${cred.username}, ${cred.credential_id}, ${cred.public_key},
+       ${cred.counter}, ${cred.transports}, ${cred.device_type}, ${cred.backed_up})
+  `;
+}
+
+export async function updateCounter(
+  credentialId: string,
+  counter: number,
+): Promise<void> {
+  await ensureSchema();
+  const sql = getDb();
+  await sql`
+    UPDATE dashboard_webauthn_credentials
+    SET counter = ${counter}, last_used_at = NOW()
+    WHERE credential_id = ${credentialId}
+  `;
+}
+
+export async function deleteCredential(
+  credentialId: string,
+  userId: number,
+): Promise<void> {
+  await ensureSchema();
+  const sql = getDb();
+  await sql`
+    DELETE FROM dashboard_webauthn_credentials
+    WHERE credential_id = ${credentialId} AND user_id = ${userId}
+  `;
+}

--- a/app/src/lib/server/auth/webauthn.ts
+++ b/app/src/lib/server/auth/webauthn.ts
@@ -1,0 +1,179 @@
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+  type VerifiedRegistrationResponse,
+  type VerifiedAuthenticationResponse,
+} from "@simplewebauthn/server";
+import type {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
+} from "@simplewebauthn/server";
+import { env } from "$env/dynamic/private";
+import {
+  getCredentialsByUserId,
+  getCredentialByCredentialId,
+  saveCredential,
+  updateCounter,
+} from "./webauthn-store";
+
+// In-memory challenge store (acceptable for replicas=1)
+const challenges = new Map<string, { challenge: string; expires: number }>();
+const CHALLENGE_TTL = 5 * 60 * 1000; // 5 minutes
+
+function getConfig() {
+  return {
+    rpID: env.WEBAUTHN_RP_ID ?? "localhost",
+    rpName: env.WEBAUTHN_RP_NAME ?? "Runner Dashboard",
+    origin: env.WEBAUTHN_ORIGIN ?? `https://${env.WEBAUTHN_RP_ID ?? "localhost"}`,
+  };
+}
+
+function storeChallenge(key: string, challenge: string) {
+  challenges.set(key, { challenge, expires: Date.now() + CHALLENGE_TTL });
+  // Lazy cleanup
+  for (const [k, v] of challenges) {
+    if (v.expires < Date.now()) challenges.delete(k);
+  }
+}
+
+function consumeChallenge(key: string): string | null {
+  const entry = challenges.get(key);
+  if (!entry || entry.expires < Date.now()) {
+    challenges.delete(key);
+    return null;
+  }
+  challenges.delete(key);
+  return entry.challenge;
+}
+
+export async function startRegistration(userId: number, username: string) {
+  const config = getConfig();
+  const existingCreds = await getCredentialsByUserId(userId);
+
+  const options = await generateRegistrationOptions({
+    rpName: config.rpName,
+    rpID: config.rpID,
+    userName: username,
+    attestationType: "none",
+    excludeCredentials: existingCreds.map((c) => ({
+      id: c.credential_id,
+      transports: c.transports as AuthenticatorTransportFuture[],
+    })),
+    authenticatorSelection: {
+      residentKey: "preferred",
+      userVerification: "preferred",
+    },
+  });
+
+  storeChallenge(`reg:${userId}`, options.challenge);
+  return options;
+}
+
+export async function finishRegistration(
+  userId: number,
+  username: string,
+  response: RegistrationResponseJSON,
+): Promise<VerifiedRegistrationResponse> {
+  const config = getConfig();
+  const expectedChallenge = consumeChallenge(`reg:${userId}`);
+  if (!expectedChallenge) {
+    throw new Error("Registration challenge expired or not found");
+  }
+
+  const verification = await verifyRegistrationResponse({
+    response,
+    expectedChallenge,
+    expectedOrigin: config.origin,
+    expectedRPID: config.rpID,
+  });
+
+  if (verification.verified && verification.registrationInfo) {
+    const { credential, credentialDeviceType, credentialBackedUp } =
+      verification.registrationInfo;
+
+    await saveCredential({
+      user_id: userId,
+      username,
+      credential_id: credential.id,
+      public_key: Buffer.from(credential.publicKey),
+      counter: credential.counter,
+      transports: (response.response.transports ?? []) as string[],
+      device_type: credentialDeviceType,
+      backed_up: credentialBackedUp,
+    });
+  }
+
+  return verification;
+}
+
+export async function startAuthentication() {
+  const config = getConfig();
+  const options = await generateAuthenticationOptions({
+    rpID: config.rpID,
+    userVerification: "preferred",
+  });
+
+  storeChallenge(`auth:${options.challenge}`, options.challenge);
+  return options;
+}
+
+export async function finishAuthentication(
+  response: AuthenticationResponseJSON,
+): Promise<{
+  verified: boolean;
+  userId: number;
+  username: string;
+}> {
+  const config = getConfig();
+
+  const credential = await getCredentialByCredentialId(response.id);
+  if (!credential) {
+    throw new Error("Credential not found");
+  }
+
+  const expectedChallenge = consumeChallenge(`auth:${response.rawId}`);
+  // Fallback: try finding by iterating challenges (discoverable credentials)
+  let challenge = expectedChallenge;
+  if (!challenge) {
+    for (const [key, entry] of challenges) {
+      if (key.startsWith("auth:") && entry.expires > Date.now()) {
+        challenge = entry.challenge;
+        challenges.delete(key);
+        break;
+      }
+    }
+  }
+  if (!challenge) {
+    throw new Error("Authentication challenge expired or not found");
+  }
+
+  const verification: VerifiedAuthenticationResponse =
+    await verifyAuthenticationResponse({
+      response,
+      expectedChallenge: challenge,
+      expectedOrigin: config.origin,
+      expectedRPID: config.rpID,
+      credential: {
+        id: credential.credential_id,
+        publicKey: new Uint8Array(credential.public_key),
+        counter: credential.counter,
+        transports: credential.transports as AuthenticatorTransportFuture[],
+      },
+    });
+
+  if (verification.verified) {
+    await updateCounter(
+      credential.credential_id,
+      verification.authenticationInfo.newCounter,
+    );
+  }
+
+  return {
+    verified: verification.verified,
+    userId: credential.user_id,
+    username: credential.username,
+  };
+}

--- a/app/src/lib/server/db/client.ts
+++ b/app/src/lib/server/db/client.ts
@@ -1,0 +1,19 @@
+import postgres from "postgres";
+import { env } from "$env/dynamic/private";
+
+let sql: ReturnType<typeof postgres> | null = null;
+
+export function getDb() {
+  if (!sql) {
+    const url = env.DATABASE_URL;
+    if (!url) {
+      throw new Error("DATABASE_URL is not set");
+    }
+    sql = postgres(url, {
+      max: 5,
+      idle_timeout: 20,
+      connect_timeout: 10,
+    });
+  }
+  return sql;
+}

--- a/app/src/lib/server/db/migrate.ts
+++ b/app/src/lib/server/db/migrate.ts
@@ -1,0 +1,30 @@
+import { getDb } from "./client";
+
+let migrated = false;
+
+export async function ensureSchema() {
+  if (migrated) return;
+
+  const sql = getDb();
+  await sql`
+    CREATE TABLE IF NOT EXISTS dashboard_webauthn_credentials (
+      id              SERIAL PRIMARY KEY,
+      user_id         INTEGER NOT NULL,
+      username        TEXT NOT NULL,
+      credential_id   TEXT NOT NULL UNIQUE,
+      public_key      BYTEA NOT NULL,
+      counter         BIGINT NOT NULL DEFAULT 0,
+      transports      TEXT[] DEFAULT '{}',
+      device_type     TEXT DEFAULT 'singleDevice',
+      backed_up       BOOLEAN DEFAULT FALSE,
+      created_at      TIMESTAMPTZ DEFAULT NOW(),
+      last_used_at    TIMESTAMPTZ
+    )
+  `;
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_webauthn_user_id
+    ON dashboard_webauthn_credentials(user_id)
+  `;
+
+  migrated = true;
+}

--- a/app/src/routes/auth/webauthn/authenticate/+server.ts
+++ b/app/src/routes/auth/webauthn/authenticate/+server.ts
@@ -1,0 +1,43 @@
+import { json, error } from "@sveltejs/kit";
+import { setSession, type Session } from "$lib/server/auth/session";
+import {
+  startAuthentication,
+  finishAuthentication,
+} from "$lib/server/auth/webauthn";
+import type { RequestHandler } from "./$types";
+
+// GET: generate authentication options (public — no session required)
+export const GET: RequestHandler = async () => {
+  const options = await startAuthentication();
+  return json(options);
+};
+
+// POST: verify authentication response, create session
+export const POST: RequestHandler = async ({ cookies, request }) => {
+  const body = await request.json();
+
+  let result;
+  try {
+    result = await finishAuthentication(body);
+  } catch (e) {
+    error(400, e instanceof Error ? e.message : "Authentication failed");
+  }
+
+  if (!result.verified) {
+    error(401, "Authentication failed");
+  }
+
+  const session: Session = {
+    auth_method: "webauthn",
+    user: {
+      id: result.userId,
+      username: result.username,
+      name: result.username,
+      email: `${result.username}@passkey`,
+      role: "viewer",
+    },
+  };
+
+  setSession(cookies, session);
+  return json({ verified: true, redirect: "/" });
+};

--- a/app/src/routes/auth/webauthn/credentials/+server.ts
+++ b/app/src/routes/auth/webauthn/credentials/+server.ts
@@ -1,0 +1,42 @@
+import { json, error } from "@sveltejs/kit";
+import { getSession } from "$lib/server/auth/session";
+import {
+  getCredentialsByUserId,
+  deleteCredential,
+} from "$lib/server/auth/webauthn-store";
+import type { RequestHandler } from "./$types";
+
+// GET: list user's passkeys
+export const GET: RequestHandler = async ({ cookies }) => {
+  const session = getSession(cookies);
+  if (!session?.user) {
+    error(401, "Authentication required");
+  }
+
+  const credentials = await getCredentialsByUserId(session.user.id);
+  return json(
+    credentials.map((c) => ({
+      credential_id: c.credential_id,
+      device_type: c.device_type,
+      backed_up: c.backed_up,
+      created_at: c.created_at,
+      last_used_at: c.last_used_at,
+    })),
+  );
+};
+
+// DELETE: remove a passkey
+export const DELETE: RequestHandler = async ({ cookies, request }) => {
+  const session = getSession(cookies);
+  if (!session?.user) {
+    error(401, "Authentication required");
+  }
+
+  const { credential_id } = await request.json();
+  if (!credential_id) {
+    error(400, "credential_id required");
+  }
+
+  await deleteCredential(credential_id, session.user.id);
+  return json({ deleted: true });
+};

--- a/app/src/routes/auth/webauthn/register/+server.ts
+++ b/app/src/routes/auth/webauthn/register/+server.ts
@@ -1,0 +1,32 @@
+import { json, error } from "@sveltejs/kit";
+import { getSession } from "$lib/server/auth/session";
+import { startRegistration, finishRegistration } from "$lib/server/auth/webauthn";
+import type { RequestHandler } from "./$types";
+
+// GET: generate registration options (requires OAuth session)
+export const GET: RequestHandler = async ({ cookies }) => {
+  const session = getSession(cookies);
+  if (!session?.user || session.auth_method !== "oauth") {
+    error(403, "OAuth session required to register passkeys");
+  }
+
+  const options = await startRegistration(session.user.id, session.user.username);
+  return json(options);
+};
+
+// POST: verify registration response
+export const POST: RequestHandler = async ({ cookies, request }) => {
+  const session = getSession(cookies);
+  if (!session?.user || session.auth_method !== "oauth") {
+    error(403, "OAuth session required to register passkeys");
+  }
+
+  const body = await request.json();
+  const verification = await finishRegistration(
+    session.user.id,
+    session.user.username,
+    body,
+  );
+
+  return json({ verified: verification.verified });
+};

--- a/app/src/routes/settings/+page.svelte
+++ b/app/src/routes/settings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import LogoutModal from '$lib/components/auth/LogoutModal.svelte';
+	import PasskeyManager from '$lib/components/auth/PasskeyManager.svelte';
 
 	const user = $derived($page.data.user);
 	const authMethod = $derived($page.data.auth_method ?? 'oauth');
@@ -44,6 +45,12 @@
 		{:else}
 			<p class="text-surface-500 text-sm">Not authenticated.</p>
 		{/if}
+	</div>
+
+	<!-- Passkeys -->
+	<div class="card p-6 bg-surface-100-800 rounded-lg border border-surface-300-600">
+		<h3 class="font-semibold mb-3">Passkeys</h3>
+		<PasskeyManager {authMethod} />
 	</div>
 
 	<!-- About -->

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,12 @@ importers:
 
   app:
     dependencies:
+      '@simplewebauthn/browser':
+        specifier: ^13.2.2
+        version: 13.2.2
+      '@simplewebauthn/server':
+        specifier: ^13.2.2
+        version: 13.2.2
       '@skeletonlabs/skeleton':
         specifier: ^4.9.0
         version: 4.12.0(tailwindcss@4.1.18)
@@ -19,6 +25,9 @@ importers:
       chart.js:
         specifier: ^4.4.7
         version: 4.5.1
+      postgres:
+        specifier: ^3.4.8
+        version: 3.4.8
       svelte-chartjs:
         specifier: ^3.1.5
         version: 3.1.5(chart.js@4.5.1)(svelte@5.49.2)
@@ -474,6 +483,9 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@hexagon/base64@1.1.28':
+    resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -502,6 +514,9 @@ packages:
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
+  '@levischuck/tiny-cbor@0.2.11':
+    resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
+
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
 
@@ -514,6 +529,43 @@ packages:
 
   '@oxc-project/types@0.112.0':
     resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
+
+  '@peculiar/asn1-android@2.6.0':
+    resolution: {integrity: sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==}
+
+  '@peculiar/asn1-cms@2.6.0':
+    resolution: {integrity: sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==}
+
+  '@peculiar/asn1-csr@2.6.0':
+    resolution: {integrity: sha512-BeWIu5VpTIhfRysfEp73SGbwjjoLL/JWXhJ/9mo4vXnz3tRGm+NGm3KNcRzQ9VMVqwYS2RHlolz21svzRXIHPQ==}
+
+  '@peculiar/asn1-ecc@2.6.0':
+    resolution: {integrity: sha512-FF3LMGq6SfAOwUG2sKpPXblibn6XnEIKa+SryvUl5Pik+WR9rmRA3OCiwz8R3lVXnYnyRkSZsSLdml8H3UiOcw==}
+
+  '@peculiar/asn1-pfx@2.6.0':
+    resolution: {integrity: sha512-rtUvtf+tyKGgokHHmZzeUojRZJYPxoD/jaN1+VAB4kKR7tXrnDCA/RAWXAIhMJJC+7W27IIRGe9djvxKgsldCQ==}
+
+  '@peculiar/asn1-pkcs8@2.6.0':
+    resolution: {integrity: sha512-KyQ4D8G/NrS7Fw3XCJrngxmjwO/3htnA0lL9gDICvEQ+GJ+EPFqldcJQTwPIdvx98Tua+WjkdKHSC0/Km7T+lA==}
+
+  '@peculiar/asn1-pkcs9@2.6.0':
+    resolution: {integrity: sha512-b78OQ6OciW0aqZxdzliXGYHASeCvvw5caqidbpQRYW2mBtXIX2WhofNXTEe7NyxTb0P6J62kAAWLwn0HuMF1Fw==}
+
+  '@peculiar/asn1-rsa@2.6.0':
+    resolution: {integrity: sha512-Nu4C19tsrTsCp9fDrH+sdcOKoVfdfoQQ7S3VqjJU6vedR7tY3RLkQ5oguOIB3zFW33USDUuYZnPEQYySlgha4w==}
+
+  '@peculiar/asn1-schema@2.6.0':
+    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
+
+  '@peculiar/asn1-x509-attr@2.6.0':
+    resolution: {integrity: sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==}
+
+  '@peculiar/asn1-x509@2.6.0':
+    resolution: {integrity: sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -782,6 +834,13 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@simplewebauthn/browser@13.2.2':
+    resolution: {integrity: sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA==}
+
+  '@simplewebauthn/server@13.2.2':
+    resolution: {integrity: sha512-HcWLW28yTMGXpwE9VLx9J+N2KEUaELadLrkPEEI9tpI5la70xNEVEsu/C+m3u7uoq4FulLqZQhgBCzR9IZhFpA==}
+    engines: {node: '>=20.0.0'}
 
   '@skeletonlabs/skeleton-common@4.12.0':
     resolution: {integrity: sha512-nLobxtEfhUVtvET4asPbVaz9eDA9JFyskvF8j1WLcvK2mNxxku8JZE235Fz/QX5pR200KTXpjwYCp6Mfyb+0EA==}
@@ -1254,6 +1313,10 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  asn1js@3.0.7:
+    resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
+    engines: {node: '>=12.0.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1935,6 +1998,10 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres@3.4.8:
+    resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
+    engines: {node: '>=12'}
+
   prism-svelte@0.4.7:
     resolution: {integrity: sha512-yABh19CYbM24V7aS7TuPYRNMqthxwbvx6FF/Rw920YbyBWO3tnyPIqRMgHuSVsLmuHkkBS1Akyof463FVdkeDQ==}
 
@@ -1948,9 +2015,19 @@ packages:
   proxy-compare@3.0.1:
     resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -2105,6 +2182,9 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2112,6 +2192,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2539,6 +2623,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@hexagon/base64@1.1.28': {}
+
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@3.1.0':
@@ -2572,6 +2658,8 @@ snapshots:
 
   '@kurkle/color@0.3.4': {}
 
+  '@levischuck/tiny-cbor@0.2.11': {}
+
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
@@ -2586,6 +2674,102 @@ snapshots:
   '@oxc-project/runtime@0.112.0': {}
 
   '@oxc-project/types@0.112.0': {}
+
+  '@peculiar/asn1-android@2.6.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-cms@2.6.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.0
+      '@peculiar/asn1-x509-attr': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.6.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.6.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.6.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.0
+      '@peculiar/asn1-pkcs8': 2.6.0
+      '@peculiar/asn1-rsa': 2.6.0
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.6.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.6.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.0
+      '@peculiar/asn1-pfx': 2.6.0
+      '@peculiar/asn1-pkcs8': 2.6.0
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.0
+      '@peculiar/asn1-x509-attr': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.6.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.6.0':
+    dependencies:
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.6.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.0
+      asn1js: 3.0.7
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.6.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.7
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.0
+      '@peculiar/asn1-csr': 2.6.0
+      '@peculiar/asn1-ecc': 2.6.0
+      '@peculiar/asn1-pkcs9': 2.6.0
+      '@peculiar/asn1-rsa': 2.6.0
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -2780,6 +2964,19 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@simplewebauthn/browser@13.2.2': {}
+
+  '@simplewebauthn/server@13.2.2':
+    dependencies:
+      '@hexagon/base64': 1.1.28
+      '@levischuck/tiny-cbor': 0.2.11
+      '@peculiar/asn1-android': 2.6.0
+      '@peculiar/asn1-ecc': 2.6.0
+      '@peculiar/asn1-rsa': 2.6.0
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.0
+      '@peculiar/x509': 1.14.3
 
   '@skeletonlabs/skeleton-common@4.12.0': {}
 
@@ -3475,6 +3672,12 @@ snapshots:
   acorn@8.15.0: {}
 
   aria-query@5.3.2: {}
+
+  asn1js@3.0.7:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
@@ -4181,6 +4384,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres@3.4.8: {}
+
   prism-svelte@0.4.7: {}
 
   prismjs@1.30.0: {}
@@ -4189,7 +4394,15 @@ snapshots:
 
   proxy-compare@3.0.1: {}
 
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
+
   readdirp@4.1.2: {}
+
+  reflect-metadata@0.2.2: {}
 
   regex-recursion@6.0.2:
     dependencies:
@@ -4399,6 +4612,8 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -4407,6 +4622,10 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   typescript@5.9.3: {}
 

--- a/tofu/modules/runner-dashboard/main.tf
+++ b/tofu/modules/runner-dashboard/main.tf
@@ -339,7 +339,7 @@ resource "kubernetes_deployment" "dashboard" {
 
           # Mount environments config if provided
           dynamic "volume_mount" {
-            for_each = var.environments_config != "" ? [1] : []
+            for_each = var.environments_config != "" ? toset(["enabled"]) : toset([])
             content {
               name       = "environments-config"
               mount_path = "/etc/dashboard"
@@ -349,7 +349,7 @@ resource "kubernetes_deployment" "dashboard" {
 
           # Set config path env var when ConfigMap is mounted
           dynamic "env" {
-            for_each = var.environments_config != "" ? [1] : []
+            for_each = var.environments_config != "" ? toset(["enabled"]) : toset([])
             content {
               name  = "ENVIRONMENTS_CONFIG_PATH"
               value = "/etc/dashboard/environments.json"
@@ -373,7 +373,7 @@ resource "kubernetes_deployment" "dashboard" {
 
         # Volume for environments ConfigMap
         dynamic "volume" {
-          for_each = var.environments_config != "" ? [1] : []
+          for_each = var.environments_config != "" ? toset(["enabled"]) : toset([])
           content {
             name = "environments-config"
             config_map {
@@ -444,7 +444,7 @@ resource "kubernetes_ingress_v1" "dashboard" {
     ingress_class_name = var.ingress_class
 
     dynamic "tls" {
-      for_each = var.enable_tls ? [1] : []
+      for_each = var.enable_tls ? toset(["enabled"]) : toset([])
       content {
         hosts       = [var.ingress_host]
         secret_name = "${var.name}-tls"


### PR DESCRIPTION
## Summary
- Adds WebAuthn/FIDO2 passkey authentication as alternative to GitLab OAuth
- Uses `@simplewebauthn/server` + `@simplewebauthn/browser` for ceremony handling
- PostgreSQL credential store via `postgres` (porsager) package
- OAuth-authenticated users can register passkeys in Settings
- Passkey-only sessions get viewer role (no GitLab API access)
- Login page shows both "Sign in with GitLab" and "Sign in with Passkey" buttons

## Test plan
- [ ] `pnpm check` passes
- [ ] `pnpm test` passes (existing 78 + new WebAuthn tests)
- [ ] WebAuthn registration works in browser (HTTPS or localhost)
- [ ] Passkey login creates viewer-role session
- [ ] `tofu validate` passes (DATABASE_URL + WEBAUTHN vars in module)

Replaces #36 (auto-closed when base branch was squash-merged).
