### PR TITLE
ci(images): add caddy-tailscale image to build workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,4 +1,4 @@
-name: Build Runner Dashboard Image
+name: Build Container Images
 
 on:
   push:
@@ -11,6 +11,7 @@ on:
       - "package.json"
       - ".npmrc"
       - "app/Dockerfile"
+      - "app/caddy/Dockerfile"
   workflow_dispatch:
 
 permissions:
@@ -18,8 +19,8 @@ permissions:
   packages: write
 
 jobs:
-  build-and-push:
-    name: Build and Push to GHCR
+  dashboard:
+    name: Build Runner Dashboard
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,3 +49,34 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/Jesssullivan/attic-iac
             org.opencontainers.image.description=Runner Dashboard
+
+  caddy-tailscale:
+    name: Build Caddy Tailscale Proxy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: app/caddy
+          file: app/caddy/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jesssullivan/caddy-tailscale:latest
+            ghcr.io/jesssullivan/caddy-tailscale:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/Jesssullivan/attic-iac
+            org.opencontainers.image.description=Caddy with Tailscale plugin for mTLS/TS proxy


### PR DESCRIPTION
Add parallel job to build and push ghcr.io/jesssullivan/caddy-tailscale alongside the runner-dashboard image.