### PR TITLE
fix(caddy): disable setcap to work with dropped capabilities

### DIFF
--- a/app/caddy/Dockerfile
+++ b/app/caddy/Dockerfile
@@ -1,4 +1,5 @@
 FROM caddy:2.10-builder AS builder
+ENV XCADDY_SETCAP=0
 RUN xcaddy build --with github.com/tailscale/caddy-tailscale
 
 FROM caddy:2.10-alpine


### PR DESCRIPTION
Caddy binary has cap_net_bind_service set by xcaddy builder, but the pod drops ALL capabilities. Since Caddy listens on high port (8443), the capability isn't needed.