### PR TITLE
fix(auth): use dynamic imports for @simplewebauthn/browser to fix SSR

### DIFF
--- a/app/src/lib/components/auth/PasskeyManager.svelte
+++ b/app/src/lib/components/auth/PasskeyManager.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { browserSupportsWebAuthn, startRegistration } from '@simplewebauthn/browser';
+	import { onMount } from 'svelte';
 
 	let { authMethod = 'oauth' }: { authMethod: string } = $props();
 
@@ -15,8 +15,11 @@
 	let loading = $state(true);
 	let registering = $state(false);
 	let error = $state('');
+	let webauthnSupported = $state(false);
 
-	$effect(() => {
+	onMount(async () => {
+		const { browserSupportsWebAuthn } = await import('@simplewebauthn/browser');
+		webauthnSupported = browserSupportsWebAuthn();
 		loadPasskeys();
 	});
 
@@ -38,6 +41,8 @@
 		registering = true;
 		error = '';
 		try {
+			const { startRegistration } = await import('@simplewebauthn/browser');
+
 			const optionsRes = await fetch('/auth/webauthn/register');
 			if (!optionsRes.ok) {
 				throw new Error('Failed to get registration options');
@@ -87,7 +92,7 @@
 		});
 	}
 
-	const canRegister = $derived(authMethod === 'oauth' && browserSupportsWebAuthn());
+	const canRegister = $derived(authMethod === 'oauth' && webauthnSupported);
 </script>
 
 <div class="space-y-3">

--- a/app/src/routes/auth/login/+page.svelte
+++ b/app/src/routes/auth/login/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-	import { browserSupportsWebAuthn, startAuthentication } from '@simplewebauthn/browser';
+	import { onMount } from 'svelte';
 
 	let webauthnSupported = $state(false);
 	let webauthnLoading = $state(false);
 	let webauthnError = $state('');
 
-	$effect(() => {
+	onMount(async () => {
+		const { browserSupportsWebAuthn } = await import('@simplewebauthn/browser');
 		webauthnSupported = browserSupportsWebAuthn();
 	});
 
@@ -13,6 +14,8 @@
 		webauthnLoading = true;
 		webauthnError = '';
 		try {
+			const { startAuthentication } = await import('@simplewebauthn/browser');
+
 			const optionsRes = await fetch('/auth/webauthn/authenticate');
 			const options = await optionsRes.json();
 


### PR DESCRIPTION
## Summary

- Replace static `import { ... } from '@simplewebauthn/browser'` with dynamic `import()` inside `onMount` and event handlers in both `+page.svelte` (login) and `PasskeyManager.svelte`
- The `@simplewebauthn/browser` package references browser APIs (`window`, `navigator.credentials`) that don't exist during SSR, causing a 500 error on `/auth/login`
- Convert `$effect` to `onMount` for WebAuthn feature detection since it only needs to run once on the client

## Test plan

- [x] `pnpm check` — 0 errors, 5 warnings (unchanged)
- [x] `pnpm test` — 103 tests pass
- [x] `pnpm build` — production build succeeds (adapter-node)
- [ ] Verify `/auth/login` no longer returns 500 after deploy
- [ ] Verify "Sign in with Passkey" button appears on browsers with WebAuthn support
- [ ] Verify passkey management in settings page still works