### PR TITLE
docs: getting started guide and overlay creation walkthrough

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -468,7 +468,7 @@ k8s-operators:
     @kubectl get pods -n cnpg-system 2>/dev/null || echo "Not installed"
 
 # =============================================================================
-# GitLab Runners (Legacy - Shortcut Commands)
+# GitLab Runners (Shortcut Commands)
 # =============================================================================
 
 # Initialize GitLab runners stack
@@ -483,78 +483,22 @@ runners-apply: (tofu-apply "gitlab-runners")
 # Full deploy cycle for runners
 runners-deploy: (tofu-deploy "gitlab-runners")
 
-# Show runner status
-runners-status:
-    @echo "=== GitLab Runners Status ==="
-    @kubectl get pods -n gitlab-runners -l app=gitlab-runner 2>/dev/null || echo "No runner pods found"
-    @echo ""
-    @kubectl get deployments -n gitlab-runners 2>/dev/null || echo "No deployments"
-    @echo ""
-    @helm list -n gitlab-runners 2>/dev/null || echo "No helm releases"
-
-# Show runner logs
-runners-logs runner="nix-runner":
-    kubectl logs -n gitlab-runners -l release={{runner}} -f --tail=100
-
-# =============================================================================
-# Organization Runners
-# =============================================================================
-
-# Runner stack name (override via RUNNER_STACK env var)
-runner_stack := env_var_or_default("RUNNER_STACK", "gitlab-runners")
-
-# Initialize organization runners stack
-ils-runners-init: (tofu-init runner_stack)
-
-# Plan organization runners deployment
-ils-runners-plan: (tofu-plan runner_stack)
-
-# Apply organization runners deployment
-ils-runners-apply: (tofu-apply runner_stack)
-
-# Full deploy cycle for organization runners
-ils-runners-deploy: (tofu-deploy runner_stack)
-
-# Show organization runner status
-ils-runners-status:
-    @echo "=== Organization Runners Status ({{env}}) ==="
+# Show runner status for a namespace
+runners-status namespace="gitlab-runners":
+    @echo "=== Runner Status ({{namespace}}) ==="
     @echo ""
     @echo "=== Pods ==="
-    @kubectl get pods -n {{runner_stack}} -o wide 2>/dev/null || echo "No pods found"
+    @kubectl get pods -n {{namespace}} -o wide 2>/dev/null || echo "No pods found"
     @echo ""
     @echo "=== HPA ==="
-    @kubectl get hpa -n {{runner_stack}} 2>/dev/null || echo "No HPA found"
+    @kubectl get hpa -n {{namespace}} 2>/dev/null || echo "No HPA found"
     @echo ""
     @echo "=== Helm Releases ==="
-    @helm list -n {{runner_stack}} 2>/dev/null || echo "No helm releases"
+    @helm list -n {{namespace}} 2>/dev/null || echo "No helm releases"
 
-# Show organization runner logs
-ils-runners-logs runner="runner-docker":
-    kubectl logs -n {{runner_stack}} -l release={{runner}} -f --tail=100
-
-# Run runner pool health check
-ils-runners-health:
-    ./scripts/runner-health-check.sh
-
-# Run security isolation audit
-ils-runners-audit:
-    ./tests/security/isolation-audit.sh
-
-# Promote from dev to prod
-ils-runners-promote: (tofu-plan runner_stack)
-    @echo "Plan generated for prod. Review and run 'just ils-runners-apply' with ENV=prod to promote."
-
-# Show all organization runner types
-ils-runners-summary:
-    @echo "=== Organization Runner Types ==="
-    @echo ""
-    @echo "runner-docker : Standard builds (tags: docker, linux, amd64)"
-    @echo "runner-dind   : Container builds (tags: docker, dind, privileged)"
-    @echo "runner-rocky8 : RHEL 8 compat (tags: rocky8, rhel8, linux)"
-    @echo "runner-rocky9 : RHEL 9 compat (tags: rocky9, rhel9, linux)"
-    @echo "runner-nix    : Nix builds (tags: nix, flakes)"
-    @echo ""
-    @echo "Documentation: docs/runners/README.md"
+# Show runner logs
+runners-logs runner namespace="gitlab-runners":
+    kubectl logs -n {{namespace}} -l release={{runner}} -f --tail=100
 
 # =============================================================================
 # Attic Cache (Shortcut Commands)

--- a/README.md
+++ b/README.md
@@ -114,15 +114,20 @@ just tex               # Build research PDF
 
 ## Creating an Overlay
 
-To deploy attic-iac for your organization:
+To deploy attic-iac for your organization, create a private overlay repository:
 
-1. Create a new repository with `MODULE.bazel` declaring `bazel_dep(name = "attic-iac")`
-2. Add `local_path_override(path = "../attic-iac")` for local development
-3. Create `build/extensions.bzl` to merge upstream with your overrides
-4. Add organization-specific `config/organization.yaml` and stack tfvars
-5. Set up CI pipeline that clones upstream and runs tofu plan/apply
+1. Clone upstream as a sibling directory (`~/git/attic-iac`)
+2. Create your overlay repo with `MODULE.bazel` declaring `bazel_dep(name = "attic-iac")`
+3. Add `build/overlay.bzl` and `build/extensions.bzl` for symlink-merge
+4. Add `config/organization.yaml` and per-stack tfvars files
+5. Set up a CI pipeline that clones upstream and runs tofu plan/apply
+6. Push to main and let CI deploy
 
-See [docs/architecture/overlay-system.md](docs/architecture/overlay-system.md) for details.
+**New to overlays?** Follow the complete walkthrough:
+[Create Your First Overlay](docs/infrastructure/overlay-creation.md)
+
+For the architecture behind the overlay system, see
+[docs/architecture/overlay-system.md](docs/architecture/overlay-system.md).
 
 ## License
 

--- a/app/src/lib/components/nav/Sidebar.svelte
+++ b/app/src/lib/components/nav/Sidebar.svelte
@@ -122,8 +122,8 @@
 				{/if}
 			</div>
 		{/if}
-		<div class="pt-1">
-			built with <a href="https://xoxd.ai" target="_blank" rel="noopener noreferrer" class="font-semibold text-primary-500 hover:text-primary-400 transition-colors">xoxd.ai</a> ^w^
+		<div class="pt-1 text-surface-500">
+			GloriousFlywheel
 		</div>
 	</div>
 </aside>

--- a/docs-site/src/routes/+layout.svelte
+++ b/docs-site/src/routes/+layout.svelte
@@ -56,12 +56,8 @@
 			{@render children()}
 		</div>
 
-		<footer class="mt-16 border-t border-surface-700 py-6 text-center text-xs text-surface-500 space-y-1">
-			<p>
-				A <a href="https://tinyland.dev" target="_blank" rel="noopener noreferrer" class="hover:text-surface-300 transition-colors">Tinyland.dev, Inc</a> project
-				&middot;
-				built with <a href="https://xoxd.ai" target="_blank" rel="noopener noreferrer" class="text-primary-500 hover:text-primary-400 transition-colors">xoxd.ai</a> ^w^
-			</p>
+		<footer class="mt-16 border-t border-surface-700 py-6 text-center text-xs text-surface-500">
+			<p>GloriousFlywheel &middot; Apache 2.0</p>
 		</footer>
 	</main>
 </div>

--- a/docs-site/src/routes/+layout.svelte
+++ b/docs-site/src/routes/+layout.svelte
@@ -57,7 +57,7 @@
 		</div>
 
 		<footer class="mt-16 border-t border-surface-700 py-6 text-center text-xs text-surface-500">
-			<p>GloriousFlywheel &middot; Apache 2.0</p>
+			<p>GloriousFlywheel</p>
 		</footer>
 	</main>
 </div>

--- a/docs-site/src/routes/+page.svelte
+++ b/docs-site/src/routes/+page.svelte
@@ -61,35 +61,22 @@
 			<h3 class="font-semibold mb-2">Greedy Build Pattern</h3>
 			<p class="text-sm text-surface-400">Build immediately, cache incrementally, validate later.</p>
 		</a>
+		<a href="{base}/docs/getting-started-guide" class="block p-5 rounded-lg border border-surface-600 hover:border-primary-500 hover:bg-surface-800/50 transition-all">
+			<h3 class="font-semibold mb-2">Getting Started</h3>
+			<p class="text-sm text-surface-400">First-time setup: prerequisites, deploy, verify.</p>
+		</a>
+		<a href="{base}/docs/infrastructure/overlay-creation" class="block p-5 rounded-lg border border-surface-600 hover:border-primary-500 hover:bg-surface-800/50 transition-all">
+			<h3 class="font-semibold mb-2">Create Your First Overlay</h3>
+			<p class="text-sm text-surface-400">Step-by-step overlay setup for your organization.</p>
+		</a>
 		<a href="{base}/docs/infrastructure/quick-start" class="block p-5 rounded-lg border border-surface-600 hover:border-primary-500 hover:bg-surface-800/50 transition-all">
 			<h3 class="font-semibold mb-2">Quick Start</h3>
 			<p class="text-sm text-surface-400">Deploy the full stack from zero.</p>
 		</a>
-		<a href="{base}/docs/infrastructure/tested-deployments" class="block p-5 rounded-lg border border-surface-600 hover:border-primary-500 hover:bg-surface-800/50 transition-all">
-			<h3 class="font-semibold mb-2">Tested Deployments</h3>
-			<p class="text-sm text-surface-400">RKE2 on-premise and Civo k3s cloud guides.</p>
-		</a>
-		<a href="{base}/docs/infrastructure/gitlab-oauth" class="block p-5 rounded-lg border border-surface-600 hover:border-primary-500 hover:bg-surface-800/50 transition-all">
-			<h3 class="font-semibold mb-2">GitLab OAuth</h3>
-			<p class="text-sm text-surface-400">Set up SSO for the runner dashboard.</p>
-		</a>
 	</div>
 
-	<!-- Branding -->
-	<div class="mt-16 border-t border-surface-700 pt-10 space-y-8 text-center">
-		<div>
-			<p class="text-sm font-semibold text-surface-400 uppercase tracking-wide">A Tinyland.dev, Inc project</p>
-			<p class="mt-2 text-surface-500 max-w-2xl mx-auto">
-				Building brutally resilient infrastructure at the intersection of individual authenticity and communal security.
-			</p>
-		</div>
-		<div>
-			<p class="text-sm text-surface-400">
-				built with <a href="https://xoxd.ai" target="_blank" rel="noopener noreferrer" class="font-semibold text-primary-500 hover:text-primary-400 transition-colors">xoxd.ai</a>
-			</p>
-			<p class="mt-2 text-surface-500 max-w-2xl mx-auto">
-				Orchestrating massively parallel, provable agent infrastructure. xoxd.ai ^w^
-			</p>
-		</div>
+	<!-- Footer -->
+	<div class="mt-16 border-t border-surface-700 pt-10 text-center">
+		<p class="text-sm text-surface-400">GloriousFlywheel &middot; Apache 2.0</p>
 	</div>
 </div>

--- a/docs-site/src/routes/+page.svelte
+++ b/docs-site/src/routes/+page.svelte
@@ -77,6 +77,6 @@
 
 	<!-- Footer -->
 	<div class="mt-16 border-t border-surface-700 pt-10 text-center">
-		<p class="text-sm text-surface-400">GloriousFlywheel &middot; Apache 2.0</p>
+		<p class="text-sm text-surface-400">GloriousFlywheel</p>
 	</div>
 </div>

--- a/docs/architecture/bzlmod-topology.md
+++ b/docs/architecture/bzlmod-topology.md
@@ -48,7 +48,7 @@ graph TD
 
 An overlay `MODULE.bazel` contains two declarations:
 
-```starlark
+```python
 bazel_dep(name = "attic-iac")
 local_path_override(
     module_name = "attic-iac",

--- a/docs/getting-started-guide.md
+++ b/docs/getting-started-guide.md
@@ -1,0 +1,187 @@
+---
+title: Getting Started
+order: 1
+---
+
+# Getting Started
+
+This guide walks you through deploying GloriousFlywheel infrastructure for your organization, from zero to a running Nix cache, GitLab runner pool, and monitoring dashboard.
+
+## Decide: Direct or Overlay?
+
+There are two ways to deploy:
+
+| Approach | When to Use | What You Get |
+|----------|-------------|--------------|
+| **Direct** | Evaluating, single cluster, no private config | Clone upstream, add `organization.yaml`, deploy |
+| **Overlay** | Production, multiple clusters, private secrets, CI/CD | Your own repo layered on top of upstream |
+
+**Most organizations should use an overlay.** It keeps your secrets, tfvars, and CI pipeline in a private repo while pulling shared modules from upstream. See [Create Your First Overlay](infrastructure/overlay-creation.md) for a step-by-step walkthrough.
+
+If you just want to try things out, the direct approach works fine -- you can always migrate to an overlay later.
+
+## Prerequisites
+
+You need three things installed on your workstation:
+
+1. **Nix** with flakes enabled
+2. **direnv** (optional but recommended)
+3. **kubectl** access to a Kubernetes cluster
+
+### Install Nix
+
+```bash
+# Official installer (Linux / macOS)
+curl -L https://nixos.org/nix/install | sh
+
+# Enable flakes (add to ~/.config/nix/nix.conf)
+echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+```
+
+### Install direnv
+
+```bash
+# macOS
+brew install direnv
+
+# Nix
+nix profile install nixpkgs#direnv
+
+# Add hook to your shell (~/.bashrc, ~/.zshrc, or ~/.config/fish/config.fish)
+eval "$(direnv hook bash)"    # bash
+eval "$(direnv hook zsh)"     # zsh
+direnv hook fish | source     # fish
+```
+
+### Kubernetes Access
+
+You need a kubeconfig file that can reach your target cluster. The cluster should be running Kubernetes 1.28+ with:
+
+- A default `StorageClass` for persistent volumes
+- Ingress controller (Traefik, nginx, or similar)
+- Optional: cert-manager for TLS, Prometheus for monitoring
+
+## Direct Deployment
+
+### 1. Clone and enter the devShell
+
+```bash
+git clone https://github.com/Jesssullivan/GloriousFlywheel.git ~/git/attic-iac
+cd ~/git/attic-iac
+direnv allow  # or: nix develop
+```
+
+The devShell provides pinned versions of `tofu`, `kubectl`, `pnpm`, `node`, and other tools. You don't need to install them separately.
+
+### 2. Configure your organization
+
+```bash
+cp config/organization.example.yaml config/organization.yaml
+```
+
+Edit `organization.yaml` with your cluster details. At minimum, set:
+
+```yaml
+organization:
+  name: your-org
+
+clusters:
+  - name: dev
+    role: development
+    domain: dev.example.com
+    context: your-kubeconfig-context
+
+namespaces:
+  attic:
+    dev: attic-cache-dev
+  runners:
+    all: gitlab-runners
+```
+
+See the [Customization Guide](infrastructure/customization-guide.md) for all fields.
+
+### 3. Set up secrets
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set the `TF_HTTP_` credentials to a GitLab Personal Access Token with `api` scope (see `.env.example` for the required variable names). This token is used for the OpenTofu state backend.
+
+### 4. Deploy the three stacks (in order)
+
+```bash
+# 1. Attic cache (must be first -- runners reference it)
+just tofu-plan attic
+just tofu-apply attic
+
+# 2. GitLab runners
+just tofu-plan gitlab-runners
+just tofu-apply gitlab-runners
+
+# 3. Runner dashboard
+just tofu-plan runner-dashboard
+just tofu-apply runner-dashboard
+```
+
+### 5. Verify
+
+```bash
+kubectl get pods -n attic-cache-dev       # Attic API + PostgreSQL + MinIO
+kubectl get pods -n gitlab-runners        # 5 runner manager pods
+kubectl get pods -n runner-dashboard      # Dashboard pod
+```
+
+Check GitLab: **Your Group > Settings > CI/CD > Runners** should show the registered runners.
+
+## Overlay Deployment
+
+For production use, create an overlay repository. This keeps your secrets and configuration private while pulling shared modules from upstream.
+
+**Follow the full walkthrough:** [Create Your First Overlay](infrastructure/overlay-creation.md)
+
+The short version:
+
+1. Create a private GitLab repo for your overlay
+2. Clone upstream as a sibling directory
+3. Add `MODULE.bazel`, `build/overlay.bzl`, `build/extensions.bzl`
+4. Add your `config/organization.yaml` and tfvars files
+5. Set up a CI pipeline that clones upstream and runs tofu plan/apply
+6. Push to main and let CI deploy
+
+## What Gets Deployed
+
+After a successful deployment, you have:
+
+```
+Kubernetes Cluster
+  attic-cache-dev/
+    atticd (Nix binary cache API)
+    attic-pg (CloudNativePG PostgreSQL)
+    attic-minio (S3-compatible object storage)
+  gitlab-runners/
+    docker-runner (general purpose CI)
+    dind-runner (Docker-in-Docker builds)
+    rocky8-runner (RHEL 8 packaging)
+    rocky9-runner (RHEL 9 packaging)
+    nix-runner (Nix builds + Attic cache)
+  runner-dashboard/
+    dashboard (SvelteKit monitoring UI)
+```
+
+The runners are registered at your GitLab group level. Any project in the group can use them by adding `tags:` to their `.gitlab-ci.yml`:
+
+```yaml
+build:
+  tags: [docker]
+  script:
+    - make build
+```
+
+## Next Steps
+
+- [Self-Service Enrollment](runners/self-service-enrollment.md) -- how project teams use the runners
+- [Project Onboarding](runners/project-onboarding.md) -- step-by-step for enrolling a project
+- [Runner Selection Guide](runners/runner-selection.md) -- which runner type for which workload
+- [Customization Guide](infrastructure/customization-guide.md) -- full `organization.yaml` reference
+- [Architecture Overview](architecture/recursive-dogfooding.md) -- understand the recursive flywheel

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,8 @@ clusters.
 
 ## Getting Started
 
+- [Getting Started Guide](getting-started-guide.md) -- first-time user journey
+- [Create Your First Overlay](infrastructure/overlay-creation.md) -- step-by-step overlay setup
 - [Quick Start](infrastructure/quick-start.md) -- deploy from zero
 - [Customization Guide](infrastructure/customization-guide.md) -- configure for your org
 - [Clusters and Environments](infrastructure/clusters-and-environments.md) -- cluster layout

--- a/docs/infrastructure/cluster-access.md
+++ b/docs/infrastructure/cluster-access.md
@@ -39,7 +39,7 @@ kubectl get nodes
 
 Configure in your overlay Justfile:
 
-```just
+```bash
 # Run kubectl against a specific cluster
 bk *ARGS:
     kubectl --kubeconfig=kubeconfig-{environment} {{ARGS}}
@@ -74,7 +74,7 @@ kubectl get pods -n {namespace}
 
 Configure in your overlay Justfile:
 
-```just
+```bash
 # Start the SOCKS5 proxy
 proxy-up:
     ssh -fN -D 1080 user@jump-host

--- a/docs/infrastructure/clusters-and-environments.md
+++ b/docs/infrastructure/clusters-and-environments.md
@@ -45,7 +45,7 @@ Houses the Attic binary cache server and its PostgreSQL database:
 - **CloudNativePG cluster** -- manages the PostgreSQL instance(s) for Attic's metadata store
 - **PVCs** -- Longhorn-backed persistent volumes for cache object storage
 
-### {org}-runners
+### gitlab-runners
 
 Contains all GitLab Runner deployments. Each runner type (docker, dind, rocky8, rocky9, nix) runs as a separate pod managed by a Helm release. Runners reference the Attic cache via the `ATTIC_SERVER` environment variable pointing into the `attic-cache-dev` namespace.
 

--- a/docs/infrastructure/overlay-creation.md
+++ b/docs/infrastructure/overlay-creation.md
@@ -1,0 +1,659 @@
+---
+title: Create Your First Overlay
+order: 5
+---
+
+# Create Your First Overlay
+
+This guide walks you through creating a private overlay repository from scratch. By the end, you'll have a fully automated CI/CD pipeline that deploys Attic infrastructure to your Kubernetes cluster.
+
+## What is an Overlay?
+
+An overlay is a thin private repository that layers your organization-specific configuration on top of the public upstream modules. Think of it like CSS for infrastructure: upstream provides the structure, your overlay provides the values.
+
+```
+upstream (public)                    overlay (private)
+  tofu/modules/gitlab-runner/          tofu/stacks/runners/beehive.tfvars
+  tofu/modules/runner-dashboard/       tofu/stacks/runners/main.tf  (optional)
+  tofu/stacks/attic/main.tf            config/organization.yaml
+  tofu/stacks/gitlab-runners/main.tf   .gitlab-ci.yml
+  app/                                 .env  (gitignored)
+```
+
+The overlay contains *only* your delta -- organization-specific config, secrets references, and CI pipeline. Upstream handles all the module logic.
+
+**Why not just fork?** Forks diverge. With an overlay, you get upstream improvements (bug fixes, new runner types, dashboard features) by simply pulling the latest upstream commit. Your private configuration is never at risk of merge conflicts because it lives in separate files.
+
+## Prerequisites
+
+Before starting, you need:
+
+- [ ] A Kubernetes cluster (1.28+) with kubectl access
+- [ ] A GitLab group where your projects live
+- [ ] A GitLab Personal Access Token (PAT) with `api` scope
+- [ ] Nix with flakes enabled (see [Getting Started](../getting-started-guide.md))
+- [ ] Git and a text editor
+
+## Step 1: Clone Upstream
+
+Clone the public upstream repo as a sibling directory to where your overlay will live:
+
+```bash
+git clone https://github.com/Jesssullivan/GloriousFlywheel.git ~/git/attic-iac
+```
+
+This directory must exist alongside your overlay -- the build system references it via relative path.
+
+## Step 2: Create Your Overlay Repository
+
+Create a new private repository on GitLab for your overlay, then clone it:
+
+```bash
+# Create the repo on GitLab (or use the GitLab UI)
+# Then clone it as a sibling to attic-iac:
+git clone git@gitlab.com:your-group/your-overlay.git ~/git/your-overlay
+cd ~/git/your-overlay
+```
+
+Your directory layout should look like:
+
+```
+~/git/
+  attic-iac/         # public upstream (from GitHub)
+  your-overlay/      # private overlay (your GitLab repo)
+```
+
+## Step 3: Add the Bazel Overlay Files
+
+The overlay system uses three files to merge upstream and private sources. Copy them from the templates below.
+
+### `MODULE.bazel`
+
+```starlark
+"""Your Organization - Private overlay module."""
+
+module(
+    name = "your-overlay",
+    version = "0.1.0",
+)
+
+# Upstream dependency
+bazel_dep(name = "attic-iac", version = "0.1.0")
+
+# Local dev: points to sibling upstream checkout
+local_path_override(module_name = "attic-iac", path = "../../attic-iac")
+
+# Core Bazel rules
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "rules_pkg", version = "1.1.0")
+
+# Overlay extension: creates @attic_merged repo
+overlay = use_extension("//build:extensions.bzl", "overlay")
+overlay.configure(name = "attic_merged")
+use_repo(overlay, "attic_merged")
+```
+
+> **Note:** The `local_path_override` path is relative to this file. Adjust if your directory layout differs from `~/git/attic-iac` and `~/git/your-overlay`.
+
+### `build/overlay.bzl`
+
+This file implements the symlink-merge repository rule. Copy it from the upstream repo:
+
+```bash
+mkdir -p build
+cp ~/git/attic-iac/docs/infrastructure/templates/overlay.bzl build/overlay.bzl
+```
+
+Or copy from an existing overlay. The file is generic and works without modification.
+
+<details>
+<summary>Full overlay.bzl source (click to expand)</summary>
+
+```starlark
+"""Overlay repository rule for merging upstream and private sources.
+
+Creates a repository that symlinks all files from an upstream Bazel module,
+then overlays private files on top. Private files win on conflict.
+"""
+
+_EXCLUDE_DIRS = [".git", "bazel-", "node_modules", ".terraform", ".svelte-kit", "__pycache__"]
+_EXCLUDE_FILES = ["MODULE.bazel", "MODULE.bazel.lock", "WORKSPACE", "WORKSPACE.bazel"]
+_EXCLUDE_EXTENSIONS = [".tfstate", ".tfstate.backup"]
+
+def _should_exclude(path):
+    for d in _EXCLUDE_DIRS:
+        if d in path.split("/"):
+            return True
+        for part in path.split("/"):
+            if part.startswith("bazel-"):
+                return True
+    for f in _EXCLUDE_FILES:
+        if path == f or path.endswith("/" + f):
+            return True
+    for ext in _EXCLUDE_EXTENSIONS:
+        if path.endswith(ext):
+            return True
+    return False
+
+def _find_files(ctx, root_path):
+    result = ctx.execute(
+        ["find", root_path, "-type", "f", "-not", "-path", "*/.git/*"],
+        timeout = 30,
+    )
+    if result.return_code != 0:
+        fail("Failed to list files in %s: %s" % (root_path, result.stderr))
+    files = []
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+        rel = line
+        if rel.startswith(root_path + "/"):
+            rel = rel[len(root_path) + 1:]
+        elif rel.startswith(root_path):
+            rel = rel[len(root_path):]
+        if rel and not _should_exclude(rel):
+            files.append(rel)
+    return files
+
+def _ensure_parent_dirs(ctx, path):
+    parent = "/".join(path.split("/")[:-1])
+    if parent:
+        ctx.execute(["mkdir", "-p", parent], timeout = 5)
+
+def _overlay_repository_impl(ctx):
+    upstream_path = str(ctx.path(ctx.attr.upstream_marker).dirname)
+    overlay_path = str(ctx.path(ctx.attr.overlay_marker).dirname)
+    ctx.watch_tree(upstream_path)
+    ctx.watch_tree(overlay_path)
+
+    upstream_files = _find_files(ctx, upstream_path)
+    for f in upstream_files:
+        _ensure_parent_dirs(ctx, f)
+        ctx.symlink(ctx.path(upstream_path + "/" + f), f)
+
+    overlay_files = _find_files(ctx, overlay_path)
+    overlaid = []
+    for f in overlay_files:
+        _ensure_parent_dirs(ctx, f)
+        target = ctx.path(f)
+        if f in upstream_files:
+            ctx.delete(target)
+            overlaid.append(f)
+        ctx.symlink(ctx.path(overlay_path + "/" + f), f)
+
+    ctx.file("BUILD.bazel", """\
+package(default_visibility = ["//visibility:public"])
+filegroup(name = "all_files", srcs = glob(["**/*"], exclude = ["BUILD.bazel"]))
+""")
+
+overlay_repository = repository_rule(
+    implementation = _overlay_repository_impl,
+    attrs = {
+        "upstream_marker": attr.label(mandatory = True),
+        "overlay_marker": attr.label(mandatory = True),
+    },
+    local = True,
+)
+```
+
+</details>
+
+### `build/extensions.bzl`
+
+```starlark
+"""Module extension bridging MODULE.bazel tag declarations to overlay_repository."""
+
+load("//build:overlay.bzl", "overlay_repository")
+
+_configure = tag_class(
+    attrs = {
+        "name": attr.string(mandatory = True),
+        "upstream_marker": attr.label(default = Label("@attic-iac//:MODULE.bazel")),
+        "overlay_marker": attr.label(default = Label("//:MODULE.bazel")),
+    },
+)
+
+def _overlay_extension_impl(module_ctx):
+    for mod in module_ctx.modules:
+        for cfg in mod.tags.configure:
+            overlay_repository(
+                name = cfg.name,
+                upstream_marker = cfg.upstream_marker,
+                overlay_marker = cfg.overlay_marker,
+            )
+
+overlay = module_extension(
+    implementation = _overlay_extension_impl,
+    tag_classes = {"configure": _configure},
+)
+```
+
+### `BUILD.bazel`
+
+```starlark
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+package(default_visibility = ["//visibility:public"])
+
+# Your org-specific filegroups
+filegroup(name = "org_config", srcs = ["config/organization.yaml"])
+filegroup(name = "org_tfvars", srcs = glob(["tofu/stacks/**/*.tfvars"]))
+filegroup(name = "gitlab_ci", srcs = glob([".gitlab-ci.yml", ".gitlab/ci/**/*.yml"]))
+
+# Aliases to upstream targets
+alias(name = "validate_modules", actual = "@attic-iac//tofu/modules:all_validate")
+alias(name = "app", actual = "@attic-iac//app:build")
+
+# Deployment bundle
+pkg_tar(
+    name = "deployment_bundle",
+    srcs = [":org_config", ":org_tfvars", ":gitlab_ci"],
+    extension = "tar.gz",
+    strip_prefix = ".",
+)
+```
+
+## Step 4: Add Organization Configuration
+
+### `config/organization.yaml`
+
+```bash
+mkdir -p config
+```
+
+Create `config/organization.yaml` with your cluster details:
+
+```yaml
+organization:
+  name: your-org
+  full_name: "Your Organization"
+  group_path: your-gitlab-group
+
+gitlab:
+  url: https://gitlab.com
+  project_id: "YOUR_OVERLAY_PROJECT_ID"
+  agent_group: your-group/kubernetes/agents
+
+clusters:
+  - name: dev
+    role: development
+    domain: dev.example.com
+    context: your-group/kubernetes/agents:dev
+
+namespaces:
+  attic:
+    dev: attic-cache-dev
+  runners:
+    all: gitlab-runners
+
+links:
+  upstream_repo: "https://github.com/Jesssullivan/GloriousFlywheel"
+  source_repo: "https://gitlab.com/your-group/your-overlay"
+```
+
+### `.env` (gitignored)
+
+```bash
+cp ~/git/attic-iac/.env.example .env
+```
+
+Set the `TF_HTTP_` credentials (see `.env.example`) to your GitLab PAT. This is used for the OpenTofu HTTP state backend.
+
+### `.gitignore`
+
+```
+.env
+*.tfstate
+*.tfstate.backup
+.terraform/
+.svelte-kit/
+kubeconfig-*
+```
+
+## Step 5: Add Stack Configuration (tfvars)
+
+Each stack needs a tfvars file with your environment-specific values. Create them under `tofu/stacks/`:
+
+### Attic Cache
+
+```bash
+mkdir -p tofu/stacks/attic
+```
+
+Create `tofu/stacks/attic/dev.tfvars`:
+
+```hcl
+# Cluster access
+cluster_context = "your-group/kubernetes/agents:dev"  # CI uses GitLab Agent path
+namespace       = "attic-cache-dev"
+
+# PostgreSQL
+pg_instances    = 1
+pg_storage      = "10Gi"
+pg_storage_class = "default"  # Use your cluster's StorageClass
+
+# MinIO
+minio_storage   = "50Gi"
+
+# Ingress
+api_host = "nix-cache.dev.example.com"
+```
+
+### GitLab Runners
+
+```bash
+mkdir -p tofu/stacks/gitlab-runners
+```
+
+Create `tofu/stacks/gitlab-runners/dev.tfvars`:
+
+```hcl
+cluster_context = "your-group/kubernetes/agents:dev"
+namespace       = "gitlab-runners"
+gitlab_url      = "https://gitlab.com"
+
+# Your GitLab group ID (Settings > General > Group ID)
+gitlab_group_id = 12345678
+
+# Runner types to deploy (disable what you don't need)
+deploy_docker_runner = true
+deploy_dind_runner   = true
+deploy_rocky8_runner = false
+deploy_rocky9_runner = false
+deploy_nix_runner    = true
+
+# Attic cache (for Nix runner)
+attic_server   = "https://nix-cache.dev.example.com"
+attic_cache    = "main"
+nix_store_size = "20Gi"
+
+# HPA
+hpa_enabled = true
+```
+
+### Runner Dashboard
+
+```bash
+mkdir -p tofu/stacks/runner-dashboard
+```
+
+Create `tofu/stacks/runner-dashboard/dev.tfvars`:
+
+```hcl
+cluster_context  = "your-group/kubernetes/agents:dev"
+namespace        = "runner-dashboard"
+ingress_host     = "dashboard.dev.example.com"
+runners_namespace = "gitlab-runners"
+```
+
+## Step 6: Self-Contained Stacks (Optional)
+
+Some stacks need overlay-specific logic beyond what tfvars provide. For example, enrolling specific GitLab projects with dedicated runner registrations requires HCL resources that reference project IDs unique to your organization.
+
+For these cases, create a self-contained `main.tf` in the overlay stack directory instead of using the upstream stack `.tf` files:
+
+```bash
+# Example: self-contained runner stack for project-level registrations
+mkdir -p tofu/stacks/your-org-runners
+```
+
+See the [Bates runner enrollment docs](https://gitlab.com/bates-ils/people/jsullivan2/attic-cache/-/blob/main/docs/bates-runner-enrollment.md) for a worked example of project-level runner registration in a self-contained overlay stack.
+
+## Step 7: Set Up CI Pipeline
+
+Create `.gitlab-ci.yml` in your overlay root:
+
+```yaml
+# Your Organization - Overlay CI Pipeline
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+stages:
+  - validate
+  - plan
+  - deploy
+
+variables:
+  UPSTREAM_REPO_URL: "https://github.com/Jesssullivan/GloriousFlywheel.git"
+  UPSTREAM_REF: "main"
+  TF_IN_AUTOMATION: "true"
+  TF_INPUT: "false"
+
+default:
+  tags: [kubernetes]  # Target SaaS shared runners
+
+# Clone upstream and symlink modules into overlay workspace
+.setup_upstream: &setup_upstream
+  - git clone --depth=1 --branch=$UPSTREAM_REF $UPSTREAM_REPO_URL /tmp/upstream
+  # Symlink upstream modules into overlay
+  - ln -sf /tmp/upstream/tofu/modules tofu/modules
+
+# Base template for OpenTofu jobs
+.tofu_base:
+  image:
+    name: ghcr.io/opentofu/opentofu:latest
+    entrypoint: [""]
+  variables:
+    # CI job token authenticates to the HTTP state backend via TF_HTTP_* env vars
+    TF_HTTP_USERNAME: gitlab-ci-token
+  before_script:
+    - *setup_upstream
+    - |
+      cd tofu/stacks/${STACK}
+      tofu init \
+        -backend-config="address=https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/terraform/state/${STATE_NAME}" \
+        -backend-config="lock_address=https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/terraform/state/${STATE_NAME}/lock" \
+        -backend-config="unlock_address=https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/terraform/state/${STATE_NAME}/lock"
+
+# Attic Cache
+plan:attic:
+  extends: .tofu_base
+  stage: plan
+  variables:
+    STACK: attic
+    STATE_NAME: attic-dev
+  script:
+    - tofu plan -var-file=dev.tfvars -out=plan.tfplan
+  artifacts:
+    paths: [tofu/stacks/attic/plan.tfplan]
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+deploy:attic:
+  extends: .tofu_base
+  stage: deploy
+  variables:
+    STACK: attic
+    STATE_NAME: attic-dev
+  script:
+    - tofu apply plan.tfplan
+  needs: [plan:attic]
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+# Runners
+plan:runners:
+  extends: .tofu_base
+  stage: plan
+  variables:
+    STACK: gitlab-runners
+    STATE_NAME: runners-dev
+  script:
+    - tofu plan -var-file=dev.tfvars -var="gitlab_token=${GITLAB_TOKEN}" -out=plan.tfplan
+  artifacts:
+    paths: [tofu/stacks/gitlab-runners/plan.tfplan]
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+deploy:runners:
+  extends: .tofu_base
+  stage: deploy
+  variables:
+    STACK: gitlab-runners
+    STATE_NAME: runners-dev
+  script:
+    - tofu apply plan.tfplan
+  needs: [plan:runners]
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+```
+
+Adapt the template to include as many stacks as you deploy.
+
+### Required CI/CD Variables
+
+Set these in **Settings > CI/CD > Variables** on your GitLab overlay project:
+
+| Variable | Scope | Description |
+|----------|-------|-------------|
+| `GITLAB_TOKEN` | All | PAT with `create_runner` scope (for automated runner token lifecycle) |
+| `TF_VAR_gitlab_oauth_client_id` | All | OAuth app client ID (dashboard auth) |
+| `TF_VAR_gitlab_oauth_client_secret` | All | OAuth app client secret (dashboard auth) |
+| `TF_VAR_attic_token` | All | Attic cache auth token (Nix runners) |
+
+## Step 8: Deploy
+
+### First deployment (local)
+
+For the initial deployment, run from your workstation:
+
+```bash
+cd ~/git/your-overlay
+eval "$(grep '^TF_HTTP' .env)"  # Load state backend credentials
+
+# Deploy in order: attic → runners → dashboard
+for stack in attic gitlab-runners runner-dashboard; do
+  cd tofu/stacks/$stack
+  tofu init -backend-config="address=..." -backend-config="..."
+  tofu plan -var-file=dev.tfvars -var="cluster_context=your-context" \
+    -var="k8s_config_path=$HOME/git/your-overlay/kubeconfig"
+  tofu apply
+  cd ~/git/your-overlay
+done
+```
+
+### Subsequent deployments (CI)
+
+After the initial deployment, push to your overlay's `main` branch. The CI pipeline handles plan and apply automatically:
+
+```bash
+git add -A && git commit -m "feat: initial overlay deployment"
+git push
+```
+
+## Step 9: Verify
+
+```bash
+# Pods running?
+kubectl get pods -n attic-cache-dev
+kubectl get pods -n gitlab-runners
+kubectl get pods -n runner-dashboard
+
+# Runners registered?
+# Check: GitLab > Your Group > Settings > CI/CD > Runners
+```
+
+## Step 10: Enroll Projects
+
+Once runners are deployed, project teams can start using them immediately by adding `tags:` to their `.gitlab-ci.yml`:
+
+```yaml
+default:
+  tags: [docker]  # Route all jobs to the docker runner
+
+build:container:
+  tags: [dind]    # Docker-in-Docker for container builds
+
+build:nix:
+  tags: [nix]     # Nix builds with Attic cache
+```
+
+See [Self-Service Enrollment](../runners/self-service-enrollment.md) and [Project Onboarding](../runners/project-onboarding.md) for complete guides.
+
+## Keeping Up with Upstream
+
+To pull upstream improvements:
+
+```bash
+cd ~/git/attic-iac
+git pull origin main
+```
+
+That's it. The overlay's `local_path_override` automatically picks up changes when you run `bazel build` or `tofu plan` locally. In CI, the pipeline clones the latest upstream on every run.
+
+For pinned deployments (recommended for production), change `UPSTREAM_REF` in your `.gitlab-ci.yml` to a specific tag or commit SHA:
+
+```yaml
+variables:
+  UPSTREAM_REF: "v1.2.0"  # or: "da8a495"
+```
+
+## Troubleshooting
+
+### `local_path_override` path not found
+
+The path in `MODULE.bazel` is relative to the overlay repo root. If your directories aren't siblings:
+
+```
+~/git/attic-iac/      # upstream
+~/git/your-overlay/   # overlay -- MODULE.bazel says path = "../../attic-iac"
+```
+
+Adjust the `path` value to match your layout. Two `../` segments are needed because `local_path_override` resolves relative to the Bazel workspace root.
+
+### OpenTofu state backend errors
+
+GitLab's HTTP state backend occasionally returns 500. If a state becomes corrupted:
+
+1. Try a different state name (append `-v2`)
+2. Re-initialize with the new state name
+3. Import existing resources if needed
+
+### Runners not visible in project
+
+Runners registered at a GitLab group only propagate *downward* in the hierarchy. If your project is in a sibling subgroup, you need project-level registrations. See the [enrollment docs](../runners/self-service-enrollment.md) for details.
+
+### CI pipeline can't clone upstream
+
+The CI pipeline clones upstream from GitHub over HTTPS. If your GitLab runners are on a restricted network (no GitHub access), you have two options:
+
+1. Use SaaS shared runners for CI (set `tags: [kubernetes]` on pipeline jobs)
+2. Mirror the upstream repo to your GitLab instance and change `UPSTREAM_REPO_URL`
+
+## Directory Structure Reference
+
+A complete overlay repository looks like this:
+
+```
+your-overlay/
+  MODULE.bazel              # Declares upstream dependency
+  BUILD.bazel               # Build targets and aliases
+  .gitlab-ci.yml            # CI/CD pipeline
+  .gitignore                # Exclude .env, tfstate, etc.
+  .env                      # Secrets (gitignored)
+  build/
+    overlay.bzl             # Symlink-merge repository rule
+    extensions.bzl          # Module extension bridge
+  config/
+    organization.yaml       # Organization identity and cluster config
+  tofu/
+    stacks/
+      attic/
+        dev.tfvars          # Attic cache config per environment
+      gitlab-runners/
+        dev.tfvars          # Runner config per environment
+        main.tf             # (optional) Self-contained stack for project enrollments
+      runner-dashboard/
+        dev.tfvars          # Dashboard config per environment
+  docs/                     # (optional) Org-specific documentation
+```
+
+## Related Documentation
+
+- [Overlay System](../architecture/overlay-system.md) -- deep dive on the symlink-merge mechanics
+- [Bzlmod Topology](../architecture/bzlmod-topology.md) -- how Bazel modules connect
+- [Multi-Repo Layout](../architecture/multi-repo-layout.md) -- repository hosting and CI flow
+- [Quick Start](./quick-start.md) -- direct deployment guide
+- [Customization Guide](./customization-guide.md) -- full `organization.yaml` reference

--- a/docs/infrastructure/overlay-creation.md
+++ b/docs/infrastructure/overlay-creation.md
@@ -69,7 +69,7 @@ The overlay system uses three files to merge upstream and private sources. Copy 
 
 ### `MODULE.bazel`
 
-```starlark
+```python
 """Your Organization - Private overlay module."""
 
 module(
@@ -106,10 +106,9 @@ cp ~/git/attic-iac/docs/infrastructure/templates/overlay.bzl build/overlay.bzl
 
 Or copy from an existing overlay. The file is generic and works without modification.
 
-<details>
-<summary>Full overlay.bzl source (click to expand)</summary>
+#### Full overlay.bzl source
 
-```starlark
+```python
 """Overlay repository rule for merging upstream and private sources.
 
 Creates a repository that symlinks all files from an upstream Bazel module,
@@ -196,11 +195,9 @@ overlay_repository = repository_rule(
 )
 ```
 
-</details>
-
 ### `build/extensions.bzl`
 
-```starlark
+```python
 """Module extension bridging MODULE.bazel tag declarations to overlay_repository."""
 
 load("//build:overlay.bzl", "overlay_repository")
@@ -230,7 +227,7 @@ overlay = module_extension(
 
 ### `BUILD.bazel`
 
-```starlark
+```python
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 package(default_visibility = ["//visibility:public"])

--- a/docs/infrastructure/quick-start.md
+++ b/docs/infrastructure/quick-start.md
@@ -135,7 +135,7 @@ git clone <overlay-repo-url> ~/git/your-org-overlay
 
 2. The overlay `MODULE.bazel` already declares a `local_path_override` pointing to the upstream sibling directory:
 
-```starlark
+```python
 local_path_override(
     module_name = "attic-iac",
     path = "../../attic-iac",

--- a/docs/reference/justfile-commands.md
+++ b/docs/reference/justfile-commands.md
@@ -46,15 +46,20 @@ Recipes for Nix-based builds and maintenance.
 
 ## OpenTofu
 
-Infrastructure-as-code recipes for planning and applying changes.
+Infrastructure-as-code recipes for planning and applying changes. Each recipe
+takes a stack name argument (e.g., `attic`, `gitlab-runners`, `runner-dashboard`).
 
 | Recipe | Description |
 |--------|-------------|
-| `just tofu-init` | Initialize tofu for all stacks |
-| `just tofu-plan` | Run tofu plan for all stacks |
-| `just tofu-apply` | Run tofu apply for all stacks |
-| `just tofu-deploy` | Full deploy cycle: init, plan, apply |
-| `just tofu-validate-all` | Run tofu validate against every module in `tofu/modules/` |
+| `just tofu-init <stack>` | Initialize tofu for a stack |
+| `just tofu-plan <stack>` | Run tofu plan for a stack (looks for `{ENV}.tfvars` in the stack dir) |
+| `just tofu-apply <stack>` | Apply a saved plan for a stack |
+| `just tofu-deploy <stack>` | Full deploy cycle: init, plan, apply |
+| `just tofu-validate-all` | Validate all initialized stacks and check module formatting |
+
+**Note:** `tofu-plan` expects a `{ENV}.tfvars` file (default `dev.tfvars`) in
+the stack directory. For overlay deployments, create your tfvars there or use
+the per-stack Justfiles directly. Set `ENV=prod` to target production.
 
 ## Bazel
 
@@ -93,13 +98,15 @@ Recipes for the SvelteKit runner-dashboard application.
 
 ## Runners
 
-Recipes specific to the GitLab Runner infrastructure stack.
+Shortcut recipes for the GitLab Runner infrastructure stack (`gitlab-runners`).
 
 | Recipe | Description |
 |--------|-------------|
 | `just runners-init` | Initialize tofu for the runners stack |
 | `just runners-plan` | Plan changes to the runners stack |
 | `just runners-apply` | Apply changes to the runners stack |
+| `just runners-status [namespace]` | Show pods, HPA, and Helm releases (default: `gitlab-runners`) |
+| `just runners-logs <runner> [namespace]` | Tail logs from a runner release |
 
 ## Attic
 

--- a/docs/runners/load-testing.md
+++ b/docs/runners/load-testing.md
@@ -164,7 +164,7 @@ kubectl get events -n {org}-runners -w
 
 ### Prometheus Queries
 
-```promql
+```text
 # Job queue depth
 gitlab_runner_jobs{state="running"}
 


### PR DESCRIPTION
## Summary

- Add **Getting Started Guide** — first-time user journey covering prerequisites, direct vs overlay decision tree, and end-to-end deployment flow
- Add **Create Your First Overlay** — complete step-by-step walkthrough from empty repo to running infrastructure, with full MODULE.bazel / overlay.bzl / extensions.bzl templates, CI pipeline template, and troubleshooting
- Add **Examples README** — quick reference for choosing the right CI template
- Remove xoxd.ai and tinyland.dev branding from dashboard sidebar and docs-site (footer + homepage); replace with neutral GloriousFlywheel label
- Add Getting Started and Overlay Creation cards to docs-site homepage
- Update README and docs index to link to new guides
- Fix Justfile semantics: replace org-specific `ils-runners-*` recipes with generic `runners-status`, add namespace parameter
- Fix Justfile command reference docs to show correct `<stack>` argument signatures

The overlay system is well-documented architecturally (overlay-system.md, bzlmod-topology.md) but missing a practical "do this, then this" guide for adopters who haven't worked with Bzlmod overlays before. These docs fill that gap.

Cross-branding with xoxd.ai / tinyland.dev removed for now — will revisit at a later date.

## Changes

| File | Description |
|------|-------------|
| `docs/getting-started-guide.md` | New: prerequisites, direct vs overlay, deployment order, verification |
| `docs/infrastructure/overlay-creation.md` | New: 10-step overlay setup with templates, CI pipeline, troubleshooting |
| `examples/README.md` | New: example picker table with runner tag reference |
| `README.md` | Updated "Creating an Overlay" section with walkthrough link |
| `docs/index.md` | Added links to new guides in Getting Started section |
| `app/src/lib/components/nav/Sidebar.svelte` | Replaced xoxd.ai footer with GloriousFlywheel |
| `docs-site/src/routes/+layout.svelte` | Replaced tinyland/xoxd footer with GloriousFlywheel |
| `docs-site/src/routes/+page.svelte` | Replaced branding section, added new guide cards |
| `Justfile` | Removed org-specific `ils-runners-*` recipes, added generic `runners-status` with namespace param |
| `docs/reference/justfile-commands.md` | Fixed OpenTofu recipe signatures, updated Runners section |

-Jess