### PR TITLE
fix(docs-site): remove duplicate footer from landing page

### DIFF
--- a/docs-site/src/routes/+page.svelte
+++ b/docs-site/src/routes/+page.svelte
@@ -74,9 +74,4 @@
 			<p class="text-sm text-surface-400">Deploy the full stack from zero.</p>
 		</a>
 	</div>
-
-	<!-- Footer -->
-	<div class="mt-16 border-t border-surface-700 pt-10 text-center">
-		<p class="text-sm text-surface-400">GloriousFlywheel</p>
-	</div>
 </div>


### PR DESCRIPTION
## Summary

- Remove the page-level footer from `+page.svelte` — the layout (`+layout.svelte`) already renders a footer, so the landing page showed "GloriousFlywheel" twice.

## Test plan

- [ ] Landing page shows single footer
- [ ] Doc pages still show footer from layout