### PR TITLE
feat(docs): add dead link checker for markdown and docs-site

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -125,3 +125,20 @@ jobs:
             README.md
             CONTRIBUTING.md
             docs/**/*.md
+
+  check-links:
+    name: Check Documentation Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Check markdown cross-references
+        run: node scripts/check-links.js --mode markdown
+
+      - name: Check docs-site routes
+        run: node scripts/check-links.js --mode site

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 bazel-*
 !tofu/modules/bazel-cache/
 !docs/research/bazel-*
+!docs/build-system/bazel-*
 user.bazelrc
 
 # Nix

--- a/Justfile
+++ b/Justfile
@@ -140,9 +140,13 @@ bcurl *args:
 # Development Workflows
 # =============================================================================
 
-# Quick validation cycle (format + lint + validate)
-check: fmt-check nix-check tofu-fmt-check
+# Quick validation cycle (format + lint + validate + links)
+check: fmt-check nix-check tofu-fmt-check check-links
     @echo "All checks passed!"
+
+# Validate markdown cross-references resolve to real files
+check-links:
+    @node scripts/check-links.js --mode markdown
 
 # Full validation including tofu (requires initialized stacks)
 check-full: check tofu-validate-all

--- a/docs/build-system/bazel-targets.md
+++ b/docs/build-system/bazel-targets.md
@@ -1,0 +1,116 @@
+---
+title: Bazel Targets
+order: 30
+---
+
+# Bazel Targets
+
+This document lists the primary Bazel build targets available in the
+project. Targets are listed from the perspective of the overlay
+repository, which merges upstream and private files through the
+`@attic_merged` repository rule (see
+[Overlay System](../architecture/overlay-system.md)).
+
+## Top-Level Targets
+
+These targets are defined in the overlay repository root `BUILD.bazel`
+and represent the most common build operations.
+
+| Target | Description |
+|---|---|
+| `//...` | Build all targets in the workspace. This includes both overlay-defined targets and upstream targets pulled in through `@attic_merged`. Bazel's content-addressable cache ensures unchanged targets resolve instantly. |
+| `//:deployment_bundle` | A `pkg_tar` archive containing overlay configuration files combined with upstream build artifacts. Used for deployment packaging. |
+| `//:validate_modules` | Alias to `@attic-iac//tofu/modules:all_validate`. Runs `tofu validate` against all upstream OpenTofu modules. |
+| `//:app` | Alias to `@attic-iac//app:build`. Produces the Vite production build of the runner dashboard SvelteKit application. |
+
+## Application Targets
+
+These targets are defined in `//app/` and operate on the SvelteKit
+runner dashboard.
+
+| Target | Description |
+|---|---|
+| `//app:build` | Vite production build. Compiles the SvelteKit application with adapter-node, producing a Node.js server bundle in `build/`. |
+| `//app:dev` | Vite development server. Starts the SvelteKit dev server with hot module replacement. This is a `run` target, not a `build` target -- invoke it with `bazel run //app:dev`. |
+| `//app:image` | OCI image manifest. Assembles a container image from the production build output using `image_layer` and `image_manifest` rules. |
+| `//app:push` | Push the OCI image to `ghcr.io`. Requires registry authentication to be configured. Invoke with `bazel run //app:push`. |
+
+## Target Dependency Graph
+
+```mermaid
+graph TD
+    ALL["//..."]
+    DB["//:deployment_bundle"]
+    VM["//:validate_modules"]
+    APP["//:app"]
+
+    AB["//app:build"]
+    AD["//app:dev"]
+    AI["//app:image"]
+    AP["//app:push"]
+
+    ALL --> DB
+    ALL --> VM
+    ALL --> APP
+    ALL --> AI
+
+    APP --> AB
+    AI --> AB
+    AP --> AI
+
+    VM --> TM["@attic-iac//tofu/modules:all_validate"]
+```
+
+## Running Targets
+
+Build targets are invoked with `bazel build`:
+
+```bash
+# Build everything
+bazel build //...
+
+# Build only the deployment bundle
+bazel build //:deployment_bundle
+
+# Validate all OpenTofu modules
+bazel build //:validate_modules
+
+# Build the SvelteKit app
+bazel build //:app
+```
+
+Run targets (dev server, image push) are invoked with `bazel run`:
+
+```bash
+# Start the dev server
+bazel run //app:dev
+
+# Push the container image
+bazel run //app:push
+```
+
+## Speculative Builds
+
+Running `bazel build //...` is the recommended default. Bazel's
+content-addressable cache means targets whose inputs have not changed
+resolve as cache hits with negligible cost. Building everything ensures
+that:
+
+- Breakages in unrelated targets surface early.
+- The deployment bundle always reflects the current state of all
+  components.
+- CI pipelines do not need to determine which subset of targets to
+  build based on changed files.
+
+This pairs with the [Greedy Build Pattern](greedy-build-pattern.md),
+where the same `build //...` command runs immediately in CI without
+waiting for validation.
+
+## Related Documents
+
+- [Greedy Build Pattern](greedy-build-pattern.md) -- CI pipeline
+  strategy for speculative builds
+- [Container Builds](containers.md) -- how `//app:image` and
+  `//app:push` produce and distribute OCI images
+- [Overlay System](../architecture/overlay-system.md) -- how upstream
+  and private targets merge into a single workspace

--- a/docs/infrastructure/proxy-and-access.md
+++ b/docs/infrastructure/proxy-and-access.md
@@ -1,0 +1,47 @@
+---
+title: Proxy and Access
+order: 60
+---
+
+# Proxy and Access
+
+Remote access to on-premise clusters typically requires a SOCKS proxy or VPN
+tunnel. This page covers common connectivity patterns.
+
+## SOCKS Proxy
+
+For clusters behind a campus network or firewall, use a SOCKS5 proxy through
+an SSH tunnel to a bastion host:
+
+```bash
+# Start a SOCKS5 proxy via SSH
+ssh -D 1080 -fN bastion.example.com
+
+# Configure tools to use the proxy
+export HTTPS_PROXY=socks5h://localhost:1080
+```
+
+Once the proxy is running, `kubectl`, `tofu`, and `curl` commands will route
+through it automatically via the `HTTPS_PROXY` environment variable.
+
+## Justfile Integration
+
+The `proxy-up` recipe starts the proxy, and `bk` / `bcurl` wrappers route
+commands through it:
+
+```bash
+just proxy-up         # Start SOCKS proxy
+just bk get pods -A   # kubectl through proxy
+just bcurl https://... # curl through proxy
+```
+
+## Tailscale
+
+For clusters accessible via Tailscale, no proxy is needed — the cluster nodes
+are directly reachable on the tailnet. Ensure the Tailscale client is running
+and authenticated.
+
+## See Also
+
+- [Clusters and Environments](./clusters-and-environments.md) -- namespace layout
+- [Quick Start](./quick-start.md) -- deployment walkthrough

--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+/**
+ * Dead link checker for markdown cross-references and docs-site routes.
+ *
+ * Usage:
+ *   node scripts/check-links.js [--mode markdown|site] [--verbose]
+ *
+ * Modes:
+ *   markdown (default) — validates relative links in *.md files resolve to real files
+ *   site               — validates every docs-site nav slug resolves via getDocPage()
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { join, dirname, resolve, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const mode = args.includes('--mode')
+	? args[args.indexOf('--mode') + 1] || 'markdown'
+	: 'markdown';
+const verbose = args.includes('--verbose') || args.includes('-v');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Recursively collect files matching a predicate. */
+function walk(dir, predicate, results = []) {
+	let entries;
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return results;
+	}
+	for (const entry of entries) {
+		// Skip hidden dirs, node_modules, build artifacts, .svelte-kit
+		if (entry.startsWith('.') || entry === 'node_modules' || entry === 'build') continue;
+		const full = join(dir, entry);
+		let s;
+		try {
+			s = statSync(full);
+		} catch {
+			continue;
+		}
+		if (s.isDirectory()) {
+			walk(full, predicate, results);
+		} else if (predicate(entry, full)) {
+			results.push(full);
+		}
+	}
+	return results;
+}
+
+/** Extract markdown links from content, returning [{line, target, text}]. */
+function extractLinks(content) {
+	const links = [];
+	const lines = content.split('\n');
+	let inCodeBlock = false;
+	for (let i = 0; i < lines.length; i++) {
+		// Track fenced code blocks (``` or ~~~)
+		if (/^(`{3,}|~{3,})/.test(lines[i].trim())) {
+			inCodeBlock = !inCodeBlock;
+			continue;
+		}
+		if (inCodeBlock) continue;
+
+		// Skip inline code spans before matching links
+		const line = lines[i].replace(/`[^`]+`/g, '');
+
+		// Match [text](target) but not ![alt](image)
+		const re = /(?<!!)\[([^\]]*)\]\(([^)]+)\)/g;
+		let m;
+		while ((m = re.exec(line)) !== null) {
+			links.push({ line: i + 1, text: m[1], target: m[2] });
+		}
+	}
+	return links;
+}
+
+/** Check if a relative markdown target resolves to a real file. */
+function resolveTarget(target, fromDir) {
+	// Strip fragment
+	const [pathPart] = target.split('#');
+	if (!pathPart) return true; // pure #anchor — skip for now
+
+	const resolved = resolve(fromDir, pathPart);
+
+	// Direct file match
+	if (existsSync(resolved)) return true;
+
+	// If target has no extension, try common markdown index files
+	if (!pathPart.endsWith('.md')) {
+		if (existsSync(join(resolved, 'index.md'))) return true;
+		if (existsSync(join(resolved, 'README.md'))) return true;
+		// Try appending .md
+		if (existsSync(resolved + '.md')) return true;
+	}
+
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Mode: markdown
+// ---------------------------------------------------------------------------
+
+async function checkMarkdown() {
+	const files = walk(ROOT, (name) => name.endsWith('.md'));
+	let broken = 0;
+	let checked = 0;
+
+	for (const file of files) {
+		const content = readFileSync(file, 'utf-8');
+		const links = extractLinks(content);
+		const fileDir = dirname(file);
+		const relFile = relative(ROOT, file);
+
+		for (const link of links) {
+			// Skip external URLs, mailto, anchors-only
+			if (/^https?:\/\//.test(link.target)) continue;
+			if (link.target.startsWith('mailto:')) continue;
+			if (link.target.startsWith('#')) continue;
+
+			checked++;
+
+			if (!resolveTarget(link.target, fileDir)) {
+				console.error(`  BROKEN  ${relFile}:${link.line}  →  ${link.target}`);
+				broken++;
+			} else if (verbose) {
+				console.log(`  ok      ${relFile}:${link.line}  →  ${link.target}`);
+			}
+		}
+	}
+
+	console.log(`\nChecked ${checked} links across ${files.length} markdown files.`);
+	if (broken > 0) {
+		console.error(`\n${broken} broken link(s) found.`);
+		process.exit(1);
+	}
+	console.log('All links OK.');
+}
+
+// ---------------------------------------------------------------------------
+// Mode: site
+// ---------------------------------------------------------------------------
+
+async function checkSite() {
+	const docsTs = join(ROOT, 'docs-site', 'src', 'lib', 'server', 'docs.ts');
+	if (!existsSync(docsTs)) {
+		console.error('docs-site/src/lib/server/docs.ts not found — skipping site mode.');
+		process.exit(1);
+	}
+
+	// Dynamic import — requires ts-node or running after build
+	// For simplicity, we re-implement the slug resolution inline
+	const DOCS_DIR = join(ROOT, 'docs');
+
+	/** Collect all .md files under docs/ and derive their slugs. */
+	const mdFiles = walk(DOCS_DIR, (name) => name.endsWith('.md'));
+
+	// Build set of valid slugs (mirroring docs.ts resolution)
+	const validSlugs = new Set();
+	for (const file of mdFiles) {
+		let slug = relative(DOCS_DIR, file)
+			.replace(/\.md$/, '')
+			.replace(/\/index$/, '')
+			.replace(/\/README$/i, '');
+		validSlugs.add(slug);
+	}
+
+	// Now walk the nav tree to find all slugs the site would generate
+	// (Re-implementing walkDir from docs.ts to avoid TypeScript import issues)
+	function buildNavSlugs(dir, base, results = []) {
+		let entries;
+		try {
+			entries = readdirSync(dir).sort();
+		} catch {
+			return results;
+		}
+		for (const entry of entries) {
+			if (entry.startsWith('.')) continue;
+			const full = join(dir, entry);
+			let s;
+			try {
+				s = statSync(full);
+			} catch {
+				continue;
+			}
+			if (s.isDirectory()) {
+				buildNavSlugs(full, base, results);
+			} else if (
+				entry.endsWith('.md') &&
+				entry !== 'index.md' &&
+				entry.toUpperCase() !== 'README.MD'
+			) {
+				const slug = relative(base, full)
+					.replace(/\.md$/, '')
+					.replace(/\/index$/, '')
+					.replace(/\/README$/i, '');
+				results.push(slug);
+			}
+		}
+		return results;
+	}
+
+	const navSlugs = buildNavSlugs(DOCS_DIR, DOCS_DIR);
+	let broken = 0;
+
+	for (const slug of navSlugs) {
+		// Check if the slug resolves (same logic as getDocPage)
+		const candidates = [
+			join(DOCS_DIR, `${slug}.md`),
+			join(DOCS_DIR, slug, 'index.md'),
+			join(DOCS_DIR, slug, 'README.md')
+		];
+		const found = candidates.some((c) => existsSync(c));
+		if (!found) {
+			console.error(`  BROKEN  docs route: /docs/${slug}  →  no matching file`);
+			broken++;
+		} else if (verbose) {
+			console.log(`  ok      /docs/${slug}`);
+		}
+	}
+
+	console.log(`\nChecked ${navSlugs.length} docs-site routes.`);
+	if (broken > 0) {
+		console.error(`\n${broken} broken route(s) found.`);
+		process.exit(1);
+	}
+	console.log('All routes OK.');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+console.log(`check-links: mode=${mode}\n`);
+
+if (mode === 'markdown') {
+	await checkMarkdown();
+} else if (mode === 'site') {
+	await checkSite();
+} else {
+	console.error(`Unknown mode: ${mode}. Use --mode markdown or --mode site.`);
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/check-links.js` — Node.js link checker with two modes:
  - `--mode markdown` (default): validates all relative `[text](./path.md)` cross-references resolve to real files, skipping code blocks and inline code
  - `--mode site`: validates every docs-site nav slug resolves via the same logic as `getDocPage()`
- Wires `check-links` into `just check` (runs on every validation cycle)
- Adds `check-links` job to GitHub Actions `validate.yml` (runs both modes)
- Creates `docs/infrastructure/proxy-and-access.md` to fix 5 broken references found by the checker
- Zero new dependencies — uses only Node.js built-ins

## Test plan

- [ ] `node scripts/check-links.js --mode markdown` exits 0
- [ ] `node scripts/check-links.js --mode site` exits 0
- [ ] `just check-links` passes
- [ ] CI `check-links` job passes
- [ ] Intentionally break a link → exits 1 with file:line error