### PR TITLE
fix(runners): make nix emptyDir volume conditional

### DIFF
--- a/tofu/modules/gitlab-runner/locals.tf
+++ b/tofu/modules/gitlab-runner/locals.tf
@@ -111,15 +111,15 @@ locals {
       ] : []
     )
 
-    # Nix store volume configuration
-    volumes = [
+    # Nix store volume configuration (only when emptyDir is enabled)
+    volumes = var.nix_store_emptydir ? [
       {
         name       = "nix-store"
         mount_path = "/nix"
         type       = "emptyDir"
         size_limit = var.nix_store_size
       }
-    ]
+    ] : []
   } : null
 
   # =============================================================================
@@ -211,8 +211,8 @@ locals {
           image = "docker:${var.docker_version}"
           command = ["--storage-driver=overlay2", "--tls=false"]
         %{endif~}
-        %{if var.runner_type == "nix"~}
-        # Nix store volume
+        %{if var.runner_type == "nix" && var.nix_store_emptydir~}
+        # Nix store volume (WARNING: shadows image /nix — use init container to preserve)
         [[runners.kubernetes.volumes.empty_dir]]
           name = "nix-store"
           mount_path = "/nix"

--- a/tofu/modules/gitlab-runner/variables.tf
+++ b/tofu/modules/gitlab-runner/variables.tf
@@ -229,6 +229,12 @@ variable "nix_store_size" {
   default     = "20Gi"
 }
 
+variable "nix_store_emptydir" {
+  description = "Mount emptyDir at /nix. WARNING: shadows the image's /nix, breaking all Nix binaries. Disable (false) to use container overlay storage instead."
+  type        = bool
+  default     = false
+}
+
 # =============================================================================
 # HPA Configuration
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add `nix_store_emptydir` variable (default `false`) to gitlab-runner module
- Make the emptyDir volume at `/nix` conditional on this variable in both `nix_config.volumes` and the TOML template

## Problem

The emptyDir mount at `/nix` shadows the `nixos/nix` image's entire Nix store, destroying all binaries (including `/bin/sh`) and causing `exec: "sh": executable file not found in $PATH` failures on K8s executor pods.

## Fix

Default `nix_store_emptydir = false` so container overlay storage preserves the image's `/nix`. Callers that need a separate emptyDir (e.g., for persistent Nix store across init containers) can opt in explicitly.