### PR TITLE
feat(runners): add spread_to_nodes for pod anti-affinity

### DIFF
--- a/tofu/modules/gitlab-runner/main.tf
+++ b/tofu/modules/gitlab-runner/main.tf
@@ -185,11 +185,14 @@ resource "helm_release" "gitlab_runner" {
 
   # Additional values including runner config
   values = [
-    yamlencode({
-      runners = {
-        config = local.runner_config_toml
-      }
-    }),
+    yamlencode(merge(
+      {
+        runners = {
+          config = local.runner_config_toml
+        }
+      },
+      local.manager_affinity_values
+    )),
     var.additional_values != "" ? var.additional_values : ""
   ]
 }

--- a/tofu/modules/gitlab-runner/variables.tf
+++ b/tofu/modules/gitlab-runner/variables.tf
@@ -502,3 +502,13 @@ variable "gpu_tolerations" {
   }))
   default = []
 }
+
+# =============================================================================
+# Anti-Affinity / Topology Spread
+# =============================================================================
+
+variable "spread_to_nodes" {
+  description = "Enable pod anti-affinity to spread manager and job pods across nodes"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- Add `spread_to_nodes` variable (default `false`) to the gitlab-runner module
- When enabled, manager pods get weight-100 `preferredDuringSchedulingIgnoredDuringExecution` podAntiAffinity via Helm values
- Job pods get weight-50 native TOML `[runners.kubernetes.affinity]` anti-affinity
- Uses GA native TOML (no feature flag needed)

## Context
All 15 runner manager pods + job pods landed on vmnode753 (90% CPU requests, 735% limits). This adds soft anti-affinity to spread across nodes.

## Files changed
- `tofu/modules/gitlab-runner/variables.tf` — new `spread_to_nodes` variable
- `tofu/modules/gitlab-runner/locals.tf` — manager affinity values + job TOML block
- `tofu/modules/gitlab-runner/main.tf` — merge affinity into Helm values