### PR TITLE
fix(runners): use part-of label for anti-affinity matching

### DIFF
--- a/tofu/modules/gitlab-runner/locals.tf
+++ b/tofu/modules/gitlab-runner/locals.tf
@@ -179,6 +179,9 @@ locals {
   # =============================================================================
 
   manager_affinity_values = var.spread_to_nodes ? {
+    podLabels = {
+      "app.kubernetes.io/part-of" = "gitlab-runners"
+    }
     affinity = {
       podAntiAffinity = {
         preferredDuringSchedulingIgnoredDuringExecution = [
@@ -187,7 +190,7 @@ locals {
             podAffinityTerm = {
               labelSelector = {
                 matchLabels = {
-                  "app.kubernetes.io/name" = "gitlab-runner"
+                  "app.kubernetes.io/part-of" = "gitlab-runners"
                 }
               }
               topologyKey = "kubernetes.io/hostname"


### PR DESCRIPTION
The Helm chart uses its own labels (app, chart, release, heritage), not app.kubernetes.io/name. The anti-affinity selector didn't match any pods. Fix: inject podLabels.app.kubernetes.io/part-of=gitlab-runners and match on that.