### PR TITLE
fix(runners): use part-of label and yamlencode for anti-affinity

### DIFF
--- a/tofu/modules/gitlab-runner/locals.tf
+++ b/tofu/modules/gitlab-runner/locals.tf
@@ -178,28 +178,29 @@ locals {
   # Manager Pod Anti-Affinity (Helm values)
   # =============================================================================
 
-  manager_affinity_values = var.spread_to_nodes ? {
-    podLabels = {
-      "app.kubernetes.io/part-of" = "gitlab-runners"
-    }
-    affinity = {
-      podAntiAffinity = {
-        preferredDuringSchedulingIgnoredDuringExecution = [
-          {
-            weight = 100
-            podAffinityTerm = {
-              labelSelector = {
-                matchLabels = {
-                  "app.kubernetes.io/part-of" = "gitlab-runners"
-                }
-              }
-              topologyKey = "kubernetes.io/hostname"
-            }
-          }
-        ]
-      }
-    }
+  # Pod label for anti-affinity selector (always safe to add)
+  manager_spread_labels = var.spread_to_nodes ? {
+    "app.kubernetes.io/part-of" = "gitlab-runners"
   } : {}
+
+  # Manager pod anti-affinity (spread across nodes)
+  manager_affinity = var.spread_to_nodes ? {
+    podAntiAffinity = {
+      preferredDuringSchedulingIgnoredDuringExecution = [
+        {
+          weight = 100
+          podAffinityTerm = {
+            labelSelector = {
+              matchLabels = {
+                "app.kubernetes.io/part-of" = "gitlab-runners"
+              }
+            }
+            topologyKey = "kubernetes.io/hostname"
+          }
+        }
+      ]
+    }
+  } : null
 
   # =============================================================================
   # Kubernetes Runner Configuration (TOML)

--- a/tofu/modules/gitlab-runner/main.tf
+++ b/tofu/modules/gitlab-runner/main.tf
@@ -184,15 +184,18 @@ resource "helm_release" "gitlab_runner" {
   }
 
   # Additional values including runner config
-  values = [
-    yamlencode(merge(
-      {
+  values = concat(
+    [
+      yamlencode({
         runners = {
           config = local.runner_config_toml
         }
-      },
-      local.manager_affinity_values
-    )),
-    var.additional_values != "" ? var.additional_values : ""
-  ]
+      })
+    ],
+    local.manager_affinity != null ? [yamlencode({
+      podLabels = local.manager_spread_labels
+      affinity  = local.manager_affinity
+    })] : [],
+    var.additional_values != "" ? [var.additional_values] : []
+  )
 }


### PR DESCRIPTION
Fixes two issues from #54: dots in Helm set keys nest incorrectly, and ternary type mismatch. Uses yamlencode values + split locals.