### PR TITLE
fix: align HPA/PDB/ServiceMonitor with Helm deployment name

### DIFF
--- a/tofu/modules/gitlab-runner/hpa.tf
+++ b/tofu/modules/gitlab-runner/hpa.tf
@@ -106,7 +106,7 @@ resource "kubernetes_pod_disruption_budget_v1" "runner" {
 
     selector {
       match_labels = {
-        "app"     = "gitlab-runner"
+        "app"     = var.runner_name
         "release" = var.runner_name
       }
     }

--- a/tofu/modules/gitlab-runner/main.tf
+++ b/tofu/modules/gitlab-runner/main.tf
@@ -42,6 +42,14 @@ resource "helm_release" "gitlab_runner" {
   namespace        = var.namespace
   create_namespace = false
 
+  # Override the Helm chart's default name (release-gitlab-runner) to just
+  # the release name. This ensures the Deployment, Service, and pod labels
+  # all use var.runner_name, which HPA, PDB, and ServiceMonitor reference.
+  set {
+    name  = "fullnameOverride"
+    value = var.runner_name
+  }
+
   depends_on = [kubernetes_namespace_v1.runner]
 
   # Runner token (sensitive)

--- a/tofu/modules/gitlab-runner/monitoring.tf
+++ b/tofu/modules/gitlab-runner/monitoring.tf
@@ -24,7 +24,7 @@ resource "kubernetes_manifest" "service_monitor" {
     spec = {
       selector = {
         matchLabels = {
-          "app"     = "gitlab-runner"
+          "app"     = var.runner_name
           "release" = var.runner_name
         }
       }


### PR DESCRIPTION
## Summary

- Add `fullnameOverride` to Helm release so deployment name matches `var.runner_name`
- Fix PDB selector: `app = var.runner_name` (was `"gitlab-runner"`)
- Fix ServiceMonitor selector: `app = var.runner_name` (was `"gitlab-runner"`)

## Problem

The gitlab-runner Helm chart names deployments as `{release}-gitlab-runner` by default, but:
- HPA `scaleTargetRef.name` was `var.runner_name` (missing `-gitlab-runner` suffix)
- PDB selected `app=gitlab-runner` (literal string, not matching any pod)
- ServiceMonitor selected `app=gitlab-runner` (same issue)

## Fix

Setting `fullnameOverride = var.runner_name` makes the Helm chart name all resources as just the release name. Then PDB/ServiceMonitor selectors use `app = var.runner_name` to match correctly.