### PR TITLE
fix(runners): increase Helm release timeout to 600s

### DIFF
--- a/tofu/modules/gitlab-runner/main.tf
+++ b/tofu/modules/gitlab-runner/main.tf
@@ -41,6 +41,7 @@ resource "helm_release" "gitlab_runner" {
   version          = var.chart_version
   namespace        = var.namespace
   create_namespace = false
+  timeout          = 600 # 10 minutes; rolling updates with PDB can exceed default 5m
 
   # Override the Helm chart's default name (release-gitlab-runner) to just
   # the release name. This ensures the Deployment, Service, and pod labels


### PR DESCRIPTION
## Summary
- Increase Helm release timeout from default 300s to 600s
- Rolling updates with PDB protection can exceed 5 minutes when HPA has scaled to many replicas