### PR TITLE
feat: mirror Docker Hub images to GHCR

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -1,0 +1,39 @@
+name: Mirror Docker Hub Images to GHCR
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly Monday 06:00 UTC
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/mirror-images.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    name: Mirror ${{ matrix.source }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - source: buchgr/bazel-remote-cache:v2.4.4
+            target: ghcr.io/tinyland-inc/bazel-remote-cache:v2.4.4
+          - source: busybox:1.36
+            target: ghcr.io/tinyland-inc/busybox:1.36
+          - source: bitnami/kubectl:1.31
+            target: ghcr.io/tinyland-inc/kubectl:1.31
+
+    steps:
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Copy ${{ matrix.source }}
+        run: crane copy "${{ matrix.source }}" "${{ matrix.target }}"

--- a/tofu/modules/bazel-cache/main.tf
+++ b/tofu/modules/bazel-cache/main.tf
@@ -149,6 +149,13 @@ resource "kubernetes_deployment_v1" "main" {
           fs_group        = 1000
         }
 
+        dynamic "image_pull_secrets" {
+          for_each = var.image_pull_secrets
+          content {
+            name = image_pull_secrets.value
+          }
+        }
+
         # Init containers for waiting on dependencies
         dynamic "init_container" {
           for_each = var.init_containers

--- a/tofu/modules/bazel-cache/variables.tf
+++ b/tofu/modules/bazel-cache/variables.tf
@@ -110,7 +110,7 @@ variable "max_queued_uploads" {
 variable "image" {
   description = "bazel-remote container image"
   type        = string
-  default     = "buchgr/bazel-remote-cache:v2.4.4"
+  default     = "ghcr.io/tinyland-inc/bazel-remote-cache:v2.4.4"
 }
 
 variable "cpu_request" {
@@ -267,6 +267,12 @@ variable "additional_labels" {
 # =============================================================================
 # Init Containers
 # =============================================================================
+
+variable "image_pull_secrets" {
+  description = "List of image pull secret names for private registries"
+  type        = list(string)
+  default     = []
+}
 
 variable "init_containers" {
   description = "Init containers to run before the main container"

--- a/tofu/modules/hpa-deployment/main.tf
+++ b/tofu/modules/hpa-deployment/main.tf
@@ -129,6 +129,13 @@ resource "kubernetes_deployment" "main" {
           }
         }
 
+        dynamic "image_pull_secrets" {
+          for_each = var.image_pull_secrets
+          content {
+            name = image_pull_secrets.value
+          }
+        }
+
         # Init containers for waiting on dependencies
         dynamic "init_container" {
           for_each = var.init_containers

--- a/tofu/modules/hpa-deployment/variables.tf
+++ b/tofu/modules/hpa-deployment/variables.tf
@@ -507,6 +507,12 @@ variable "pdb_min_available" {
 # Init Containers
 # =============================================================================
 
+variable "image_pull_secrets" {
+  description = "List of image pull secret names for private registries"
+  type        = list(string)
+  default     = []
+}
+
 variable "init_containers" {
   description = "Init containers to run before the main container (for waiting on dependencies)"
   type = list(object({

--- a/tofu/modules/runner-cleanup/main.tf
+++ b/tofu/modules/runner-cleanup/main.tf
@@ -174,6 +174,13 @@ resource "kubernetes_cron_job_v1" "cleanup" {
             service_account_name = kubernetes_service_account_v1.cleanup.metadata[0].name
             restart_policy       = "OnFailure"
 
+            dynamic "image_pull_secrets" {
+              for_each = var.image_pull_secrets
+              content {
+                name = image_pull_secrets.value
+              }
+            }
+
             container {
               name    = "cleanup"
               image   = var.kubectl_image

--- a/tofu/modules/runner-cleanup/variables.tf
+++ b/tofu/modules/runner-cleanup/variables.tf
@@ -32,5 +32,11 @@ variable "failed_threshold_seconds" {
 variable "kubectl_image" {
   description = "Container image for kubectl"
   type        = string
-  default     = "bitnami/kubectl:latest"
+  default     = "ghcr.io/tinyland-inc/kubectl:1.31"
+}
+
+variable "image_pull_secrets" {
+  description = "List of image pull secret names for private registries"
+  type        = list(string)
+  default     = []
 }

--- a/tofu/stacks/attic/variables.tf
+++ b/tofu/stacks/attic/variables.tf
@@ -661,6 +661,29 @@ variable "enable_cache_warming" {
 }
 
 # =============================================================================
+# GHCR Registry Authentication
+# =============================================================================
+
+variable "ghcr_token" {
+  description = "GHCR personal access token for pulling mirrored images (empty to skip)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "ghcr_username" {
+  description = "GHCR username for image pull authentication"
+  type        = string
+  default     = "tinyland-inc"
+}
+
+variable "init_image" {
+  description = "Init container image (busybox mirror on GHCR)"
+  type        = string
+  default     = "ghcr.io/tinyland-inc/busybox:1.36"
+}
+
+# =============================================================================
 # Bazel Remote Cache Configuration
 # =============================================================================
 # Optional bazel-remote cache server for Bazel action caching.

--- a/tofu/stacks/gitlab-runners/variables.tf
+++ b/tofu/stacks/gitlab-runners/variables.tf
@@ -76,6 +76,43 @@ variable "k8s_concurrent_jobs" {
   default     = 4
 }
 
+# =============================================================================
+# Runner Cleanup
+# =============================================================================
+
+variable "enable_runner_cleanup" {
+  description = "Deploy runner cleanup CronJob"
+  type        = bool
+  default     = false
+}
+
+variable "kubectl_image" {
+  description = "Container image for kubectl (cleanup job)"
+  type        = string
+  default     = "ghcr.io/tinyland-inc/kubectl:1.31"
+}
+
+# =============================================================================
+# GHCR Registry Authentication
+# =============================================================================
+
+variable "ghcr_token" {
+  description = "GHCR personal access token for pulling mirrored images (empty to skip)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "ghcr_username" {
+  description = "GHCR username for image pull authentication"
+  type        = string
+  default     = "tinyland-inc"
+}
+
+# =============================================================================
+# Runner Resources
+# =============================================================================
+
 variable "nix_cpu_request" {
   description = "CPU request for Nix runner manager"
   type        = string


### PR DESCRIPTION
## Summary
- Adds `crane copy` GitHub Actions workflow to mirror `bazel-remote-cache`, `busybox`, and `kubectl` from Docker Hub to `ghcr.io/tinyland-inc/` (weekly + on-push + dispatch)
- Updates all module defaults and stack references to pull from GHCR instead of Docker Hub
- Adds opt-in `image_pull_secrets` support across `bazel-cache`, `runner-cleanup`, and `hpa-deployment` modules
- Wires GHCR auth secret + `image_pull_secrets` into `attic` and `gitlab-runners` stacks

## Motivation
Civo cluster hits Docker Hub anonymous pull rate limits (429), breaking bazel-cache, init containers, and runner-cleanup pods.

## Test plan
- [ ] Merge to main → confirm `mirror-images.yml` runs and images appear at `ghcr.io/tinyland-inc/`
- [ ] `tofu validate` in `tofu/stacks/attic/` and `tofu/stacks/gitlab-runners/`
- [ ] `tofu plan` in tinyland-infra overlay — should show image changes + new pull secrets
- [ ] After apply: `kubectl get pods -n nix-cache` shows pods pulling from GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)