### PR TITLE
fix: use bitnami/kubectl:latest tag

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -25,8 +25,8 @@ jobs:
             target: ghcr.io/tinyland-inc/bazel-remote-cache:v2.4.4
           - source: busybox:1.36
             target: ghcr.io/tinyland-inc/busybox:1.36
-          - source: bitnami/kubectl:1.31
-            target: ghcr.io/tinyland-inc/kubectl:1.31
+          - source: bitnami/kubectl:latest
+            target: ghcr.io/tinyland-inc/kubectl:latest
 
     steps:
       - name: Install crane

--- a/tofu/modules/runner-cleanup/variables.tf
+++ b/tofu/modules/runner-cleanup/variables.tf
@@ -32,7 +32,7 @@ variable "failed_threshold_seconds" {
 variable "kubectl_image" {
   description = "Container image for kubectl"
   type        = string
-  default     = "ghcr.io/tinyland-inc/kubectl:1.31"
+  default     = "ghcr.io/tinyland-inc/kubectl:latest"
 }
 
 variable "image_pull_secrets" {

--- a/tofu/stacks/gitlab-runners/variables.tf
+++ b/tofu/stacks/gitlab-runners/variables.tf
@@ -89,7 +89,7 @@ variable "enable_runner_cleanup" {
 variable "kubectl_image" {
   description = "Container image for kubectl (cleanup job)"
   type        = string
-  default     = "ghcr.io/tinyland-inc/kubectl:1.31"
+  default     = "ghcr.io/tinyland-inc/kubectl:latest"
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Bitnami dropped semver tags for kubectl — `1.31` doesn't exist, only `latest` + sha256 digests
- Updates mirror workflow source and module/stack defaults from `:1.31` to `:latest`

## Context
The `bitnami/kubectl:1.31` copy step in #59's mirror workflow failed with `MANIFEST_UNKNOWN`. The other two images (busybox, bazel-remote-cache) mirrored successfully.

## Test plan
- [ ] Merge → mirror workflow re-runs, all 3 images succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)