### PR TITLE
fix: mirror heywoodlh/attic image to GHCR

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -27,6 +27,8 @@ jobs:
             target: ghcr.io/tinyland-inc/busybox:1.36
           - source: bitnami/kubectl:latest
             target: ghcr.io/tinyland-inc/kubectl:latest
+          - source: heywoodlh/attic:12cbeca141f46e1ade76728bce8adc447f2166c6
+            target: ghcr.io/tinyland-inc/attic:12cbeca141f46e1ade76728bce8adc447f2166c6
 
     steps:
       - name: Install crane


### PR DESCRIPTION
## Summary
- Add `heywoodlh/attic:12cbeca...` to the mirror workflow
- The attic app image itself is also hitting Docker Hub 429s on nodes without cached copies

## Context
After merging #59 and #60, init containers and bazel-cache pull from GHCR successfully. But the main attic container (`heywoodlh/attic`) is still pulled from Docker Hub and hits rate limits on nodes that don't have it cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)