### PR TITLE
fix: update attic_image default to GHCR mirror

### DIFF
--- a/tofu/stacks/attic/variables.tf
+++ b/tofu/stacks/attic/variables.tf
@@ -72,7 +72,7 @@ variable "attic_image" {
   type        = string
   # Pinned to commit 12cbeca (2026-01-22) for reproducibility and security
   # Update this when upgrading Attic version after testing
-  default = "heywoodlh/attic:12cbeca141f46e1ade76728bce8adc447f2166c6"
+  default = "ghcr.io/tinyland-inc/attic:12cbeca141f46e1ade76728bce8adc447f2166c6"
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Switch `attic_image` default from `heywoodlh/attic` (Docker Hub) to `ghcr.io/tinyland-inc/attic` to avoid rate limits
- Completes the GHCR migration started in #59/#61

## Test plan
- [ ] `tofu validate` passes
- [ ] Next `tofu plan` shows image change for attic deployment