### PR TITLE
feat(runners): support nix, docker, and dind runner types

### DIFF
--- a/tofu/stacks/gitlab-runners/outputs.tf
+++ b/tofu/stacks/gitlab-runners/outputs.tf
@@ -1,5 +1,5 @@
 output "nix_runner_namespace" {
-  description = "Namespace for Nix runner"
+  description = "Namespace for runners"
   value       = module.nix_runner.namespace
 }
 
@@ -8,7 +8,12 @@ output "nix_runner_release" {
   value       = module.nix_runner.release_name
 }
 
-output "k8s_runner_release" {
-  description = "K8s runner Helm release name"
-  value       = var.deploy_k8s_runner ? module.k8s_runner[0].release_name : ""
+output "docker_runner_release" {
+  description = "Docker runner Helm release name"
+  value       = var.deploy_docker_runner ? module.docker_runner[0].release_name : ""
+}
+
+output "dind_runner_release" {
+  description = "DinD runner Helm release name"
+  value       = var.deploy_dind_runner ? module.dind_runner[0].release_name : ""
 }

--- a/tofu/stacks/gitlab-runners/variables.tf
+++ b/tofu/stacks/gitlab-runners/variables.tf
@@ -25,19 +25,6 @@ variable "gitlab_url" {
   default     = "https://gitlab.com"
 }
 
-variable "nix_runner_token" {
-  description = "Runner token for Nix runner (create in GitLab > Settings > CI/CD > Runners)"
-  type        = string
-  sensitive   = true
-}
-
-variable "k8s_runner_token" {
-  description = "Runner token for K8s runner (create in GitLab > Settings > CI/CD > Runners)"
-  type        = string
-  sensitive   = true
-  default     = ""
-}
-
 # =============================================================================
 # Namespace
 # =============================================================================
@@ -55,25 +42,268 @@ variable "create_namespace" {
 }
 
 # =============================================================================
-# Runner Configuration
+# Runner Tokens (sensitive - pass via -var flags)
 # =============================================================================
 
-variable "deploy_k8s_runner" {
-  description = "Deploy the K8s/tofu runner"
+variable "nix_runner_token" {
+  description = "Runner token for Nix runner (create in GitLab > Settings > CI/CD > Runners)"
+  type        = string
+  sensitive   = true
+}
+
+variable "docker_runner_token" {
+  description = "Runner token for Docker runner"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "dind_runner_token" {
+  description = "Runner token for DinD runner"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# =============================================================================
+# Runner Names (override per deployment)
+# =============================================================================
+
+variable "nix_runner_name" {
+  description = "Helm release name for Nix runner"
+  type        = string
+  default     = "nix-runner"
+}
+
+variable "docker_runner_name" {
+  description = "Helm release name for Docker runner"
+  type        = string
+  default     = "docker-runner"
+}
+
+variable "dind_runner_name" {
+  description = "Helm release name for DinD runner"
+  type        = string
+  default     = "dind-runner"
+}
+
+# =============================================================================
+# Deploy Toggles
+# =============================================================================
+
+variable "deploy_docker_runner" {
+  description = "Deploy the Docker runner"
   type        = bool
   default     = true
 }
 
+variable "deploy_dind_runner" {
+  description = "Deploy the DinD runner"
+  type        = bool
+  default     = false
+}
+
+# =============================================================================
+# Common Runner Configuration
+# =============================================================================
+
+variable "use_legacy_exec_strategy" {
+  description = "Use legacy Kubernetes exec strategy"
+  type        = bool
+  default     = true
+}
+
+variable "spread_to_nodes" {
+  description = "Enable pod anti-affinity to spread across nodes"
+  type        = bool
+  default     = true
+}
+
+variable "manager_priority_class_name" {
+  description = "PriorityClass for runner manager pods"
+  type        = string
+  default     = ""
+}
+
+variable "job_priority_class_name" {
+  description = "PriorityClass for CI job pods"
+  type        = string
+  default     = ""
+}
+
+# =============================================================================
+# Manager Pod Resources (shared across all runners)
+# =============================================================================
+
+variable "manager_cpu_request" {
+  description = "CPU request for runner manager pods"
+  type        = string
+  default     = "50m"
+}
+
+variable "manager_memory_request" {
+  description = "Memory request for runner manager pods"
+  type        = string
+  default     = "128Mi"
+}
+
+variable "manager_cpu_limit" {
+  description = "CPU limit for runner manager pods"
+  type        = string
+  default     = "200m"
+}
+
+variable "manager_memory_limit" {
+  description = "Memory limit for runner manager pods"
+  type        = string
+  default     = "256Mi"
+}
+
+# =============================================================================
+# Nix Runner Configuration
+# =============================================================================
+
 variable "nix_concurrent_jobs" {
   description = "Max concurrent Nix build jobs"
   type        = number
-  default     = 4
+  default     = 6
 }
 
-variable "k8s_concurrent_jobs" {
-  description = "Max concurrent K8s deploy jobs"
+variable "nix_job_cpu_request" {
+  type    = string
+  default = "500m"
+}
+
+variable "nix_job_memory_request" {
+  type    = string
+  default = "1Gi"
+}
+
+variable "nix_job_cpu_limit" {
+  type    = string
+  default = "4"
+}
+
+variable "nix_job_memory_limit" {
+  type    = string
+  default = "8Gi"
+}
+
+variable "nix_hpa_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "nix_hpa_min_replicas" {
+  type    = number
+  default = 2
+}
+
+variable "nix_hpa_max_replicas" {
+  type    = number
+  default = 5
+}
+
+variable "attic_server" {
+  description = "Attic cache server URL for Nix runner"
+  type        = string
+  default     = ""
+}
+
+variable "attic_cache" {
+  description = "Attic cache name"
+  type        = string
+  default     = "main"
+}
+
+# =============================================================================
+# Docker Runner Configuration
+# =============================================================================
+
+variable "docker_concurrent_jobs" {
+  description = "Max concurrent Docker jobs"
   type        = number
-  default     = 4
+  default     = 12
+}
+
+variable "docker_job_cpu_request" {
+  type    = string
+  default = "100m"
+}
+
+variable "docker_job_memory_request" {
+  type    = string
+  default = "256Mi"
+}
+
+variable "docker_job_cpu_limit" {
+  type    = string
+  default = "2"
+}
+
+variable "docker_job_memory_limit" {
+  type    = string
+  default = "4Gi"
+}
+
+variable "docker_hpa_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "docker_hpa_min_replicas" {
+  type    = number
+  default = 2
+}
+
+variable "docker_hpa_max_replicas" {
+  type    = number
+  default = 8
+}
+
+# =============================================================================
+# DinD Runner Configuration
+# =============================================================================
+
+variable "dind_concurrent_jobs" {
+  description = "Max concurrent DinD jobs"
+  type        = number
+  default     = 6
+}
+
+variable "dind_job_cpu_request" {
+  type    = string
+  default = "500m"
+}
+
+variable "dind_job_memory_request" {
+  type    = string
+  default = "1Gi"
+}
+
+variable "dind_job_cpu_limit" {
+  type    = string
+  default = "4"
+}
+
+variable "dind_job_memory_limit" {
+  type    = string
+  default = "8Gi"
+}
+
+variable "dind_hpa_enabled" {
+  type    = bool
+  default = true
+}
+
+variable "dind_hpa_min_replicas" {
+  type    = number
+  default = 1
+}
+
+variable "dind_hpa_max_replicas" {
+  type    = number
+  default = 5
 }
 
 # =============================================================================
@@ -107,20 +337,4 @@ variable "ghcr_username" {
   description = "GHCR username for image pull authentication"
   type        = string
   default     = "tinyland-inc"
-}
-
-# =============================================================================
-# Runner Resources
-# =============================================================================
-
-variable "nix_cpu_request" {
-  description = "CPU request for Nix runner manager"
-  type        = string
-  default     = "100m"
-}
-
-variable "nix_memory_request" {
-  description = "Memory request for Nix runner manager"
-  type        = string
-  default     = "128Mi"
 }


### PR DESCRIPTION
## Summary

- Rewrites the `gitlab-runners` stack to deploy 3 runner types (nix, docker, dind) instead of the previous nix+k8s pair
- Each runner has configurable name, token, job resources, HPA settings, and concurrency via variables
- Defaults match the live tinyland-civo-dev cluster (tl-nix, tl-docker, tl-dind)
- Removes hardcoded runner config in favor of the `gitlab-runner` module's built-in `runner_type` system

## State

- New state `gitlab-runners-tinyland` created in GitLab with 11 imported resources
- `tofu plan` returns "No changes. Infrastructure matches configuration."

## Test plan

- [x] `tofu validate` passes
- [x] All 11 resources imported successfully
- [x] `tofu plan` shows no drift after apply
- [x] All runner pods healthy: tl-nix (2), tl-docker (2), tl-dind (1)
- [x] HPAs functioning: tl-nix-hpa, tl-docker-hpa, tl-dind-hpa
- [x] runner-cleanup CronJob running every 5 minutes