### PR TITLE
fix: mirror alpine:3.19 and remove last Docker Hub reference

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -27,6 +27,8 @@ jobs:
             target: ghcr.io/tinyland-inc/busybox:1.36
           - source: bitnami/kubectl:latest
             target: ghcr.io/tinyland-inc/kubectl:latest
+          - source: alpine:3.19
+            target: ghcr.io/tinyland-inc/alpine:3.19
           - source: heywoodlh/attic:12cbeca141f46e1ade76728bce8adc447f2166c6
             target: ghcr.io/tinyland-inc/attic:12cbeca141f46e1ade76728bce8adc447f2166c6
 

--- a/tofu/stacks/attic/main.tf
+++ b/tofu/stacks/attic/main.tf
@@ -1178,7 +1178,7 @@ resource "kubernetes_job_v1" "init_cache" {
 
         container {
           name  = "init"
-          image = "alpine:3.19"
+          image = var.init_cache_image
 
           command = ["/bin/sh", "-c"]
           args = [

--- a/tofu/stacks/attic/variables.tf
+++ b/tofu/stacks/attic/variables.tf
@@ -683,6 +683,12 @@ variable "init_image" {
   default     = "ghcr.io/tinyland-inc/busybox:1.36"
 }
 
+variable "init_cache_image" {
+  description = "Image for init-cache job (needs apk/curl/openssl)"
+  type        = string
+  default     = "ghcr.io/tinyland-inc/alpine:3.19"
+}
+
 # =============================================================================
 # Bazel Remote Cache Configuration
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds `alpine:3.19` to the mirror-images workflow (crane copy to `ghcr.io/tinyland-inc/alpine:3.19`)
- Replaces the hardcoded `alpine:3.19` in the `init_cache` job with a new `init_cache_image` variable
- This was the last Docker Hub image reference in the managed tofu stacks

## Test plan

- [ ] Run mirror-images workflow via `workflow_dispatch` to mirror alpine:3.19
- [ ] `tofu validate` passes in attic stack
- [ ] `tofu plan` shows only the image change for the init_cache job