### PR TITLE
fix(attic): add image_pull_secrets to init_cache job

### DIFF
--- a/tofu/stacks/attic/main.tf
+++ b/tofu/stacks/attic/main.tf
@@ -1176,6 +1176,13 @@ resource "kubernetes_job_v1" "init_cache" {
       spec {
         restart_policy = "OnFailure"
 
+        dynamic "image_pull_secrets" {
+          for_each = local.ghcr_pull_secrets
+          content {
+            name = image_pull_secrets.value
+          }
+        }
+
         container {
           name  = "init"
           image = var.init_cache_image


### PR DESCRIPTION
## Summary

- Adds `dynamic "image_pull_secrets"` block to the `init_cache` job pod spec
- Without this, the job fails with ImagePullBackOff when using the GHCR alpine mirror
- Also imported the existing `ghcr-auth` secret into the attic-tinyland state

## Test plan

- [x] `tofu plan` shows no changes (converged)
- [x] init_cache job completed successfully with GHCR alpine:3.19
- [x] Cache verified: `WantMassQuery: 1, StoreDir: /nix/store, Priority: 41`