### PR TITLE
fix(runner): move job resources before nested TOML tables

### DIFF
--- a/tofu/modules/gitlab-runner/locals.tf
+++ b/tofu/modules/gitlab-runner/locals.tf
@@ -225,6 +225,19 @@ locals {
         privileged = ${local.privileged}
         poll_timeout = ${var.poll_timeout}
         poll_interval = ${var.poll_interval}
+        # Job pod resources — MUST be before any nested [table] headers
+        # (TOML flat keys after a [nested.table] are parsed under that table)
+        cpu_request = "${var.job_cpu_request}"
+        memory_request = "${var.job_memory_request}"
+        cpu_limit = "${var.job_cpu_limit}"
+        memory_limit = "${var.job_memory_limit}"
+        %{if var.job_priority_class_name != ""~}
+        pod_priority_class_name = "${var.job_priority_class_name}"
+        %{endif~}
+        %{if var.cleanup_enabled~}
+        pod_termination_grace_period_seconds = ${var.cleanup_grace_seconds}
+        cleanup_grace_period_seconds = ${var.cleanup_grace_period_seconds}
+        %{endif~}
         %{if var.namespace_per_job~}
         namespace_per_job = true
         namespace_per_job_prefix = "${var.namespace_per_job_prefix}"
@@ -259,18 +272,6 @@ locals {
                   [[runners.kubernetes.affinity.pod_anti_affinity.preferred_during_scheduling_ignored_during_execution.pod_affinity_term.label_selector.match_expressions]]
                     key = "pod"
                     operator = "Exists"
-        %{endif~}
-        # Job pod resources
-        cpu_request = "${var.job_cpu_request}"
-        memory_request = "${var.job_memory_request}"
-        cpu_limit = "${var.job_cpu_limit}"
-        memory_limit = "${var.job_memory_limit}"
-        %{if var.job_priority_class_name != ""~}
-        pod_priority_class_name = "${var.job_priority_class_name}"
-        %{endif~}
-        %{if var.cleanup_enabled~}
-        pod_termination_grace_period_seconds = ${var.cleanup_grace_seconds}
-        cleanup_grace_period_seconds = ${var.cleanup_grace_period_seconds}
         %{endif~}
         %{if local.gpu_enabled~}
         # GPU node selector


### PR DESCRIPTION
## Summary
- TOML flat keys after a `[nested.table]` header are parsed under that nested table, not the parent
- `cpu_request`, `memory_request`, `cpu_limit`, and `memory_limit` were silently swallowed when `spread_to_nodes=true` (which injects `[runners.kubernetes.affinity]`)  
- Pods were getting the LimitRange default (1Gi) instead of the configured `memory_limit` (8Gi)

## Root Cause
The TOML template placed job pod resource settings AFTER the conditional `[runners.kubernetes.affinity]` block. In TOML, flat keys following a `[nested.table]` header belong to that nested table, not the parent `[runners.kubernetes]`.

## Fix
Move all flat key-value resource settings before any nested `[table]` headers to ensure correct TOML parsing.

## Test Plan
- [ ] Verify cgroup memory limit matches config via `/sys/fs/cgroup/memory.max` in job pod
- [ ] Confirm nix build jobs no longer OOM-killed at ~87s