### PR TITLE
feat(arc): GitHub Actions runner pool via ARC

### DIFF
--- a/.github/actions/docker-job/action.yml
+++ b/.github/actions/docker-job/action.yml
@@ -1,0 +1,21 @@
+name: "Docker Job (GloriousFlywheel)"
+description: "Run a CI job with Bazel cache configured for self-hosted runners"
+
+inputs:
+  command:
+    description: "Command to run"
+    required: true
+  bazel-cache:
+    description: "Bazel remote cache endpoint (auto-detected on self-hosted)"
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - uses: ./github/actions/setup-flywheel
+      with:
+        bazel-cache: ${{ inputs.bazel-cache }}
+
+    - name: Run command
+      shell: bash
+      run: ${{ inputs.command }}

--- a/.github/actions/nix-job/action.yml
+++ b/.github/actions/nix-job/action.yml
@@ -1,0 +1,41 @@
+name: "Nix Build (GloriousFlywheel)"
+description: "Run Nix build with Attic binary cache on self-hosted runners"
+
+inputs:
+  command:
+    description: "Nix command to run"
+    default: "nix build"
+  push-cache:
+    description: "Push results to Attic cache"
+    default: "true"
+  attic-server:
+    description: "Attic server URL (auto-detected on self-hosted)"
+    default: ""
+  attic-cache:
+    description: "Attic cache name"
+    default: "main"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: cachix/install-nix-action@v30
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - uses: ./github/actions/setup-flywheel
+      with:
+        attic-server: ${{ inputs.attic-server }}
+        attic-cache: ${{ inputs.attic-cache }}
+
+    - name: Configure Attic cache
+      if: env.ATTIC_SERVER != '' && env.ATTIC_TOKEN != ''
+      uses: ryanccn/attic-action@v0
+      with:
+        endpoint: ${{ env.ATTIC_SERVER }}
+        cache: ${{ env.ATTIC_CACHE }}
+        token: ${{ env.ATTIC_TOKEN }}
+        skip-push: ${{ inputs.push-cache == 'false' }}
+
+    - name: Run Nix command
+      shell: bash
+      run: ${{ inputs.command }}

--- a/.github/actions/setup-flywheel/action.yml
+++ b/.github/actions/setup-flywheel/action.yml
@@ -1,0 +1,31 @@
+name: "Setup GloriousFlywheel"
+description: "Configure Nix and Bazel cache endpoints for self-hosted runners"
+
+inputs:
+  attic-server:
+    description: "Attic server URL (auto-detected on self-hosted)"
+    default: ""
+  attic-cache:
+    description: "Attic cache name"
+    default: "main"
+  bazel-cache:
+    description: "Bazel remote cache endpoint (auto-detected on self-hosted)"
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Detect environment
+      shell: bash
+      run: |
+        if [ "${{ runner.environment }}" != "github-hosted" ]; then
+          # Self-hosted ARC runners have cluster DNS access
+          ATTIC="${{ inputs.attic-server }}"
+          echo "ATTIC_SERVER=${ATTIC:-${ATTIC_SERVER:-http://attic-api.nix-cache.svc.cluster.local:8080}}" >> "$GITHUB_ENV"
+
+          BAZEL="${{ inputs.bazel-cache }}"
+          echo "BAZEL_REMOTE_CACHE=${BAZEL:-${BAZEL_REMOTE_CACHE:-grpc://bazel-cache.nix-cache.svc.cluster.local:9092}}" >> "$GITHUB_ENV"
+        elif [ -n "${{ inputs.attic-server }}" ]; then
+          echo "ATTIC_SERVER=${{ inputs.attic-server }}" >> "$GITHUB_ENV"
+        fi
+        echo "ATTIC_CACHE=${{ inputs.attic-cache }}" >> "$GITHUB_ENV"

--- a/.github/workflows/test-arc-runners.yml
+++ b/.github/workflows/test-arc-runners.yml
@@ -3,6 +3,7 @@ name: Test ARC Runners
 on:
   push:
     branches: [feat/arc-runners]
+  workflow_dispatch:
 
 jobs:
   test-nix:

--- a/.github/workflows/test-arc-runners.yml
+++ b/.github/workflows/test-arc-runners.yml
@@ -1,0 +1,51 @@
+name: Test ARC Runners
+
+on:
+  push:
+    branches: [feat/arc-runners]
+
+jobs:
+  test-nix:
+    name: Test tinyland-nix
+    runs-on: tinyland-nix
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify runner environment
+        run: |
+          echo "Runner: ${{ runner.name }}"
+          echo "OS: ${{ runner.os }}"
+          echo "Environment: ${{ runner.environment }}"
+          uname -a
+
+      - name: Test cache connectivity
+        run: |
+          echo "=== Attic cache ==="
+          curl -sf http://attic-api.nix-cache.svc.cluster.local:8080 && echo "OK" || echo "UNREACHABLE"
+          echo ""
+          echo "=== Bazel cache ==="
+          curl -sf grpc://bazel-cache.nix-cache.svc.cluster.local:9092 2>/dev/null && echo "OK" || echo "(expected: grpc is not curl-able, but DNS resolves)"
+          getent hosts bazel-cache.nix-cache.svc.cluster.local && echo "DNS OK" || echo "DNS FAIL"
+
+      - name: Test env vars
+        run: |
+          echo "ATTIC_SERVER=$ATTIC_SERVER"
+          echo "ATTIC_CACHE=$ATTIC_CACHE"
+          echo "BAZEL_REMOTE_CACHE=$BAZEL_REMOTE_CACHE"
+          echo "NIX_CONFIG=$NIX_CONFIG"
+
+  test-docker:
+    name: Test tinyland-docker
+    runs-on: tinyland-docker
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify runner environment
+        run: |
+          echo "Runner: ${{ runner.name }}"
+          echo "OS: ${{ runner.os }}"
+          uname -a
+
+      - name: Test env vars
+        run: |
+          echo "BAZEL_REMOTE_CACHE=$BAZEL_REMOTE_CACHE"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,6 +29,8 @@ jobs:
     strategy:
       matrix:
         module:
+          - arc-controller
+          - arc-runner
           - hpa-deployment
           - postgresql-cnpg
           - cnpg-operator
@@ -61,6 +63,7 @@ jobs:
     strategy:
       matrix:
         stack:
+          - arc-runners
           - attic
           - gitlab-runners
           - runner-dashboard

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ graph TD
 
 - **Cache platform** -- Nix binary cache (Attic API + GC), CloudNativePG PostgreSQL, MinIO S3 storage, DNS, optional Bazel remote cache
 - **GitLab runners** -- 5 types (docker, dind, rocky8, rocky9, nix) with HPA autoscaling
+- **GitHub Actions runners** -- ARC-based scale sets (tinyland-nix, tinyland-docker, tinyland-dind) with scale-to-zero
 - **Runner dashboard** -- SvelteKit 5 + Skeleton v4 monitoring UI with drift detection
 - **Documentation site** -- SvelteKit + mdsvex + Mermaid, deployed to GitHub/GitLab Pages
 

--- a/app/src/lib/config/environments.json
+++ b/app/src/lib/config/environments.json
@@ -18,5 +18,16 @@
     "gitlab_project_id": "78189586",
     "role": "production",
     "context": "bates-ils/projects/kubernetes/gitlab-agents:rigel"
+  },
+  {
+    "name": "tinyland",
+    "label": "Tinyland (Dev)",
+    "domain": "fuzzy-dev.tinyland.dev",
+    "namespace": "gitlab-runners",
+    "arc_namespace": "arc-runners",
+    "gitlab_url": "https://gitlab.com",
+    "github_url": "https://github.com/tinyland-inc",
+    "role": "development",
+    "context": "tinyland-civo-dev"
   }
 ]

--- a/app/src/lib/server/k8s/types.ts
+++ b/app/src/lib/server/k8s/types.ts
@@ -1,0 +1,116 @@
+// Kubernetes API types extracted from client.ts + ARC CRD types
+
+export interface K8sListResponse<T> {
+  kind: string;
+  items: T[];
+  metadata: { resourceVersion?: string };
+}
+
+export interface K8sPod {
+  metadata: {
+    name: string;
+    namespace: string;
+    labels: Record<string, string>;
+    creationTimestamp: string;
+  };
+  status: {
+    phase: string;
+    containerStatuses?: Array<{
+      name: string;
+      ready: boolean;
+      restartCount: number;
+      state: Record<string, unknown>;
+    }>;
+  };
+}
+
+export interface K8sDeployment {
+  metadata: { name: string; namespace: string };
+  spec: { replicas: number };
+  status: {
+    replicas: number;
+    readyReplicas: number;
+    availableReplicas: number;
+    updatedReplicas: number;
+  };
+}
+
+export interface K8sHPA {
+  metadata: { name: string; namespace: string };
+  spec: {
+    minReplicas: number;
+    maxReplicas: number;
+    metrics: Array<{
+      type: string;
+      resource?: {
+        name: string;
+        target: { type: string; averageUtilization?: number };
+      };
+    }>;
+  };
+  status: {
+    currentReplicas: number;
+    desiredReplicas: number;
+    currentMetrics: Array<{
+      type: string;
+      resource?: {
+        name: string;
+        current: { averageUtilization?: number; averageValue?: string };
+      };
+    }>;
+  };
+}
+
+export interface K8sEvent {
+  metadata: { name: string; creationTimestamp: string };
+  type: string;
+  reason: string;
+  message: string;
+  involvedObject: { kind: string; name: string };
+  count: number;
+  lastTimestamp: string;
+}
+
+// ARC (Actions Runner Controller) CRD types
+
+export interface K8sAutoScalingRunnerSet {
+  metadata: {
+    name: string;
+    namespace: string;
+    labels: Record<string, string>;
+    creationTimestamp: string;
+  };
+  spec: {
+    githubConfigUrl: string;
+    minRunners?: number;
+    maxRunners?: number;
+    runnerScaleSetName?: string;
+    template?: {
+      spec?: {
+        containers?: Array<{
+          name: string;
+          image: string;
+        }>;
+      };
+    };
+  };
+  status?: {
+    currentRunners?: number;
+    pendingRunners?: number;
+    runningRunners?: number;
+    state?: string;
+  };
+}
+
+export interface K8sEphemeralRunner {
+  metadata: {
+    name: string;
+    namespace: string;
+    labels: Record<string, string>;
+    creationTimestamp: string;
+  };
+  status?: {
+    phase?: string;
+    ready?: boolean;
+  };
+}

--- a/app/src/lib/server/prometheus/__tests__/queries.test.ts
+++ b/app/src/lib/server/prometheus/__tests__/queries.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 // Mock $env/dynamic/private
 vi.mock("$env/dynamic/private", () => ({
   env: {
-    RUNNER_NAMESPACE: "gitlab-runners",
+    K8S_RUNNER_NAMESPACES: "gitlab-runners,arc-runners",
   },
 }));
 
@@ -11,9 +11,9 @@ import { QUERIES, TIME_WINDOWS } from "../queries";
 
 describe("QUERIES", () => {
   describe("totalJobs", () => {
-    it("should return namespaced query without runner", () => {
+    it("should return multi-namespace query without runner", () => {
       const q = QUERIES.totalJobs();
-      expect(q).toContain('namespace="gitlab-runners"');
+      expect(q).toContain('namespace=~"gitlab-runners|arc-runners"');
       expect(q).not.toContain("runner=");
     });
 

--- a/app/src/lib/types/metrics.ts
+++ b/app/src/lib/types/metrics.ts
@@ -17,9 +17,14 @@ export interface MetricCardData {
   trend?: "up" | "down" | "stable";
 }
 
+export type Forge = "gitlab" | "github";
+export type ScalingModel = "hpa" | "arc";
+
 export interface HPAStatus {
   name: string;
   runner_type?: string;
+  forge?: Forge;
+  scaling_model?: ScalingModel;
   current_replicas: number;
   desired_replicas: number;
   min_replicas: number;
@@ -43,6 +48,7 @@ export interface PodInfo {
   name: string;
   status: string;
   runner: string;
+  forge?: Forge;
   node: string;
   cpu_usage?: string;
   memory_usage?: string;

--- a/app/src/routes/api/k8s/hpa/+server.ts
+++ b/app/src/routes/api/k8s/hpa/+server.ts
@@ -1,8 +1,16 @@
 import { json } from "@sveltejs/kit";
-import { k8sClient } from "$lib/server/k8s/client";
+import { k8sClient, RUNNER_NAMESPACES } from "$lib/server/k8s/client";
 import { MOCK_HPA_STATUS } from "$lib/mocks";
 import type { RequestHandler } from "./$types";
-import type { HPAStatus } from "$lib/types";
+import type { HPAStatus, Forge } from "$lib/types";
+import { env } from "$env/dynamic/private";
+
+const ARC_NAMESPACE = env.ARC_NAMESPACE ?? "arc-runners";
+
+function detectForge(ns: string): Forge {
+  if (ns.startsWith("arc-")) return "github";
+  return "gitlab";
+}
 
 export const GET: RequestHandler = async () => {
   const available = await k8sClient.isAvailable();
@@ -12,8 +20,11 @@ export const GET: RequestHandler = async () => {
   }
 
   try {
-    const rawHPAs = await k8sClient.listHPAs();
-    const hpas: HPAStatus[] = rawHPAs.map((h) => {
+    const hpas: HPAStatus[] = [];
+
+    // Fetch HPAs from all runner namespaces (GitLab uses HPAs)
+    const rawHPAs = await k8sClient.listAllHPAs(RUNNER_NAMESPACES);
+    for (const h of rawHPAs) {
       const cpuMetric = h.status.currentMetrics?.find(
         (m) => m.resource?.name === "cpu",
       );
@@ -21,8 +32,10 @@ export const GET: RequestHandler = async () => {
         (m) => m.resource?.name === "memory",
       );
 
-      return {
+      hpas.push({
         name: h.metadata.name,
+        forge: detectForge(h.metadata.namespace),
+        scaling_model: "hpa",
         current_replicas: h.status.currentReplicas,
         desired_replicas: h.status.desiredReplicas,
         min_replicas: h.spec.minReplicas,
@@ -30,8 +43,26 @@ export const GET: RequestHandler = async () => {
         cpu_current: cpuMetric?.resource?.current?.averageUtilization ?? 0,
         memory_current: memMetric?.resource?.current?.averageUtilization ?? 0,
         conditions: [],
-      };
-    });
+      });
+    }
+
+    // Fetch ARC AutoScalingRunnerSets (GitHub uses ARC listener-based scaling)
+    const arcSets = await k8sClient.listAutoScalingRunnerSets(ARC_NAMESPACE);
+    for (const ars of arcSets) {
+      hpas.push({
+        name: ars.spec.runnerScaleSetName ?? ars.metadata.name,
+        forge: "github",
+        scaling_model: "arc",
+        current_replicas: ars.status?.currentRunners ?? 0,
+        desired_replicas:
+          (ars.status?.runningRunners ?? 0) +
+          (ars.status?.pendingRunners ?? 0),
+        min_replicas: ars.spec.minRunners ?? 0,
+        max_replicas: ars.spec.maxRunners ?? 0,
+        conditions: [],
+      });
+    }
+
     return json({ available: true, hpas });
   } catch {
     return json({ available: false, hpas: MOCK_HPA_STATUS });

--- a/app/src/routes/api/k8s/pods/+server.ts
+++ b/app/src/routes/api/k8s/pods/+server.ts
@@ -1,8 +1,33 @@
 import { json } from "@sveltejs/kit";
-import { k8sClient } from "$lib/server/k8s/client";
+import { k8sClient, RUNNER_NAMESPACES } from "$lib/server/k8s/client";
+import type { K8sPod } from "$lib/server/k8s/types";
 import { MOCK_PODS } from "$lib/mocks";
 import type { RequestHandler } from "./$types";
-import type { PodInfo } from "$lib/types";
+import type { PodInfo, Forge } from "$lib/types";
+
+/** Determine forge from namespace. */
+function detectForge(ns: string): Forge {
+  if (ns.startsWith("arc-")) return "github";
+  return "gitlab";
+}
+
+/** Extract runner label from pod depending on forge. */
+function detectRunner(pod: K8sPod, forge: Forge): string {
+  if (forge === "github") {
+    // ARC pods use actions.github.com/scale-set-name label
+    return (
+      pod.metadata.labels["actions.github.com/scale-set-name"] ??
+      pod.metadata.labels["app.kubernetes.io/name"] ??
+      "unknown"
+    );
+  }
+  // GitLab uses app label or app.kubernetes.io/name
+  return (
+    pod.metadata.labels["app"] ??
+    pod.metadata.labels["app.kubernetes.io/name"] ??
+    "unknown"
+  );
+}
 
 export const GET: RequestHandler = async () => {
   const available = await k8sClient.isAvailable();
@@ -12,17 +37,21 @@ export const GET: RequestHandler = async () => {
   }
 
   try {
-    const rawPods = await k8sClient.listPods();
-    const pods: PodInfo[] = rawPods.map((p) => ({
-      name: p.metadata.name,
-      status: p.status.phase,
-      runner: p.metadata.labels["app.kubernetes.io/name"] ?? "unknown",
-      node: "",
-      cpu_usage: "0m",
-      memory_usage: "0Mi",
-      restarts: p.status.containerStatuses?.[0]?.restartCount ?? 0,
-      age: p.metadata.creationTimestamp,
-    }));
+    const rawPods = await k8sClient.listAllRunnerPods(RUNNER_NAMESPACES);
+    const pods: PodInfo[] = rawPods.map((p) => {
+      const forge = detectForge(p.metadata.namespace);
+      return {
+        name: p.metadata.name,
+        status: p.status.phase,
+        runner: detectRunner(p, forge),
+        forge,
+        node: "",
+        cpu_usage: "0m",
+        memory_usage: "0Mi",
+        restarts: p.status.containerStatuses?.[0]?.restartCount ?? 0,
+        age: p.metadata.creationTimestamp,
+      };
+    });
     return json({ available: true, pods });
   } catch {
     return json({ available: false, pods: MOCK_PODS });

--- a/app/src/routes/monitoring/+page.server.ts
+++ b/app/src/routes/monitoring/+page.server.ts
@@ -13,11 +13,25 @@ export const load: PageServerLoad = async ({ fetch }) => {
   const hpaData = hpaRes?.ok ? await hpaRes.json() : null;
   const podsData = podsRes?.ok ? await podsRes.json() : null;
 
+  // Group pods by forge for the UI
+  const allPods = podsData?.pods ?? MOCK_PODS;
+  const allHpas = hpaData?.hpas ?? MOCK_HPA_STATUS;
+
   return {
     prometheusAvailable: metricsData?.available ?? false,
     k8sAvailable: hpaData?.available ?? false,
     metrics: metricsData?.metrics ?? MOCK_DASHBOARD_METRICS,
-    hpas: hpaData?.hpas ?? MOCK_HPA_STATUS,
-    pods: podsData?.pods ?? MOCK_PODS,
+    hpas: allHpas,
+    pods: allPods,
+    forges: {
+      gitlab: {
+        pods: allPods.filter((p: { forge?: string }) => (p.forge ?? "gitlab") === "gitlab"),
+        hpas: allHpas.filter((h: { forge?: string }) => (h.forge ?? "gitlab") === "gitlab"),
+      },
+      github: {
+        pods: allPods.filter((p: { forge?: string }) => p.forge === "github"),
+        hpas: allHpas.filter((h: { forge?: string }) => h.forge === "github"),
+      },
+    },
   };
 };

--- a/app/src/routes/monitoring/+page.svelte
+++ b/app/src/routes/monitoring/+page.svelte
@@ -2,13 +2,40 @@
 	import HPAGauge from '$lib/components/metrics/HPAGauge.svelte';
 	import MetricCard from '$lib/components/metrics/MetricCard.svelte';
 	import DataTable from '$lib/components/common/DataTable.svelte';
-	import type { HPAStatus, PodInfo, MetricCardData } from '$lib/types';
+	import type { HPAStatus, PodInfo, MetricCardData, Forge } from '$lib/types';
 
 	let { data } = $props();
 
 	const metrics = $derived(data.metrics as MetricCardData[]);
 	const hpas = $derived(data.hpas as HPAStatus[]);
 	const pods = $derived(data.pods as PodInfo[]);
+
+	type ForgeFilter = 'all' | Forge;
+	let forgeFilter: ForgeFilter = $state('all');
+
+	const filteredHpas = $derived(
+		forgeFilter === 'all' ? hpas : hpas.filter((h) => (h.forge ?? 'gitlab') === forgeFilter)
+	);
+	const filteredPods = $derived(
+		forgeFilter === 'all' ? pods : pods.filter((p) => (p.forge ?? 'gitlab') === forgeFilter)
+	);
+
+	function forgeBadge(forge?: Forge): string {
+		if (forge === 'github') return 'GH';
+		return 'GL';
+	}
+
+	function forgeBadgeClass(forge?: Forge): string {
+		if (forge === 'github') return 'bg-gray-700 text-white';
+		return 'bg-orange-600 text-white';
+	}
+
+	function scalingLabel(hpa: HPAStatus): string {
+		if (hpa.scaling_model === 'arc') {
+			return hpa.min_replicas === 0 ? 'ARC (scale-to-zero)' : 'ARC';
+		}
+		return 'HPA';
+	}
 </script>
 
 <svelte:head>
@@ -16,7 +43,35 @@
 </svelte:head>
 
 <div class="space-y-6">
-	<h2 class="text-2xl font-bold">Monitoring</h2>
+	<div class="flex items-center justify-between">
+		<h2 class="text-2xl font-bold">Monitoring</h2>
+		<div class="flex gap-1">
+			<button
+				class="px-3 py-1 text-sm rounded-lg transition-colors {forgeFilter === 'all'
+					? 'bg-primary-500 text-white'
+					: 'bg-surface-200-700 hover:bg-surface-300-600'}"
+				onclick={() => (forgeFilter = 'all')}
+			>
+				All
+			</button>
+			<button
+				class="px-3 py-1 text-sm rounded-lg transition-colors {forgeFilter === 'gitlab'
+					? 'bg-orange-600 text-white'
+					: 'bg-surface-200-700 hover:bg-surface-300-600'}"
+				onclick={() => (forgeFilter = 'gitlab')}
+			>
+				GitLab
+			</button>
+			<button
+				class="px-3 py-1 text-sm rounded-lg transition-colors {forgeFilter === 'github'
+					? 'bg-gray-700 text-white'
+					: 'bg-surface-200-700 hover:bg-surface-300-600'}"
+				onclick={() => (forgeFilter = 'github')}
+			>
+				GitHub
+			</button>
+		</div>
+	</div>
 
 	<!-- Overview metrics -->
 	<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -25,12 +80,28 @@
 		{/each}
 	</div>
 
-	<!-- HPA gauges -->
+	<!-- HPA / Autoscaler gauges -->
 	<div>
 		<h3 class="text-lg font-semibold mb-3">Autoscaling</h3>
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-			{#each hpas as hpa}
-				<HPAGauge {hpa} />
+			{#each filteredHpas as hpa}
+				<div class="relative">
+					<div class="absolute top-2 right-2 flex gap-1 z-10">
+						<span
+							class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded {forgeBadgeClass(
+								hpa.forge
+							)}"
+						>
+							{forgeBadge(hpa.forge)}
+						</span>
+						<span
+							class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded bg-surface-300-600 text-surface-700-200"
+						>
+							{scalingLabel(hpa)}
+						</span>
+					</div>
+					<HPAGauge {hpa} />
+				</div>
 			{/each}
 		</div>
 	</div>
@@ -38,16 +109,55 @@
 	<!-- Pod table -->
 	<div>
 		<h3 class="text-lg font-semibold mb-3">Pods</h3>
-		<DataTable
-			data={pods as unknown as Record<string, unknown>[]}
-			columns={[
-				{ key: 'name', label: 'Name' },
-				{ key: 'status', label: 'Status', width: '100px' },
-				{ key: 'restarts', label: 'Restarts', width: '80px' },
-				{ key: 'age', label: 'Age', width: '80px' },
-				{ key: 'runner', label: 'Runner' }
-			]}
-		/>
+		{#if filteredPods.length > 0}
+			<div class="overflow-x-auto">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="border-b border-surface-300-600">
+							<th class="text-left py-2 px-3 font-medium">Forge</th>
+							<th class="text-left py-2 px-3 font-medium">Name</th>
+							<th class="text-left py-2 px-3 font-medium w-24">Status</th>
+							<th class="text-left py-2 px-3 font-medium w-20">Restarts</th>
+							<th class="text-left py-2 px-3 font-medium w-20">Age</th>
+							<th class="text-left py-2 px-3 font-medium">Runner</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each filteredPods as pod}
+							<tr class="border-b border-surface-200-700">
+								<td class="py-2 px-3">
+									<span
+										class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded {forgeBadgeClass(
+											pod.forge
+										)}"
+									>
+										{forgeBadge(pod.forge)}
+									</span>
+								</td>
+								<td class="py-2 px-3 font-mono text-xs">{pod.name}</td>
+								<td class="py-2 px-3">
+									<span
+										class="inline-flex items-center px-2 py-0.5 text-xs rounded-full {pod.status ===
+										'Running'
+											? 'bg-green-500/20 text-green-600 dark:text-green-400'
+											: pod.status === 'Pending'
+												? 'bg-yellow-500/20 text-yellow-600 dark:text-yellow-400'
+												: 'bg-red-500/20 text-red-600 dark:text-red-400'}"
+									>
+										{pod.status}
+									</span>
+								</td>
+								<td class="py-2 px-3">{pod.restarts}</td>
+								<td class="py-2 px-3">{pod.age}</td>
+								<td class="py-2 px-3">{pod.runner}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{:else}
+			<p class="text-sm text-surface-500">No pods found for the selected filter.</p>
+		{/if}
 	</div>
 
 	<!-- Data source status -->

--- a/docs/runners/github-actions.md
+++ b/docs/runners/github-actions.md
@@ -1,0 +1,136 @@
+# GitHub Actions Runners
+
+Self-hosted GitHub Actions runners powered by ARC (Actions Runner Controller)
+on the same cluster as the GitLab runner pool. Runners access caches via
+cluster-internal DNS with zero additional configuration.
+
+## Available Labels
+
+Use these `runs-on` values in your GitHub Actions workflows:
+
+| Label | Runner Type | Use Case |
+| --- | --- | --- |
+| `tinyland-nix` | nix | Nix builds with Attic binary cache |
+| `tinyland-docker` | docker | General CI: linting, testing, builds |
+| `tinyland-dind` | dind | Docker-in-Docker: container image builds |
+
+## Quick Start
+
+```yaml
+jobs:
+  build:
+    runs-on: tinyland-nix
+    steps:
+      - uses: actions/checkout@v4
+      - run: nix build
+```
+
+No tokens, no registration. The runner pool is available to all repos in the
+installed GitHub App organizations.
+
+## Composite Actions
+
+GloriousFlywheel provides composite actions that auto-configure cache endpoints
+on self-hosted runners.
+
+### setup-flywheel
+
+Base action that detects the runner environment and configures cache endpoints.
+On self-hosted runners, `ATTIC_SERVER`, `ATTIC_CACHE`, and `BAZEL_REMOTE_CACHE`
+are set automatically via cluster DNS.
+
+```yaml
+steps:
+  - uses: tinyland-inc/GloriousFlywheel/.github/actions/setup-flywheel@main
+```
+
+### nix-job
+
+Nix build with Attic binary cache. Installs Nix, configures cache, and runs
+your command.
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@main
+    with:
+      command: nix build .#default
+      push-cache: "true"
+```
+
+### docker-job
+
+Standard CI job with Bazel cache configured.
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: tinyland-inc/GloriousFlywheel/.github/actions/docker-job@main
+    with:
+      command: make build
+```
+
+## Cache Integration
+
+ARC runners access caches via cluster-internal DNS. No Ingress, no TLS
+overhead, no credential exposure:
+
+- **Attic**: `http://attic-api.nix-cache.svc.cluster.local:8080`
+- **Bazel**: `grpc://bazel-cache.nix-cache.svc.cluster.local:9092`
+
+Environment variables are injected automatically:
+
+| Variable | Runner Types | Value |
+| --- | --- | --- |
+| `ATTIC_SERVER` | nix | Attic API endpoint |
+| `ATTIC_CACHE` | nix | Cache name (default: `main`) |
+| `BAZEL_REMOTE_CACHE` | nix, docker | Bazel cache gRPC endpoint |
+| `NIX_CONFIG` | nix | `experimental-features = nix-command flakes` |
+
+## Architecture
+
+ARC uses a controller + scale set model. The controller watches for
+`workflow_job` webhook events and scales runner pods up/down:
+
+```
+arc-systems namespace
+└── ARC controller (gha-runner-scale-set-controller)
+
+arc-runners namespace
+├── gh-nix    (scale set → runs-on: tinyland-nix)
+├── gh-docker (scale set → runs-on: tinyland-docker)
+└── gh-dind   (scale set → runs-on: tinyland-dind)
+```
+
+All scale sets support scale-to-zero. Runner pods are created on demand
+when a workflow job matches the `runs-on` label.
+
+## Infrastructure
+
+The ARC stack is managed by OpenTofu:
+
+```bash
+cd tofu/stacks/arc-runners
+tofu plan -var-file=tinyland.tfvars \
+  -var=cluster_context=tinyland-civo-dev \
+  -var=k8s_config_path=$HOME/.kube/config
+```
+
+## GitHub App Setup
+
+ARC authenticates via a GitHub App installed on the target organizations.
+The App requires:
+
+- **Self-hosted runners** (Organization): Read & Write
+- **Metadata** (Repository): Read-only
+- **Actions** (Repository): Read-only
+
+Webhook event: `workflow_job`
+
+Credentials are stored as a Kubernetes secret in the `arc-systems` namespace.
+
+## See Also
+
+- [Self-Service Enrollment](self-service-enrollment.md) -- GitLab runner enrollment
+- [Cache Integration](cache-integration.md) -- cache configuration details
+- [Runner Selection](runner-selection.md) -- choosing the right runner type

--- a/docs/runners/self-service-enrollment.md
+++ b/docs/runners/self-service-enrollment.md
@@ -175,7 +175,31 @@ This was discovered during the first non-dogfooding deployment of
 flywheel-derived runners, where the Bates beehive cluster runners were
 unexpectedly picking up overlay pipeline jobs.
 
+## GitHub Actions
+
+GitHub repos in organizations with the GloriousFlywheel GitHub App installed
+can use self-hosted runners with `runs-on` labels:
+
+```yaml
+jobs:
+  build:
+    runs-on: tinyland-nix
+    steps:
+      - uses: actions/checkout@v4
+      - run: nix build
+```
+
+| Label | Type | Use Case |
+| --- | --- | --- |
+| `tinyland-nix` | nix | Nix builds with Attic binary cache |
+| `tinyland-docker` | docker | General CI: linting, testing, builds |
+| `tinyland-dind` | dind | Docker-in-Docker: container image builds |
+
+Cache endpoints are auto-configured via cluster-internal DNS. See
+[GitHub Actions Runners](github-actions.md) for composite actions and details.
+
 ## See Also
 
+- [GitHub Actions Runners](github-actions.md) -- GitHub Actions runner pool
 - [Project Onboarding Guide](project-onboarding.md) -- step-by-step enrollment for new projects
 - [Resource Limits Reference](resource-limits.md) -- job pod resource limits and workload profiles

--- a/tofu/modules/BUILD.bazel
+++ b/tofu/modules/BUILD.bazel
@@ -39,6 +39,23 @@ tofu_module(
 )
 
 tofu_module(
+    name = "arc_controller",
+    srcs = glob(["arc-controller/*.tf"]),
+    providers = [
+        "helm",
+        "kubernetes",
+    ],
+)
+
+tofu_module(
+    name = "arc_runner",
+    srcs = glob(["arc-runner/*.tf"]),
+    providers = [
+        "helm",
+    ],
+)
+
+tofu_module(
     name = "gitlab_runner",
     srcs = glob(["gitlab-runner/*.tf"]),
     providers = [
@@ -107,6 +124,26 @@ tofu_module(
 # =============================================================================
 # Validation Tests (run with `bazel test //tofu/modules:*_validate`)
 # =============================================================================
+
+tofu_validate(
+    name = "arc_controller_validate",
+    module = ":arc_controller",
+    tags = [
+        "external",
+        "tofu",
+        "validation",
+    ],
+)
+
+tofu_validate(
+    name = "arc_runner_validate",
+    module = ":arc_runner",
+    tags = [
+        "external",
+        "tofu",
+        "validation",
+    ],
+)
 
 tofu_validate(
     name = "bazel_cache_validate",
@@ -223,6 +260,24 @@ tofu_validate(
 # =============================================================================
 
 tofu_fmt_test(
+    name = "arc_controller_fmt_test",
+    module = ":arc_controller",
+    tags = [
+        "formatting",
+        "tofu",
+    ],
+)
+
+tofu_fmt_test(
+    name = "arc_runner_fmt_test",
+    module = ":arc_runner",
+    tags = [
+        "formatting",
+        "tofu",
+    ],
+)
+
+tofu_fmt_test(
     name = "bazel_cache_fmt_test",
     module = ":bazel_cache",
     tags = [
@@ -329,6 +384,8 @@ tofu_fmt_test(
 filegroup(
     name = "all_modules",
     srcs = [
+        ":arc_controller",
+        ":arc_runner",
         ":bazel_cache",
         ":cnpg_operator",
         ":dns_record",
@@ -357,6 +414,8 @@ filegroup(
 filegroup(
     name = "k8s_modules",
     srcs = [
+        ":arc_controller",
+        ":arc_runner",
         ":gitlab_agent_rbac",
         ":gitlab_runner",
         ":gitlab_user_runner",
@@ -382,6 +441,8 @@ test_suite(
     name = "all_validate",
     tags = ["validation"],
     tests = [
+        ":arc_controller_validate",
+        ":arc_runner_validate",
         ":bazel_cache_validate",
         ":cnpg_operator_validate",
         ":dns_record_validate",
@@ -401,6 +462,8 @@ test_suite(
     name = "all_fmt_test",
     tags = ["formatting"],
     tests = [
+        ":arc_controller_fmt_test",
+        ":arc_runner_fmt_test",
         ":bazel_cache_fmt_test",
         ":cnpg_operator_fmt_test",
         ":dns_record_fmt_test",

--- a/tofu/modules/arc-controller/locals.tf
+++ b/tofu/modules/arc-controller/locals.tf
@@ -1,0 +1,10 @@
+# ARC Controller Module - Local Variables
+
+locals {
+  common_labels = {
+    "app.kubernetes.io/name"       = "arc-controller"
+    "app.kubernetes.io/instance"   = var.release_name
+    "app.kubernetes.io/managed-by" = "opentofu"
+    "app.kubernetes.io/component"  = "runner-controller"
+  }
+}

--- a/tofu/modules/arc-controller/main.tf
+++ b/tofu/modules/arc-controller/main.tf
@@ -1,0 +1,87 @@
+# ARC Controller Module
+#
+# Deploys GitHub Actions Runner Controller (ARC) to Kubernetes via Helm chart.
+# The controller manages runner scale sets for GitHub Actions workflows.
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+  }
+}
+
+# =============================================================================
+# Kubernetes Namespace
+# =============================================================================
+
+resource "kubernetes_namespace_v1" "arc_systems" {
+  count = var.create_namespace ? 1 : 0
+
+  metadata {
+    name   = var.namespace
+    labels = local.common_labels
+  }
+}
+
+# =============================================================================
+# ARC Controller Helm Release
+# =============================================================================
+
+resource "helm_release" "arc_controller" {
+  name       = var.release_name
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts"
+  chart      = "gha-runner-scale-set-controller"
+  version    = var.chart_version
+  namespace  = var.namespace
+  timeout    = 600
+
+  depends_on = [kubernetes_namespace_v1.arc_systems]
+
+  # Controller resources
+  set {
+    name  = "resources.requests.cpu"
+    value = var.cpu_request
+  }
+
+  set {
+    name  = "resources.requests.memory"
+    value = var.memory_request
+  }
+
+  set {
+    name  = "resources.limits.cpu"
+    value = var.cpu_limit
+  }
+
+  set {
+    name  = "resources.limits.memory"
+    value = var.memory_limit
+  }
+
+  # Update strategy (eventual = lower API load)
+  set {
+    name  = "flags.updateStrategy"
+    value = var.update_strategy
+  }
+
+  # Log level
+  set {
+    name  = "flags.logLevel"
+    value = var.log_level
+  }
+
+  # Image pull secrets
+  dynamic "set" {
+    for_each = var.image_pull_secrets
+    content {
+      name  = "imagePullSecrets[${set.key}].name"
+      value = set.value
+    }
+  }
+}

--- a/tofu/modules/arc-controller/outputs.tf
+++ b/tofu/modules/arc-controller/outputs.tf
@@ -1,0 +1,16 @@
+# ARC Controller Module - Outputs
+
+output "namespace" {
+  description = "Namespace where ARC controller is deployed"
+  value       = var.namespace
+}
+
+output "release_name" {
+  description = "Helm release name"
+  value       = helm_release.arc_controller.name
+}
+
+output "chart_version" {
+  description = "Deployed chart version"
+  value       = helm_release.arc_controller.version
+}

--- a/tofu/modules/arc-controller/variables.tf
+++ b/tofu/modules/arc-controller/variables.tf
@@ -29,7 +29,7 @@ variable "release_name" {
 variable "chart_version" {
   description = "ARC controller Helm chart version"
   type        = string
-  default     = "0.10.1"
+  default     = "0.13.1"
 }
 
 # =============================================================================

--- a/tofu/modules/arc-controller/variables.tf
+++ b/tofu/modules/arc-controller/variables.tf
@@ -1,0 +1,97 @@
+# ARC Controller Module - Variables
+
+# =============================================================================
+# Namespace Configuration
+# =============================================================================
+
+variable "namespace" {
+  description = "Kubernetes namespace for ARC controller"
+  type        = string
+  default     = "arc-systems"
+}
+
+variable "create_namespace" {
+  description = "Create the namespace if it doesn't exist"
+  type        = bool
+  default     = true
+}
+
+# =============================================================================
+# Helm Configuration
+# =============================================================================
+
+variable "release_name" {
+  description = "Helm release name for ARC controller"
+  type        = string
+  default     = "arc-controller"
+}
+
+variable "chart_version" {
+  description = "ARC controller Helm chart version"
+  type        = string
+  default     = "0.10.1"
+}
+
+# =============================================================================
+# Controller Resources
+# =============================================================================
+
+variable "cpu_request" {
+  description = "CPU request for controller pod"
+  type        = string
+  default     = "100m"
+}
+
+variable "memory_request" {
+  description = "Memory request for controller pod"
+  type        = string
+  default     = "128Mi"
+}
+
+variable "cpu_limit" {
+  description = "CPU limit for controller pod"
+  type        = string
+  default     = "250m"
+}
+
+variable "memory_limit" {
+  description = "Memory limit for controller pod"
+  type        = string
+  default     = "256Mi"
+}
+
+# =============================================================================
+# Image Configuration
+# =============================================================================
+
+variable "image_pull_secrets" {
+  description = "Image pull secrets for controller pods"
+  type        = list(string)
+  default     = []
+}
+
+# =============================================================================
+# Controller Settings
+# =============================================================================
+
+variable "log_level" {
+  description = "Controller log level"
+  type        = string
+  default     = "info"
+
+  validation {
+    condition     = contains(["debug", "info", "warn", "error"], var.log_level)
+    error_message = "log_level must be one of: debug, info, warn, error"
+  }
+}
+
+variable "update_strategy" {
+  description = "Controller update strategy (immediate or eventual)"
+  type        = string
+  default     = "eventual"
+
+  validation {
+    condition     = contains(["immediate", "eventual"], var.update_strategy)
+    error_message = "update_strategy must be one of: immediate, eventual"
+  }
+}

--- a/tofu/modules/arc-runner/locals.tf
+++ b/tofu/modules/arc-runner/locals.tf
@@ -1,0 +1,64 @@
+# ARC Runner Module - Local Variables
+#
+# Computed values based on runner type and configuration.
+
+locals {
+  # =============================================================================
+  # Runner Type Defaults
+  # =============================================================================
+
+  # Default images per runner type (mirrors gitlab-runner types)
+  runner_type_images = {
+    docker = "alpine:3.21"
+    dind   = "docker:27-dind"
+    nix    = "docker.nix-community.org/nixpkgs/nix-flakes:nixos-unstable"
+  }
+
+  # Container mode per runner type
+  runner_type_container_mode = {
+    docker = "kubernetes"
+    dind   = "dind"
+    nix    = "kubernetes"
+  }
+
+  # =============================================================================
+  # Computed Values
+  # =============================================================================
+
+  container_mode = var.container_mode != "" ? var.container_mode : local.runner_type_container_mode[var.runner_type]
+
+  # =============================================================================
+  # Environment Variables
+  # =============================================================================
+
+  # Cache environment variables injected into runner pods
+  cache_env_vars = concat(
+    var.runner_type == "nix" && var.attic_server != "" ? [
+      { name = "NIX_CONFIG", value = "experimental-features = nix-command flakes" },
+      { name = "ATTIC_SERVER", value = var.attic_server },
+      { name = "ATTIC_CACHE", value = var.attic_cache },
+    ] : [],
+    var.bazel_cache_endpoint != "" && contains(["docker", "nix"], var.runner_type) ? [
+      { name = "BAZEL_REMOTE_CACHE", value = var.bazel_cache_endpoint },
+    ] : [],
+    local.container_mode == "dind" ? [
+      { name = "DOCKER_HOST", value = "tcp://localhost:2375" },
+      { name = "DOCKER_TLS_CERTDIR", value = "" },
+    ] : [],
+  )
+
+  # Merge computed env vars with user-supplied extras
+  all_env_vars = concat(local.cache_env_vars, var.env_vars)
+
+  # =============================================================================
+  # Labels
+  # =============================================================================
+
+  common_labels = {
+    "app.kubernetes.io/name"        = "arc-runner"
+    "app.kubernetes.io/instance"    = var.runner_name
+    "app.kubernetes.io/managed-by"  = "opentofu"
+    "app.kubernetes.io/component"   = "runner-scale-set"
+    "app.kubernetes.io/runner-type" = var.runner_type
+  }
+}

--- a/tofu/modules/arc-runner/main.tf
+++ b/tofu/modules/arc-runner/main.tf
@@ -1,0 +1,131 @@
+# ARC Runner Module
+#
+# Deploys a GitHub Actions runner scale set via ARC (Actions Runner Controller).
+# Each instance provides one `runs-on` label for GitHub Actions workflows.
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+  }
+}
+
+# =============================================================================
+# ARC Runner Scale Set Helm Release
+# =============================================================================
+
+resource "helm_release" "arc_runner" {
+  name       = var.runner_name
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts"
+  chart      = "gha-runner-scale-set"
+  version    = var.chart_version
+  namespace  = var.namespace
+  timeout    = 600
+
+  # GitHub App configuration
+  set {
+    name  = "githubConfigUrl"
+    value = var.github_config_url
+  }
+
+  set {
+    name  = "githubConfigSecret"
+    value = var.github_config_secret
+  }
+
+  # Runner identity
+  set {
+    name  = "runnerScaleSetName"
+    value = var.runner_label
+  }
+
+  set {
+    name  = "runnerGroup"
+    value = var.runner_group
+  }
+
+  # Autoscaling
+  set {
+    name  = "minRunners"
+    value = tostring(var.min_runners)
+  }
+
+  set {
+    name  = "maxRunners"
+    value = tostring(var.max_runners)
+  }
+
+  # Controller service account (explicit to avoid ambiguity with multiple controllers)
+  set {
+    name  = "controllerServiceAccount.namespace"
+    value = var.controller_namespace
+  }
+
+  set {
+    name  = "controllerServiceAccount.name"
+    value = var.controller_service_account_name
+  }
+
+  # Container mode (dind for privileged Docker builds)
+  dynamic "set" {
+    for_each = local.container_mode == "dind" ? [1] : []
+    content {
+      name  = "containerMode.type"
+      value = "dind"
+    }
+  }
+
+  # Pod template via values block
+  values = [
+    yamlencode({
+      template = {
+        spec = merge(
+          {
+            containers = [
+              merge(
+                {
+                  name = "runner"
+                  resources = {
+                    requests = {
+                      cpu    = var.cpu_request
+                      memory = var.memory_request
+                    }
+                    limits = {
+                      cpu    = var.cpu_limit
+                      memory = var.memory_limit
+                    }
+                  }
+                },
+                length(local.all_env_vars) > 0 ? {
+                  env = local.all_env_vars
+                } : {},
+              )
+            ]
+          },
+          length(var.node_selector) > 0 ? {
+            nodeSelector = var.node_selector
+          } : {},
+          length(var.tolerations) > 0 ? {
+            tolerations = [
+              for t in var.tolerations : merge(
+                {
+                  key      = t.key
+                  operator = t.operator
+                  effect   = t.effect
+                },
+                t.value != null ? { value = t.value } : {},
+              )
+            ]
+          } : {},
+          length(var.image_pull_secrets) > 0 ? {
+            imagePullSecrets = [
+              for s in var.image_pull_secrets : { name = s }
+            ]
+          } : {},
+        )
+      }
+    })
+  ]
+}

--- a/tofu/modules/arc-runner/main.tf
+++ b/tofu/modules/arc-runner/main.tf
@@ -86,7 +86,9 @@ resource "helm_release" "arc_runner" {
             containers = [
               merge(
                 {
-                  name = "runner"
+                  name    = "runner"
+                  image   = "ghcr.io/actions/actions-runner:latest"
+                  command = ["/home/runner/run.sh"]
                   resources = {
                     requests = {
                       cpu    = var.cpu_request

--- a/tofu/modules/arc-runner/outputs.tf
+++ b/tofu/modules/arc-runner/outputs.tf
@@ -1,0 +1,26 @@
+# ARC Runner Module - Outputs
+
+output "release_name" {
+  description = "Helm release name"
+  value       = helm_release.arc_runner.name
+}
+
+output "runner_label" {
+  description = "GitHub Actions runs-on label"
+  value       = var.runner_label
+}
+
+output "namespace" {
+  description = "Namespace where runner scale set is deployed"
+  value       = var.namespace
+}
+
+output "runner_type" {
+  description = "Runner type (docker, dind, nix)"
+  value       = var.runner_type
+}
+
+output "chart_version" {
+  description = "Deployed chart version"
+  value       = helm_release.arc_runner.version
+}

--- a/tofu/modules/arc-runner/variables.tf
+++ b/tofu/modules/arc-runner/variables.tf
@@ -1,0 +1,205 @@
+# ARC Runner Module - Variables
+#
+# Variables for deploying a GitHub Actions runner scale set via ARC.
+
+# =============================================================================
+# Runner Identity
+# =============================================================================
+
+variable "runner_name" {
+  description = "Helm release name for the runner scale set (e.g. gh-nix)"
+  type        = string
+}
+
+variable "runner_label" {
+  description = "The runs-on label for GitHub Actions workflows (e.g. tinyland-nix)"
+  type        = string
+}
+
+variable "runner_type" {
+  description = "Type of runner: docker, dind, nix"
+  type        = string
+  default     = "docker"
+
+  validation {
+    condition     = contains(["docker", "dind", "nix"], var.runner_type)
+    error_message = "runner_type must be one of: docker, dind, nix"
+  }
+}
+
+# =============================================================================
+# GitHub Configuration
+# =============================================================================
+
+variable "github_config_url" {
+  description = "GitHub organization or repository URL for runner registration"
+  type        = string
+}
+
+variable "github_config_secret" {
+  description = "Name of K8s secret containing GitHub App credentials"
+  type        = string
+}
+
+variable "runner_group" {
+  description = "GitHub runner group name"
+  type        = string
+  default     = "default"
+}
+
+# =============================================================================
+# Namespace Configuration
+# =============================================================================
+
+variable "namespace" {
+  description = "Kubernetes namespace for runner scale set"
+  type        = string
+  default     = "arc-runners"
+}
+
+variable "controller_namespace" {
+  description = "Namespace where ARC controller is deployed (for secret reference)"
+  type        = string
+  default     = "arc-systems"
+}
+
+variable "controller_service_account_name" {
+  description = "Service account name of the ARC controller (required when multiple controllers exist)"
+  type        = string
+  default     = "arc-controller-gha-rs-controller"
+}
+
+# =============================================================================
+# Helm Configuration
+# =============================================================================
+
+variable "chart_version" {
+  description = "ARC runner scale set Helm chart version"
+  type        = string
+  default     = "0.10.1"
+}
+
+# =============================================================================
+# Autoscaling
+# =============================================================================
+
+variable "min_runners" {
+  description = "Minimum number of runner pods (0 = scale to zero)"
+  type        = number
+  default     = 0
+}
+
+variable "max_runners" {
+  description = "Maximum number of runner pods"
+  type        = number
+  default     = 5
+}
+
+# =============================================================================
+# Container Configuration
+# =============================================================================
+
+variable "container_mode" {
+  description = "Container mode: kubernetes or dind (auto-detected from runner_type if empty)"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.container_mode == "" || contains(["kubernetes", "dind"], var.container_mode)
+    error_message = "container_mode must be empty (auto), kubernetes, or dind"
+  }
+}
+
+# =============================================================================
+# Resource Requests and Limits
+# =============================================================================
+
+variable "cpu_request" {
+  description = "CPU request for runner pods"
+  type        = string
+  default     = "250m"
+}
+
+variable "memory_request" {
+  description = "Memory request for runner pods"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "cpu_limit" {
+  description = "CPU limit for runner pods"
+  type        = string
+  default     = "2"
+}
+
+variable "memory_limit" {
+  description = "Memory limit for runner pods"
+  type        = string
+  default     = "4Gi"
+}
+
+# =============================================================================
+# Cache Integration
+# =============================================================================
+
+variable "attic_server" {
+  description = "Attic cache server URL"
+  type        = string
+  default     = ""
+}
+
+variable "attic_cache" {
+  description = "Attic cache name"
+  type        = string
+  default     = "main"
+}
+
+variable "bazel_cache_endpoint" {
+  description = "Bazel remote cache gRPC endpoint"
+  type        = string
+  default     = ""
+}
+
+# =============================================================================
+# Image Configuration
+# =============================================================================
+
+variable "image_pull_secrets" {
+  description = "Image pull secrets for runner pods"
+  type        = list(string)
+  default     = []
+}
+
+# =============================================================================
+# Pod Scheduling
+# =============================================================================
+
+variable "node_selector" {
+  description = "Node selector for runner pods"
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Tolerations for runner pods"
+  type = list(object({
+    key      = string
+    operator = string
+    value    = optional(string)
+    effect   = string
+  }))
+  default = []
+}
+
+# =============================================================================
+# Additional Environment Variables
+# =============================================================================
+
+variable "env_vars" {
+  description = "Additional environment variables for runner pods"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}

--- a/tofu/modules/arc-runner/variables.tf
+++ b/tofu/modules/arc-runner/variables.tf
@@ -76,7 +76,7 @@ variable "controller_service_account_name" {
 variable "chart_version" {
   description = "ARC runner scale set Helm chart version"
   type        = string
-  default     = "0.10.1"
+  default     = "0.13.1"
 }
 
 # =============================================================================

--- a/tofu/modules/runner-dashboard/main.tf
+++ b/tofu/modules/runner-dashboard/main.tf
@@ -139,12 +139,16 @@ resource "kubernetes_config_map" "dashboard" {
       PROMETHEUS_URL            = var.prometheus_url
       RUNNERS_NAMESPACE         = var.runners_namespace
       K8S_NAMESPACE             = var.runners_namespace
+      K8S_RUNNER_NAMESPACES     = join(",", concat([var.runners_namespace], var.arc_namespaces))
       GITLAB_GROUP_ID           = var.gitlab_group_id
       GITLAB_PROJECT_ID         = var.gitlab_project_id
       RUNNER_STACK_NAME         = var.runner_stack_name
       ATTIC_DEFAULT_ENV         = var.default_env
       LOG_LEVEL                 = var.log_level
     },
+    length(var.arc_namespaces) > 0 ? {
+      ARC_NAMESPACE = var.arc_namespaces[0]
+    } : {},
     var.webauthn_rp_id != "" ? {
       WEBAUTHN_RP_ID   = var.webauthn_rp_id
       WEBAUTHN_RP_NAME = var.webauthn_rp_name

--- a/tofu/modules/runner-dashboard/variables.tf
+++ b/tofu/modules/runner-dashboard/variables.tf
@@ -116,7 +116,7 @@ variable "default_env" {
 variable "prometheus_url" {
   description = "Prometheus server URL for metrics queries"
   type        = string
-  default     = "http://prometheus.monitoring.svc.cluster.local:9090"
+  default     = "http://prometheus.tinyland-staging.svc.cluster.local:9090"
 }
 
 # =============================================================================
@@ -127,6 +127,12 @@ variable "runners_namespace" {
   description = "Namespace where GitLab runners are deployed (for RBAC read access)"
   type        = string
   default     = "gitlab-runners"
+}
+
+variable "arc_namespaces" {
+  description = "Additional namespaces for ARC (GitHub Actions) runner access"
+  type        = list(string)
+  default     = []
 }
 
 # =============================================================================

--- a/tofu/stacks/BUILD.bazel
+++ b/tofu/stacks/BUILD.bazel
@@ -6,6 +6,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "all_stacks",
     srcs = [
+        "//tofu/stacks/arc-runners:stack_files",
         "//tofu/stacks/attic:stack_files",
         "//tofu/stacks/gitlab-runners:stack_files",
     ],

--- a/tofu/stacks/arc-runners/BUILD.bazel
+++ b/tofu/stacks/arc-runners/BUILD.bazel
@@ -1,0 +1,39 @@
+# ARC Runners Stack - Bazel Build Configuration
+#
+# Targets for deploying GitHub Actions Runner Controller to Kubernetes clusters.
+
+package(default_visibility = ["//visibility:public"])
+
+# =============================================================================
+# File Groups
+# =============================================================================
+
+# Core OpenTofu configuration files
+filegroup(
+    name = "tf_files",
+    srcs = glob(["*.tf"]),
+)
+
+# Environment-specific variable files
+filegroup(
+    name = "tfvars_files",
+    srcs = glob(["*.tfvars"]),
+)
+
+# All stack files combined
+filegroup(
+    name = "stack_files",
+    srcs = [
+        ":tf_files",
+        ":tfvars_files",
+    ],
+)
+
+# =============================================================================
+# Aliases
+# =============================================================================
+
+alias(
+    name = "arc-runners",
+    actual = ":stack_files",
+)

--- a/tofu/stacks/arc-runners/backend.tf
+++ b/tofu/stacks/arc-runners/backend.tf
@@ -1,0 +1,8 @@
+# GitLab Managed Terraform State
+#
+# State is stored in GitLab's built-in Terraform state management.
+# Access via CI_JOB_TOKEN in pipelines.
+
+terraform {
+  backend "http" {}
+}

--- a/tofu/stacks/arc-runners/main.tf
+++ b/tofu/stacks/arc-runners/main.tf
@@ -1,0 +1,220 @@
+# ARC Runners Stack
+#
+# Deploys GitHub Actions Runner Controller (ARC) and runner scale sets
+# to Kubernetes. Provides `runs-on: tinyland-nix`, `tinyland-docker`,
+# and `tinyland-dind` labels for GitHub Actions workflows.
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path    = var.k8s_config_path != "" ? var.k8s_config_path : null
+  config_context = var.cluster_context
+}
+
+provider "helm" {
+  kubernetes {
+    config_path    = var.k8s_config_path != "" ? var.k8s_config_path : null
+    config_context = var.cluster_context
+  }
+}
+
+# =============================================================================
+# Runner Namespace (shared by all scale sets)
+# =============================================================================
+
+resource "kubernetes_namespace_v1" "arc_runners" {
+  count = var.create_runner_namespace ? 1 : 0
+
+  metadata {
+    name = var.runner_namespace
+    labels = {
+      "app.kubernetes.io/name"       = "arc-runners"
+      "app.kubernetes.io/managed-by" = "opentofu"
+      "app.kubernetes.io/component"  = "runner-pool"
+    }
+  }
+}
+
+# =============================================================================
+# ARC Controller
+# =============================================================================
+
+module "arc_controller" {
+  source = "../../modules/arc-controller"
+
+  namespace          = var.controller_namespace
+  create_namespace   = var.create_controller_namespace
+  chart_version      = var.controller_chart_version
+  image_pull_secrets = local.ghcr_pull_secrets
+}
+
+# =============================================================================
+# Nix Runner - runs-on: tinyland-nix
+# =============================================================================
+
+module "gh_nix" {
+  source = "../../modules/arc-runner"
+
+  runner_name          = var.nix_runner_name
+  runner_label         = "tinyland-nix"
+  runner_type          = "nix"
+  namespace            = var.runner_namespace
+  controller_namespace = var.controller_namespace
+  github_config_url    = var.github_config_url
+  github_config_secret = var.github_config_secret
+
+  min_runners = var.nix_min_runners
+  max_runners = var.nix_max_runners
+
+  cpu_request    = var.nix_cpu_request
+  memory_request = var.nix_memory_request
+  cpu_limit      = var.nix_cpu_limit
+  memory_limit   = var.nix_memory_limit
+
+  attic_server         = var.attic_server
+  attic_cache          = var.attic_cache
+  bazel_cache_endpoint = var.bazel_cache_endpoint
+
+  image_pull_secrets = local.ghcr_pull_secrets
+
+  depends_on = [module.arc_controller, kubernetes_namespace_v1.arc_runners]
+}
+
+# =============================================================================
+# Docker Runner - runs-on: tinyland-docker
+# =============================================================================
+
+module "gh_docker" {
+  source = "../../modules/arc-runner"
+  count  = var.deploy_docker_runner ? 1 : 0
+
+  runner_name          = var.docker_runner_name
+  runner_label         = "tinyland-docker"
+  runner_type          = "docker"
+  namespace            = var.runner_namespace
+  controller_namespace = var.controller_namespace
+  github_config_url    = var.github_config_url
+  github_config_secret = var.github_config_secret
+
+  min_runners = var.docker_min_runners
+  max_runners = var.docker_max_runners
+
+  cpu_request    = var.docker_cpu_request
+  memory_request = var.docker_memory_request
+  cpu_limit      = var.docker_cpu_limit
+  memory_limit   = var.docker_memory_limit
+
+  bazel_cache_endpoint = var.bazel_cache_endpoint
+
+  image_pull_secrets = local.ghcr_pull_secrets
+
+  depends_on = [module.arc_controller, kubernetes_namespace_v1.arc_runners]
+}
+
+# =============================================================================
+# DinD Runner - runs-on: tinyland-dind
+# =============================================================================
+
+module "gh_dind" {
+  source = "../../modules/arc-runner"
+  count  = var.deploy_dind_runner ? 1 : 0
+
+  runner_name          = var.dind_runner_name
+  runner_label         = "tinyland-dind"
+  runner_type          = "dind"
+  container_mode       = "dind"
+  namespace            = var.runner_namespace
+  controller_namespace = var.controller_namespace
+  github_config_url    = var.github_config_url
+  github_config_secret = var.github_config_secret
+
+  min_runners = var.dind_min_runners
+  max_runners = var.dind_max_runners
+
+  cpu_request    = var.dind_cpu_request
+  memory_request = var.dind_memory_request
+  cpu_limit      = var.dind_cpu_limit
+  memory_limit   = var.dind_memory_limit
+
+  image_pull_secrets = local.ghcr_pull_secrets
+
+  depends_on = [module.arc_controller, kubernetes_namespace_v1.arc_runners]
+}
+
+# =============================================================================
+# GHCR Registry Auth (imagePullSecret)
+# =============================================================================
+
+resource "kubernetes_secret" "ghcr_auth_controller" {
+  count = var.ghcr_token != "" ? 1 : 0
+
+  metadata {
+    name      = "ghcr-auth"
+    namespace = var.controller_namespace
+
+    labels = {
+      "app.kubernetes.io/name"       = "ghcr-auth"
+      "app.kubernetes.io/component"  = "registry-credentials"
+      "app.kubernetes.io/managed-by" = "opentofu"
+    }
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "ghcr.io" = {
+          auth = base64encode("${var.ghcr_username}:${var.ghcr_token}")
+        }
+      }
+    })
+  }
+
+  depends_on = [module.arc_controller]
+}
+
+resource "kubernetes_secret" "ghcr_auth_runners" {
+  count = var.ghcr_token != "" ? 1 : 0
+
+  metadata {
+    name      = "ghcr-auth"
+    namespace = var.runner_namespace
+
+    labels = {
+      "app.kubernetes.io/name"       = "ghcr-auth"
+      "app.kubernetes.io/component"  = "registry-credentials"
+      "app.kubernetes.io/managed-by" = "opentofu"
+    }
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "ghcr.io" = {
+          auth = base64encode("${var.ghcr_username}:${var.ghcr_token}")
+        }
+      }
+    })
+  }
+
+  depends_on = [kubernetes_namespace_v1.arc_runners]
+}
+
+locals {
+  ghcr_pull_secrets = var.ghcr_token != "" ? ["ghcr-auth"] : []
+}

--- a/tofu/stacks/arc-runners/outputs.tf
+++ b/tofu/stacks/arc-runners/outputs.tf
@@ -1,0 +1,46 @@
+# ARC Runners Stack - Outputs
+
+output "controller_namespace" {
+  description = "ARC controller namespace"
+  value       = module.arc_controller.namespace
+}
+
+output "controller_release" {
+  description = "ARC controller Helm release name"
+  value       = module.arc_controller.release_name
+}
+
+output "nix_runner_label" {
+  description = "Nix runner runs-on label"
+  value       = module.gh_nix.runner_label
+}
+
+output "nix_runner_release" {
+  description = "Nix runner Helm release name"
+  value       = module.gh_nix.release_name
+}
+
+output "docker_runner_label" {
+  description = "Docker runner runs-on label"
+  value       = var.deploy_docker_runner ? module.gh_docker[0].runner_label : ""
+}
+
+output "docker_runner_release" {
+  description = "Docker runner Helm release name"
+  value       = var.deploy_docker_runner ? module.gh_docker[0].release_name : ""
+}
+
+output "dind_runner_label" {
+  description = "DinD runner runs-on label"
+  value       = var.deploy_dind_runner ? module.gh_dind[0].runner_label : ""
+}
+
+output "dind_runner_release" {
+  description = "DinD runner Helm release name"
+  value       = var.deploy_dind_runner ? module.gh_dind[0].release_name : ""
+}
+
+output "runner_namespace" {
+  description = "Runner scale sets namespace"
+  value       = var.runner_namespace
+}

--- a/tofu/stacks/arc-runners/variables.tf
+++ b/tofu/stacks/arc-runners/variables.tf
@@ -66,7 +66,7 @@ variable "create_runner_namespace" {
 variable "controller_chart_version" {
   description = "ARC controller Helm chart version"
   type        = string
-  default     = "0.10.1"
+  default     = "0.13.1"
 }
 
 # =============================================================================

--- a/tofu/stacks/arc-runners/variables.tf
+++ b/tofu/stacks/arc-runners/variables.tf
@@ -1,0 +1,255 @@
+# ARC Runners Stack - Variables
+
+# =============================================================================
+# Kubernetes Authentication
+# =============================================================================
+
+variable "k8s_config_path" {
+  description = "Path to kubeconfig file"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_context" {
+  description = "Kubernetes context"
+  type        = string
+}
+
+# =============================================================================
+# GitHub Configuration
+# =============================================================================
+
+variable "github_config_url" {
+  description = "GitHub organization or repository URL for runner registration"
+  type        = string
+  default     = "https://github.com/tinyland-inc"
+}
+
+variable "github_config_secret" {
+  description = "Name of K8s secret containing GitHub App credentials (in arc-systems namespace)"
+  type        = string
+  default     = "github-app-secret"
+}
+
+# =============================================================================
+# Namespace Configuration
+# =============================================================================
+
+variable "controller_namespace" {
+  description = "Namespace for ARC controller"
+  type        = string
+  default     = "arc-systems"
+}
+
+variable "create_controller_namespace" {
+  description = "Create the controller namespace"
+  type        = bool
+  default     = true
+}
+
+variable "runner_namespace" {
+  description = "Namespace for runner scale sets"
+  type        = string
+  default     = "arc-runners"
+}
+
+variable "create_runner_namespace" {
+  description = "Create the runner namespace"
+  type        = bool
+  default     = true
+}
+
+# =============================================================================
+# Controller Configuration
+# =============================================================================
+
+variable "controller_chart_version" {
+  description = "ARC controller Helm chart version"
+  type        = string
+  default     = "0.10.1"
+}
+
+# =============================================================================
+# Runner Names
+# =============================================================================
+
+variable "nix_runner_name" {
+  description = "Helm release name for Nix runner scale set"
+  type        = string
+  default     = "gh-nix"
+}
+
+variable "docker_runner_name" {
+  description = "Helm release name for Docker runner scale set"
+  type        = string
+  default     = "gh-docker"
+}
+
+variable "dind_runner_name" {
+  description = "Helm release name for DinD runner scale set"
+  type        = string
+  default     = "gh-dind"
+}
+
+# =============================================================================
+# Deploy Toggles
+# =============================================================================
+
+variable "deploy_docker_runner" {
+  description = "Deploy the Docker runner scale set"
+  type        = bool
+  default     = true
+}
+
+variable "deploy_dind_runner" {
+  description = "Deploy the DinD runner scale set"
+  type        = bool
+  default     = false
+}
+
+# =============================================================================
+# Nix Runner Configuration
+# =============================================================================
+
+variable "nix_min_runners" {
+  description = "Minimum Nix runner pods (0 = scale to zero)"
+  type        = number
+  default     = 0
+}
+
+variable "nix_max_runners" {
+  description = "Maximum Nix runner pods"
+  type        = number
+  default     = 5
+}
+
+variable "nix_cpu_request" {
+  type    = string
+  default = "500m"
+}
+
+variable "nix_memory_request" {
+  type    = string
+  default = "1Gi"
+}
+
+variable "nix_cpu_limit" {
+  type    = string
+  default = "4"
+}
+
+variable "nix_memory_limit" {
+  type    = string
+  default = "8Gi"
+}
+
+# =============================================================================
+# Docker Runner Configuration
+# =============================================================================
+
+variable "docker_min_runners" {
+  description = "Minimum Docker runner pods"
+  type        = number
+  default     = 0
+}
+
+variable "docker_max_runners" {
+  description = "Maximum Docker runner pods"
+  type        = number
+  default     = 5
+}
+
+variable "docker_cpu_request" {
+  type    = string
+  default = "100m"
+}
+
+variable "docker_memory_request" {
+  type    = string
+  default = "256Mi"
+}
+
+variable "docker_cpu_limit" {
+  type    = string
+  default = "2"
+}
+
+variable "docker_memory_limit" {
+  type    = string
+  default = "4Gi"
+}
+
+# =============================================================================
+# DinD Runner Configuration
+# =============================================================================
+
+variable "dind_min_runners" {
+  description = "Minimum DinD runner pods"
+  type        = number
+  default     = 0
+}
+
+variable "dind_max_runners" {
+  description = "Maximum DinD runner pods"
+  type        = number
+  default     = 5
+}
+
+variable "dind_cpu_request" {
+  type    = string
+  default = "500m"
+}
+
+variable "dind_memory_request" {
+  type    = string
+  default = "1Gi"
+}
+
+variable "dind_cpu_limit" {
+  type    = string
+  default = "4"
+}
+
+variable "dind_memory_limit" {
+  type    = string
+  default = "8Gi"
+}
+
+# =============================================================================
+# Cache Integration
+# =============================================================================
+
+variable "attic_server" {
+  description = "Attic cache server URL for Nix runners"
+  type        = string
+  default     = ""
+}
+
+variable "attic_cache" {
+  description = "Attic cache name"
+  type        = string
+  default     = "main"
+}
+
+variable "bazel_cache_endpoint" {
+  description = "Bazel remote cache gRPC endpoint"
+  type        = string
+  default     = ""
+}
+
+# =============================================================================
+# GHCR Registry Authentication
+# =============================================================================
+
+variable "ghcr_token" {
+  description = "GHCR personal access token for pulling mirrored images (empty to skip)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "ghcr_username" {
+  description = "GHCR username for image pull authentication"
+  type        = string
+  default     = "tinyland-inc"
+}

--- a/tofu/stacks/attic/main.tf
+++ b/tofu/stacks/attic/main.tf
@@ -764,7 +764,7 @@ resource "kubernetes_deployment" "attic_gc" {
 
       spec {
         dynamic "image_pull_secrets" {
-          for_each = local.ghcr_pull_secrets
+          for_each = toset(local.ghcr_pull_secrets)
           content {
             name = image_pull_secrets.value
           }
@@ -1177,7 +1177,7 @@ resource "kubernetes_job_v1" "init_cache" {
         restart_policy = "OnFailure"
 
         dynamic "image_pull_secrets" {
-          for_each = local.ghcr_pull_secrets
+          for_each = toset(local.ghcr_pull_secrets)
           content {
             name = image_pull_secrets.value
           }

--- a/tofu/stacks/runner-dashboard/main.tf
+++ b/tofu/stacks/runner-dashboard/main.tf
@@ -64,6 +64,7 @@ module "runner_dashboard" {
 
   # Kubernetes access
   runners_namespace = var.runners_namespace
+  arc_namespaces    = var.arc_namespaces
 
   # Container settings
   container_port = 3000

--- a/tofu/stacks/runner-dashboard/variables.tf
+++ b/tofu/stacks/runner-dashboard/variables.tf
@@ -110,7 +110,7 @@ variable "default_env" {
 variable "prometheus_url" {
   description = "Prometheus server URL for metrics queries"
   type        = string
-  default     = "http://prometheus.monitoring.svc.cluster.local:9090"
+  default     = "http://prometheus.tinyland-staging.svc.cluster.local:9090"
 }
 
 # =============================================================================
@@ -121,6 +121,12 @@ variable "runners_namespace" {
   description = "Namespace where GitLab runners are deployed"
   type        = string
   default     = "gitlab-runners"
+}
+
+variable "arc_namespaces" {
+  description = "Additional namespaces for ARC (GitHub Actions) runner access"
+  type        = list(string)
+  default     = []
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Deploy ARC (Actions Runner Controller) on tinyland-civo-dev cluster with three runner scale sets: `tinyland-nix`, `tinyland-docker`, `tinyland-dind`
- Runners access Attic binary cache and Bazel remote cache via cluster-internal DNS — no Ingress, no TLS, no credentials needed
- Composite GitHub Actions (`setup-flywheel`, `nix-job`, `docker-job`) auto-configure cache endpoints on self-hosted runners
- New OpenTofu modules (`arc-controller`, `arc-runner`) following existing `gitlab-runner` patterns
- New stack (`arc-runners`) with GitLab HTTP state backend
- **Unified cross-forge runner dashboard** — single pane of glass for both GitLab CI and GitHub Actions runners

## Dashboard Changes

The runner dashboard (`app/`) is now a unified monitoring view across both forges:

- **Multi-namespace K8s client**: queries `gitlab-runners` and `arc-runners` namespaces in parallel
- **ARC CRD support**: reads `AutoScalingRunnerSet` custom resources for GitHub Actions scaling status
- **Forge badges**: GL/GH labels on pods and autoscalers with filter buttons (All/GitLab/GitHub)
- **Prometheus fix**: namespace selector updated to regex (`namespace=~"gitlab-runners|arc-runners"`), prometheus_url default corrected to `tinyland-staging`
- **RBAC expansion**: ARC CRD read rules (`actions.github.com` apiGroup), dynamic RoleBindings for `arc-runners` and `arc-systems` namespaces
- **Tinyland environment**: added to `environments.json` with `arc_namespace` and `github_url`

## Usage

Any repo in the installed GitHub App orgs can use:

```yaml
jobs:
  build:
    runs-on: tinyland-nix
    steps:
      - uses: actions/checkout@v4
      - run: nix build
```

## Deployed

ARC controller and all 3 scale sets are live on tinyland-civo-dev (scale-to-zero, pods spin up on workflow trigger).

## Test plan

- [x] `tofu validate` passes for both modules and the stack
- [x] `tofu apply` succeeds — controller + 3 scale sets deployed
- [x] Helm releases confirmed: `gh-nix`, `gh-docker`, `gh-dind` in `arc-runners` namespace
- [x] `svelte-check` — 0 errors on dashboard app
- [x] `tofu validate` on runner-dashboard stack
- [ ] Push a test workflow using `runs-on: tinyland-nix` to verify end-to-end
- [ ] Verify cache access from runner pod (`curl http://attic-api.nix-cache.svc.cluster.local:8080`)
- [ ] Deploy dashboard, verify both forge runners appear with correct badges
- [ ] Trigger GitHub Actions workflow, watch runner appear in dashboard