### PR TITLE
docs: comprehensive documentation upgrade for cross-forge runner pool

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -145,3 +145,15 @@ jobs:
 
       - name: Check docs-site routes
         run: node scripts/check-links.js --mode site
+
+  check-external-links:
+    name: Check External Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check external URLs
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: "--config .lychee.toml docs/**/*.md README.md"
+          fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -10,10 +10,11 @@ exclude = [
   "\\{org\\}",
   "\\$CI_",
   "quintessence\\.sh",
+  "jesssullivan\\.github\\.io/attic-iac",
 ]
 
-# Accept these status codes
-accept = [200, 201, 204, 301, 302, 307, 308]
+# Accept these status codes (403 = auth-walled pages like ACM, private GitLab repos)
+accept = [200, 201, 204, 301, 302, 307, 308, 403]
 
 # Performance
 max_concurrency = 8

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -9,6 +9,7 @@ exclude = [
   "example\\.com",
   "\\{org\\}",
   "\\$CI_",
+  "quintessence\\.sh",
 ]
 
 # Accept these status codes

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -19,4 +19,4 @@ max_concurrency = 8
 timeout = 30
 
 # Don't check mail addresses
-exclude_mail = true
+include_mail = false

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,22 +1,18 @@
 # Lychee link checker configuration
 # https://lychee.cli.rs/usage/config/
 
-# Only check external URLs (internal links are handled by scripts/check-links.js)
-include = ["docs/**/*.md", "README.md", "app/README.md"]
-
 # Exclude patterns
 exclude = [
   "localhost",
   "127\\.0\\.0\\.1",
   "svc\\.cluster\\.local",
   "example\\.com",
-  "\\{org\\}",             # placeholder in docs
-  "\\$CI_",                # GitLab CI variables
+  "\\{org\\}",
+  "\\$CI_",
 ]
 
-# Exclude status codes
-accept = "100..=399"
-exclude_status = [429, 403]
+# Accept these status codes
+accept = [200, 201, 204, 301, 302, 307, 308]
 
 # Performance
 max_concurrency = 8

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,26 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/usage/config/
+
+# Only check external URLs (internal links are handled by scripts/check-links.js)
+include = ["docs/**/*.md", "README.md", "app/README.md"]
+
+# Exclude patterns
+exclude = [
+  "localhost",
+  "127\\.0\\.0\\.1",
+  "svc\\.cluster\\.local",
+  "example\\.com",
+  "\\{org\\}",             # placeholder in docs
+  "\\$CI_",                # GitLab CI variables
+]
+
+# Exclude status codes
+accept = "100..=399"
+exclude_status = [429, 403]
+
+# Performance
+max_concurrency = 8
+timeout = 30
+
+# Don't check mail addresses
+exclude_mail = true

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Self-deploying infrastructure that builds, caches, and monitors itself.
 ## What is this?
 
 A set of OpenTofu modules, Nix packages, and a SvelteKit monitoring dashboard that
-form a recursive infrastructure system for Gitlab.  GitLab runners deploy themselves as a HPA runner pool, the Nix
-binary cache caches its own derivations, bazel overlay orchestrates intrer enterprise deployments,
-intra enterprise automations (such as your companies pool of autonmous clankers, Steve, RenovateBot or your manager checking in every now and again)
-all running on infrastructure managed by this code.  I think its kinda neat.
+form a recursive infrastructure system for GitLab and GitHub. Runners deploy themselves as an HPA runner pool (GitLab) or ARC scale sets (GitHub Actions), the Nix
+binary cache caches its own derivations, bazel overlay orchestrates inter-enterprise deployments,
+intra-enterprise automations (such as your company's pool of autonomous clankers, Steve, RenovateBot or your manager checking in every now and again)
+all running on infrastructure managed by this code. I think its kinda neat.
 
 ## Architecture
 
@@ -66,6 +66,7 @@ cp .env.example .env
 # Deploy stacks in order (each needs a tfvars file in its stack dir)
 just tofu-deploy attic            # Cache platform: CNPG, MinIO, PostgreSQL, Attic API
 just tofu-deploy gitlab-runners
+just tofu-deploy arc-runners         # GitHub Actions runner pool (ARC)
 just tofu-deploy runner-dashboard
 ```
 

--- a/docs-site/.gitignore
+++ b/docs-site/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 build/
 .svelte-kit/
 static/llms.txt
+static/llms-full.txt

--- a/docs/dashboard/overview.md
+++ b/docs/dashboard/overview.md
@@ -1,0 +1,81 @@
+---
+title: Dashboard Overview
+order: 1
+---
+
+# Runner Dashboard Overview
+
+The runner dashboard is a SvelteKit 5 application that provides real-time
+monitoring of the cross-forge runner pool.
+
+## Architecture
+
+- **Framework**: SvelteKit 5 + Skeleton v4 + adapter-node
+- **Source**: `app/`
+- **Infrastructure**: `tofu/modules/runner-dashboard/` + `tofu/stacks/runner-dashboard/`
+
+## Features
+
+- **Cross-forge monitoring**: View GitLab CI and GitHub Actions runners in a
+  unified interface with forge badges (GL/GH)
+- **HPA status**: Live replica counts, CPU/memory utilization, scaling events
+  for GitLab runners
+- **ARC autoscaler views**: Scale set status, active/idle/pending runner
+  counts for GitHub Actions runners with scale-to-zero labels
+- **Drift detection**: Alerts when deployed state diverges from tofu state
+- **Forge filter**: Toggle between All, GitLab, and GitHub runner views
+
+## Multi-Namespace Queries
+
+The dashboard queries multiple Kubernetes namespaces:
+
+- `gitlab-runners` -- GitLab runner pods, HPAs, deployments
+- `arc-runners` -- ARC runner scale sets, runner pods
+
+Namespaces are configured via the `K8S_RUNNER_NAMESPACES` environment
+variable. ARC namespaces additionally query `AutoScalingRunnerSet` CRDs
+from `actions.github.com/v1alpha1`.
+
+RBAC is configured as a ClusterRole with dynamic RoleBindings for each
+namespace.
+
+## Prometheus Integration
+
+PromQL queries pull metrics from the cluster Prometheus instance for
+historical utilization data, scaling event timelines, and cache hit rates.
+
+Prometheus URL is configured via `PROMETHEUS_URL` in the runner-dashboard
+module.
+
+## Authentication
+
+- **GitLab OAuth**: Primary login via GitLab OAuth2 flow
+- **WebAuthn / FIDO2**: Optional passwordless authentication backed by
+  a PostgreSQL credential store (`webauthn-db` module)
+
+## Caddy Sidecar Proxy
+
+The dashboard module supports an optional Caddy reverse proxy sidecar with
+two modes:
+
+- **mTLS mode**: Client certificate authentication with a custom CA
+- **Tailscale mode**: Automatic TLS via Tailscale MagicDNS
+
+Configure via `enable_caddy_proxy`, `caddy_mode`, and related variables
+in the runner-dashboard module.
+
+## Development
+
+```bash
+cd app
+pnpm install
+pnpm dev          # Start dev server
+pnpm check        # Type check
+pnpm test         # Run tests
+pnpm build        # Production build
+```
+
+## See Also
+
+- [OpenTofu Modules](../reference/tofu-modules.md#runner-dashboard) -- deployment configuration
+- [Runners Overview](../runners/README.md) -- the runner pool this dashboard monitors

--- a/docs/guides/cross-forge-ci.md
+++ b/docs/guides/cross-forge-ci.md
@@ -1,0 +1,146 @@
+---
+title: Cross-Forge CI
+order: 2
+---
+
+# Cross-Forge CI
+
+GloriousFlywheel supports both GitLab CI and GitHub Actions from the same
+Kubernetes cluster. This guide shows equivalent configurations side by side.
+
+## Quick Comparison
+
+| Feature | GitLab CI | GitHub Actions |
+|---------|-----------|----------------|
+| Config file | `.gitlab-ci.yml` | `.github/workflows/*.yml` |
+| Runner selection | `tags: [docker]` | `runs-on: tinyland-docker` |
+| Scaling | HPA (always-warm) | ARC (scale-to-zero) |
+| Cache access | Auto-injected env vars | Auto-injected env vars |
+| Reusable configs | CI/CD Components | Composite Actions |
+| CLI tool | `glab` | `gh` |
+
+## Equivalent Jobs
+
+### Simple Build
+
+**GitLab CI:**
+
+```yaml
+build:
+  tags: [docker]
+  script:
+    - make build
+```
+
+**GitHub Actions:**
+
+```yaml
+jobs:
+  build:
+    runs-on: tinyland-docker
+    steps:
+      - uses: actions/checkout@v4
+      - run: make build
+```
+
+### Nix Build with Cache
+
+**GitLab CI:**
+
+```yaml
+build:
+  tags: [nix]
+  script:
+    - nix build .#default
+    - attic push main result
+```
+
+**GitHub Actions:**
+
+```yaml
+jobs:
+  build:
+    runs-on: tinyland-nix
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@main
+        with:
+          command: nix build .#default
+          push-cache: "true"
+```
+
+### Docker Image Build
+
+**GitLab CI:**
+
+```yaml
+build-image:
+  tags: [dind]
+  services:
+    - docker:dind
+  script:
+    - docker build -t $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA .
+    - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+```
+
+**GitHub Actions:**
+
+```yaml
+jobs:
+  build-image:
+    runs-on: tinyland-dind
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          docker build -t ghcr.io/${{ github.repository }}:${{ github.sha }} .
+          docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
+```
+
+## CLI Commands
+
+### Pipeline / Workflow Status
+
+```bash
+# GitLab
+glab ci status
+glab ci view
+
+# GitHub
+gh run list
+gh run view <run-id>
+```
+
+### Create Merge Request / Pull Request
+
+```bash
+# GitLab
+glab mr create --fill --squash-before-merge
+
+# GitHub
+gh pr create --fill
+```
+
+### View CI Logs
+
+```bash
+# GitLab
+glab ci trace
+
+# GitHub
+gh run view <run-id> --log
+```
+
+## When to Use Which Forge
+
+| Scenario | Recommended Forge | Reason |
+|----------|-------------------|--------|
+| IaC changes (this repo) | GitLab | State backend on GitLab, CI/CD Components |
+| Open source projects | GitHub | Community visibility, Actions marketplace |
+| Private org projects | Either | Both have full runner access |
+| Nix builds | Either | Both use the same Attic cache |
+
+## See Also
+
+- [GitHub App Adoption](github-app-adoption.md) -- install GloriousFlywheel on your org
+- [Self-Service Enrollment](../runners/self-service-enrollment.md) -- GitLab runner enrollment
+- [GitHub Actions Runners](../runners/github-actions.md) -- ARC runner details

--- a/docs/guides/github-app-adoption.md
+++ b/docs/guides/github-app-adoption.md
@@ -1,0 +1,153 @@
+---
+title: GitHub App Adoption
+order: 1
+---
+
+# GitHub App Adoption
+
+GloriousFlywheel uses a GitHub App to authenticate ARC (Actions Runner
+Controller) with GitHub. This guide explains how to install the app on
+your organization and configure runner access.
+
+## What is GloriousFlywheel?
+
+GloriousFlywheel is a GitHub App (ID 2953466) that enables self-hosted
+GitHub Actions runners via ARC. It listens for `workflow_job` webhook
+events and scales runner pods on demand.
+
+## Install on a New Organization
+
+1. Navigate to the GitHub App settings page
+2. Click **Install** and select the target organization
+3. Choose **All repositories** or select specific repos
+4. Approve the installation
+
+### Required Permissions
+
+| Permission | Scope | Access |
+|-----------|-------|--------|
+| Self-hosted runners | Organization | Read & Write |
+| Metadata | Repository | Read-only |
+| Actions | Repository | Read-only |
+
+### Webhook Events
+
+The app subscribes to `workflow_job` events. These trigger runner
+pod creation when a job matches a self-hosted runner label.
+
+## Kubernetes Secret Setup
+
+ARC authenticates using a Kubernetes secret containing the GitHub App
+credentials. This secret **must exist in both namespaces**:
+
+- `arc-systems` -- used by the ARC controller for API authentication
+- `arc-runners` -- used by runner scale sets for registration
+
+```bash
+# Create the secret in both namespaces
+for ns in arc-systems arc-runners; do
+  kubectl create secret generic github-app-secret \
+    --namespace="$ns" \
+    --from-literal=github_app_id=2953466 \
+    --from-literal=github_app_installation_id=<INSTALLATION_ID> \
+    --from-file=github_app_pem=<PATH_TO_PEM_FILE>
+done
+```
+
+## Runner Group Configuration
+
+The default runner group must allow public repositories if you want
+self-hosted runners available to public repos:
+
+```bash
+gh api -X PATCH /orgs/<ORG>/actions/runner-groups/1 \
+  -f allows_public_repositories=true
+```
+
+Without this, workflows in public repos will fail to match self-hosted
+runner labels.
+
+## Deploy the ARC Stack
+
+```bash
+cd tofu/stacks/arc-runners
+tofu init
+tofu plan -var-file=tinyland.tfvars \
+  -var=cluster_context=tinyland-civo-dev \
+  -var=k8s_config_path=$HOME/.kube/config
+tofu apply -var-file=tinyland.tfvars \
+  -var=cluster_context=tinyland-civo-dev \
+  -var=k8s_config_path=$HOME/.kube/config
+```
+
+This deploys:
+- ARC controller in `arc-systems`
+- Three runner scale sets (gh-nix, gh-docker, gh-dind) in `arc-runners`
+
+## Composite Actions
+
+GloriousFlywheel provides composite actions that auto-configure cache
+endpoints on self-hosted runners:
+
+| Action | Description |
+|--------|------------|
+| `setup-flywheel` | Detect runner environment, configure cache endpoints |
+| `nix-job` | Nix build with Attic binary cache |
+| `docker-job` | Standard CI job with Bazel cache |
+
+### Usage
+
+```yaml
+jobs:
+  build:
+    runs-on: tinyland-nix
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tinyland-inc/GloriousFlywheel/.github/actions/nix-job@main
+        with:
+          command: nix build .#default
+          push-cache: "true"
+```
+
+## Workflow Examples
+
+### Simple Nix Build
+
+```yaml
+name: Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: tinyland-nix
+    steps:
+      - uses: actions/checkout@v4
+      - run: nix build
+```
+
+### Docker Build
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: tinyland-docker
+    steps:
+      - uses: actions/checkout@v4
+      - run: make test
+
+  build-image:
+    runs-on: tinyland-dind
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -t myapp .
+```
+
+## See Also
+
+- [GitHub Actions Runners](../runners/github-actions.md) -- runner labels, cache integration, architecture
+- [Cross-Forge CI](cross-forge-ci.md) -- GitLab CI vs GitHub Actions comparison
+- [Runner Selection Guide](../runners/runner-selection.md) -- choosing the right runner type

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,8 +45,10 @@ clusters.
 
 ## Runners
 
-- [Overview](runners/README.md) -- 5 runner types
+- [Overview](runners/README.md) -- cross-forge runner pool (GitLab CI + GitHub Actions)
 - [Selection Guide](runners/runner-selection.md) -- which runner to use
+- [GitHub Actions Runners](runners/github-actions.md) -- ARC setup, composite actions, cache integration
+- [Self-Service Enrollment](runners/self-service-enrollment.md) -- onboard your project
 - [Runbook](runners/runbook.md) -- operational procedures
 
 ## CI/CD
@@ -54,6 +56,15 @@ clusters.
 - [Pipeline Overview](ci-cd/pipeline-overview.md) -- 4-stage pipeline
 - [Overlay Pipelines](ci-cd/overlay-pipelines.md) -- how overlays extend CI
 - [Deployment Flow](ci-cd/deployment-flow.md) -- commit to production
+
+## Guides
+
+- [GitHub App Adoption](guides/github-app-adoption.md) -- install GloriousFlywheel on your org
+- [Cross-Forge CI](guides/cross-forge-ci.md) -- GitLab CI vs GitHub Actions side-by-side
+
+## Dashboard
+
+- [Dashboard Overview](dashboard/overview.md) -- architecture, features, auth
 
 ## Reference
 

--- a/docs/runners/README.md
+++ b/docs/runners/README.md
@@ -5,40 +5,90 @@ order: 1
 
 # Runners Overview
 
-This project deploys five GitLab CI runner types on Kubernetes via the
-GitLab Runner Helm chart. Each runner targets a specific workload profile.
-All runners are managed by the `gitlab-runner` OpenTofu module and configured
-through `organization.yaml`.
+GloriousFlywheel provides a cross-forge runner pool that serves both
+GitLab CI and GitHub Actions from the same Kubernetes cluster. Six runner
+types are deployed across two scaling models.
 
 ## Runner Types
 
-| Runner | Base Image | Privileged | Docker Builds | Package Manager | Use Case |
-|--------|-----------|------------|---------------|-----------------|----------|
-| docker | Alpine | No | No | apk | General CI jobs |
-| dind | Alpine + Docker | Yes | Yes | apk | Container builds |
-| rocky8 | Rocky Linux 8 | No | No | dnf (glibc 2.28) | RHEL 8 compatibility |
-| rocky9 | Rocky Linux 9 | No | No | dnf (glibc 2.34) | RHEL 9 compatibility |
-| nix | NixOS | No | No | nix | Reproducible builds |
+| Runner | Forge | Scaling | Base Image | Privileged | Use Case |
+|--------|-------|---------|-----------|------------|----------|
+| `{prefix}-docker` | GitLab CI | HPA | Alpine | No | General CI jobs |
+| `{prefix}-dind` | GitLab CI | HPA | Alpine + Docker | Yes | Container builds |
+| `{prefix}-nix` | GitLab CI | HPA | NixOS | No | Reproducible builds |
+| `gh-docker` | GitHub Actions | ARC | Alpine | No | General CI jobs |
+| `gh-dind` | GitHub Actions | ARC | Alpine + Docker | Yes | Container builds |
+| `gh-nix` | GitHub Actions | ARC | NixOS | No | Reproducible builds |
+
+## Scaling Models
+
+**GitLab runners** use Kubernetes HorizontalPodAutoscalers (HPA) with
+configurable min/max replicas and CPU-based scaling. Runners are always
+warm with at least one replica.
+
+**GitHub Actions runners** use ARC (Actions Runner Controller) scale sets
+with scale-to-zero. Runner pods are created on demand when a workflow job
+matches the `runs-on` label and terminated after the job completes.
+
+## Namespace Layout
+
+```mermaid
+graph TD
+    subgraph cluster["Kubernetes Cluster"]
+        subgraph ns_gl["gitlab-runners namespace"]
+            GL_NIX["{prefix}-nix"]
+            GL_DOCKER["{prefix}-docker"]
+            GL_DIND["{prefix}-dind"]
+        end
+        subgraph ns_arc_sys["arc-systems namespace"]
+            CTRL["ARC Controller"]
+        end
+        subgraph ns_arc["arc-runners namespace"]
+            GH_NIX["gh-nix"]
+            GH_DOCKER["gh-docker"]
+            GH_DIND["gh-dind"]
+        end
+        subgraph ns_cache["nix-cache namespace"]
+            ATTIC["Attic API"]
+            BAZEL["Bazel Cache"]
+        end
+    end
+    GL_NIX -->|"cluster DNS"| ATTIC
+    GH_NIX -->|"cluster DNS"| ATTIC
+    GL_NIX --> BAZEL
+    GH_NIX --> BAZEL
+    CTRL -->|"manages"| GH_NIX
+    CTRL -->|"manages"| GH_DOCKER
+    CTRL -->|"manages"| GH_DIND
+```
 
 ## Common Properties
 
-- **Deployment method**: Kubernetes-deployed via the GitLab Runner Helm chart.
-- **Autoscaling**: Each runner type has an independent HorizontalPodAutoscaler
-  configured for 1--5 replicas, with a 15-second scale-up stabilization window
-  and a 5-minute scale-down stabilization window.
-- **Nix integration**: Nix runners auto-configure the `ATTIC_SERVER` and
+- **Cache integration**: All runners access the Attic Nix binary cache and
+  Bazel remote cache via cluster-internal DNS. No Ingress or credentials
+  required for cache access.
+- **Infrastructure as Code**: Deployed via OpenTofu modules in
+  `tofu/modules/gitlab-runner/` and `tofu/modules/arc-runner/`.
+- **Nix integration**: Nix runners auto-configure `ATTIC_SERVER` and
   `ATTIC_CACHE` environment variables for transparent binary cache access.
-- **Infrastructure**: Deployed via the `gitlab-runner` OpenTofu module in
-  `tofu/modules/gitlab-runner/`.
 
 ## Further Reading
+
+### GitLab CI Runners
 
 - [Runner Selection Guide](runner-selection.md) -- how to choose the right runner
 - [Docker Builds](docker-builds.md) -- Docker-in-Docker configuration
 - [Nix Builds](nix-builds.md) -- Nix flake and Attic cache patterns
 - [HPA Tuning](hpa-tuning.md) -- autoscaler configuration
+- [Self-Service Enrollment](self-service-enrollment.md) -- onboard your project
+
+### GitHub Actions Runners
+
+- [GitHub Actions Runners](github-actions.md) -- ARC setup, composite actions, cache integration
+
+### Operations
+
 - [Security Model](security-model.md) -- privilege and access boundaries
 - [Troubleshooting](troubleshooting.md) -- common issues and fixes
 - [Runbook](runbook.md) -- operational procedures
-- [Project Onboarding](project-onboarding.md) -- enroll a project on the runner pool
 - [Resource Limits](resource-limits.md) -- job pod resource limits reference

--- a/docs/runners/github-actions.md
+++ b/docs/runners/github-actions.md
@@ -1,3 +1,8 @@
+---
+title: GitHub Actions Runners
+order: 15
+---
+
 # GitHub Actions Runners
 
 Self-hosted GitHub Actions runners powered by ARC (Actions Runner Controller)

--- a/docs/runners/self-service-enrollment.md
+++ b/docs/runners/self-service-enrollment.md
@@ -18,20 +18,12 @@ No registration tokens, no admin requests. Add tags and go.
 
 ## Runner Types
 
-| Type   | Tags                           | Use Case                                 |
-| ------ | ------------------------------ | ---------------------------------------- |
-| docker | `docker`, `linux`, `amd64`     | General CI: linting, testing, builds     |
-| dind   | `docker`, `dind`, `privileged` | Docker-in-Docker: container image builds |
-| rocky8 | `rocky8`, `rhel8`, `linux`     | RHEL 8 compatibility testing             |
-| rocky9 | `rocky9`, `rhel9`, `linux`     | RHEL 9 compatibility testing             |
-| nix    | `nix`, `flakes`                | Nix builds with Attic binary cache       |
+See the [Runner Selection Guide](runner-selection.md) for the full
+capabilities matrix and decision tree. The three core types are:
 
-**Choosing a runner:**
-
-- Default to `docker` for most workloads.
-- Use `dind` only when you need to build container images (`docker build`).
-- Use `rocky8`/`rocky9` when your target is RHEL and you need OS-level packages.
-- Use `nix` for Nix flake builds; the Attic cache is pre-configured.
+- **docker** (tags: `docker`, `linux`, `amd64`) -- default for most jobs
+- **dind** (tags: `dind`, `privileged`) -- Docker-in-Docker container builds
+- **nix** (tags: `nix`, `flakes`) -- Nix flake builds with Attic cache
 
 ## CI/CD Components
 


### PR DESCRIPTION
## Summary

- Fix README typos and add ARC runners to Quick Start
- Rewrite runner overview from GitLab-only to cross-forge (GitLab CI + GitHub Actions/ARC)
- Deduplicate runner tables, replace Bates-specific names with generic `{prefix}` pattern
- Rewrite tofu-modules reference for actual 15-module inventory (remove phantom modules)
- Add GitHub App adoption guide and cross-forge CI comparison guide
- Add dashboard architecture overview and update getting-started with ARC stack
- Add lychee external link checking to CI
- Split llms.txt into structured index + full content per llms.txt spec

## Test plan

- [x] `node scripts/check-links.js --mode markdown` — 184 links across 54 files, all OK
- [x] `node docs-site/scripts/generate-llms-txt.js` — generates llms.txt (8.6 KB) + llms-full.txt (300 KB)
- [ ] CI: validate.yml passes (including new `check-external-links` job)
- [ ] Review new docs: guides/github-app-adoption.md, guides/cross-forge-ci.md, dashboard/overview.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)