### PR TITLE
feat(arc): support multi-scope runner scale sets

### DIFF
--- a/docs/runners/github-actions.md
+++ b/docs/runners/github-actions.md
@@ -136,6 +136,7 @@ Credentials are stored as a Kubernetes secret in the `arc-systems` namespace.
 
 ## See Also
 
+- [Multi-Org / Cross-Repo Runners](../guides/github-app-adoption.md#multi-org--cross-repo-runners) -- add runners for personal repos or other orgs
 - [Self-Service Enrollment](self-service-enrollment.md) -- GitLab runner enrollment
 - [Cache Integration](cache-integration.md) -- cache configuration details
 - [Runner Selection](runner-selection.md) -- choosing the right runner type

--- a/tofu/stacks/arc-runners/main.tf
+++ b/tofu/stacks/arc-runners/main.tf
@@ -154,6 +154,35 @@ module "gh_dind" {
 }
 
 # =============================================================================
+# Extra Runner Scale Sets (multi-org / cross-repo)
+# =============================================================================
+
+module "extra_runners" {
+  source   = "../../modules/arc-runner"
+  for_each = var.extra_runner_sets
+
+  runner_name          = each.key
+  runner_label         = each.value.runner_label
+  runner_type          = each.value.runner_type
+  namespace            = var.runner_namespace
+  controller_namespace = var.controller_namespace
+  github_config_url    = each.value.github_config_url
+  github_config_secret = each.value.github_config_secret
+  min_runners          = each.value.min_runners
+  max_runners          = each.value.max_runners
+  cpu_request          = each.value.cpu_request
+  memory_request       = each.value.memory_request
+  cpu_limit            = each.value.cpu_limit
+  memory_limit         = each.value.memory_limit
+  attic_server         = each.value.attic_server
+  attic_cache          = each.value.attic_cache
+  bazel_cache_endpoint = each.value.bazel_cache_endpoint
+  image_pull_secrets   = local.ghcr_pull_secrets
+
+  depends_on = [module.arc_controller, kubernetes_namespace_v1.arc_runners]
+}
+
+# =============================================================================
 # GHCR Registry Auth (imagePullSecret)
 # =============================================================================
 

--- a/tofu/stacks/arc-runners/outputs.tf
+++ b/tofu/stacks/arc-runners/outputs.tf
@@ -44,3 +44,8 @@ output "runner_namespace" {
   description = "Runner scale sets namespace"
   value       = var.runner_namespace
 }
+
+output "extra_runner_labels" {
+  description = "Labels for extra runner scale sets"
+  value       = { for k, v in module.extra_runners : k => v.runner_label }
+}

--- a/tofu/stacks/arc-runners/variables.tf
+++ b/tofu/stacks/arc-runners/variables.tf
@@ -253,3 +253,27 @@ variable "ghcr_username" {
   type        = string
   default     = "tinyland-inc"
 }
+
+# =============================================================================
+# Extra Runner Scale Sets (multi-org / cross-repo)
+# =============================================================================
+
+variable "extra_runner_sets" {
+  description = "Additional runner scale sets for external repos/orgs (keyed by unique name)"
+  type = map(object({
+    github_config_url    = string
+    github_config_secret = optional(string, "github-app-secret")
+    runner_label         = string
+    runner_type          = optional(string, "nix")
+    min_runners          = optional(number, 0)
+    max_runners          = optional(number, 5)
+    cpu_request          = optional(string, "500m")
+    memory_request       = optional(string, "1Gi")
+    cpu_limit            = optional(string, "4")
+    memory_limit         = optional(string, "8Gi")
+    attic_server         = optional(string, "")
+    attic_cache          = optional(string, "main")
+    bazel_cache_endpoint = optional(string, "")
+  }))
+  default = {}
+}


### PR DESCRIPTION
## Summary

- Add `extra_runner_sets` map variable to the `arc-runners` stack, enabling additional AutoscalingRunnerSets scoped to different GitHub orgs or individual repositories
- Each entry deploys a separate `arc-runner` module instance via `for_each`, sharing the same ARC controller and runner namespace
- Add `extra_runner_labels` output for downstream consumption
- Document multi-org workflow in `docs/guides/github-app-adoption.md`: install App, create K8s secret, add tfvars entry, use new `runs-on` label
- Cross-reference from `docs/runners/github-actions.md`

Closes #71

## Test plan

- [ ] `tofu init -backend=false && tofu validate` passes (empty `extra_runner_sets`)
- [ ] `tofu plan -var-file=tinyland.tfvars` shows no diff for existing resources
- [ ] CI `validate-tofu` matrix passes for `arc-runners` stack
- [ ] End-to-end: install App on target account, create secret, add `extra_runner_sets` entry, apply, run workflow with new label