### PR TITLE
refactor(tofu): genericize tinyland-inc variable defaults

### DIFF
--- a/tofu/modules/runner-dashboard/variables.tf
+++ b/tofu/modules/runner-dashboard/variables.tf
@@ -116,7 +116,7 @@ variable "default_env" {
 variable "prometheus_url" {
   description = "Prometheus server URL for metrics queries"
   type        = string
-  default     = "http://prometheus.tinyland-staging.svc.cluster.local:9090"
+  default     = ""
 }
 
 # =============================================================================

--- a/tofu/stacks/arc-runners/main.tf
+++ b/tofu/stacks/arc-runners/main.tf
@@ -160,6 +160,13 @@ module "gh_dind" {
 resource "kubernetes_secret" "ghcr_auth_controller" {
   count = var.ghcr_token != "" ? 1 : 0
 
+  lifecycle {
+    precondition {
+      condition     = var.ghcr_username != ""
+      error_message = "ghcr_username is required when ghcr_token is set"
+    }
+  }
+
   metadata {
     name      = "ghcr-auth"
     namespace = var.controller_namespace

--- a/tofu/stacks/arc-runners/variables.tf
+++ b/tofu/stacks/arc-runners/variables.tf
@@ -22,7 +22,11 @@ variable "cluster_context" {
 variable "github_config_url" {
   description = "GitHub organization or repository URL for runner registration"
   type        = string
-  default     = "https://github.com/tinyland-inc"
+
+  validation {
+    condition     = can(regex("^https://github\\.com/.+", var.github_config_url))
+    error_message = "github_config_url must be a GitHub URL (e.g. https://github.com/my-org)"
+  }
 }
 
 variable "github_config_secret" {
@@ -251,5 +255,5 @@ variable "ghcr_token" {
 variable "ghcr_username" {
   description = "GHCR username for image pull authentication"
   type        = string
-  default     = "tinyland-inc"
+  default     = ""
 }

--- a/tofu/stacks/gitlab-runners/main.tf
+++ b/tofu/stacks/gitlab-runners/main.tf
@@ -166,6 +166,13 @@ module "dind_runner" {
 resource "kubernetes_secret" "ghcr_auth" {
   count = var.ghcr_token != "" ? 1 : 0
 
+  lifecycle {
+    precondition {
+      condition     = var.ghcr_username != ""
+      error_message = "ghcr_username is required when ghcr_token is set"
+    }
+  }
+
   metadata {
     name      = "ghcr-auth"
     namespace = var.namespace

--- a/tofu/stacks/gitlab-runners/variables.tf
+++ b/tofu/stacks/gitlab-runners/variables.tf
@@ -319,7 +319,7 @@ variable "enable_runner_cleanup" {
 variable "kubectl_image" {
   description = "Container image for kubectl (cleanup job)"
   type        = string
-  default     = "ghcr.io/tinyland-inc/kubectl:latest"
+  default     = "bitnami/kubectl:latest"
 }
 
 # =============================================================================
@@ -336,5 +336,5 @@ variable "ghcr_token" {
 variable "ghcr_username" {
   description = "GHCR username for image pull authentication"
   type        = string
-  default     = "tinyland-inc"
+  default     = ""
 }


### PR DESCRIPTION
## Summary

- Remove hardcoded `tinyland-inc` defaults from upstream-consumable variables across 3 stacks/modules
- `github_config_url` is now required with URL format validation (was defaulting to `https://github.com/tinyland-inc`)
- `ghcr_username` defaults to `""` in arc-runners and gitlab-runners (was `tinyland-inc`)
- `kubectl_image` defaults to `bitnami/kubectl:latest` (was `ghcr.io/tinyland-inc/kubectl:latest`)
- `prometheus_url` defaults to `""` in runner-dashboard module (was tinyland-staging internal URL)
- Add precondition: `ghcr_username` required when `ghcr_token` is set

No functional changes — tinyland.tfvars already provides all these values explicitly.

## Test plan

- [ ] `tofu validate` passes for arc-runners, gitlab-runners, and runner-dashboard stacks
- [ ] `tofu plan -var-file=tinyland.tfvars` shows no diff for existing deployments
- [ ] CI `validate-tofu` matrix passes