### PR TITLE
fix(nix-job): install xz-utils on self-hosted ARC runners

### DIFF
--- a/.github/actions/nix-job/action.yml
+++ b/.github/actions/nix-job/action.yml
@@ -18,6 +18,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Install Nix prerequisites
+      if: runner.environment != 'github-hosted'
+      shell: bash
+      run: |
+        if ! command -v xz &>/dev/null; then
+          sudo apt-get update -qq && sudo apt-get install -y -qq xz-utils
+        fi
+
     - uses: cachix/install-nix-action@v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION
## Summary

- Install `xz-utils` on self-hosted runners before `cachix/install-nix-action` runs
- Only triggers on non-github-hosted runners (no-op on `ubuntu-latest`)
- Skips if `xz` is already available

The `ghcr.io/actions/actions-runner:latest` base image doesn't include `xz-utils`, which the Nix installer needs to unpack the binary tarball. This was discovered when deploying `chapel-nix` runners for `Jesssullivan/chapel`.

## Test plan

- [ ] CI passes on this PR
- [ ] Re-run chapel workflow after merge — Nix install succeeds