### PR TITLE
fix(attic): pass cert_manager_issuer to bazel-cache module

### DIFF
--- a/tofu/stacks/attic/main.tf
+++ b/tofu/stacks/attic/main.tf
@@ -1318,8 +1318,9 @@ module "bazel_cache" {
   memory_limit   = var.bazel_cache_memory_limit
 
   # Ingress (optional)
-  enable_ingress = var.bazel_cache_enable_ingress
-  ingress_host   = var.bazel_cache_ingress_host != "" ? var.bazel_cache_ingress_host : "bazel-cache.${var.ingress_domain}"
+  enable_ingress      = var.bazel_cache_enable_ingress
+  ingress_host        = var.bazel_cache_ingress_host != "" ? var.bazel_cache_ingress_host : "bazel-cache.${var.ingress_domain}"
+  cert_manager_issuer = var.cert_manager_issuer
 
   # Monitoring
   enable_metrics         = var.enable_prometheus_monitoring


### PR DESCRIPTION
## Summary
- Pass `cert_manager_issuer` from the attic stack through to the `bazel_cache` module
- Without this, bazel-cache defaults to `letsencrypt-prod` even when the stack uses a different issuer (e.g. sectigo)

## Test plan
- [x] Verified bazel-cache module accepts `cert_manager_issuer` variable
- [x] Confirmed the variable is used in ingress annotations
- [ ] Deploy to rketest2 and verify bazel-cache TLS cert uses sectigo issuer