### PR TITLE
feat(devtools): add dhall and dhall-json to devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,10 @@
             skopeo
             dive
 
+            # Configuration language (typed tfvars generation)
+            dhall
+            dhall-json
+
             # Development utilities
             jq
             yq-go


### PR DESCRIPTION
## Summary

Add `dhall` and `dhall-json` to the Nix devShell's `devTools` list.

Overlays using Dhall for typed tfvars generation (like gf-overlay) need these tools in the development environment. Adding them to the upstream devShell ensures CI/local parity for all consumers.

## Changes

- `flake.nix`: Add `dhall` and `dhall-json` packages to `devTools`

Both packages are available in nixpkgs (dhall 1.42.1, dhall-json 1.7.12).