### PR TITLE
feat(dashboard): Skeleton 4.12 Popover for HPA cards + Prometheus retry

### DIFF
--- a/app/src/lib/components/metrics/HPAGauge.svelte
+++ b/app/src/lib/components/metrics/HPAGauge.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import type { HPAStatus } from '$lib/types';
+	import { Popover } from '@skeletonlabs/skeleton-svelte';
+	import type { HPAStatus, Forge } from '$lib/types';
 
 	let { hpa }: { hpa: HPAStatus } = $props();
 
@@ -17,57 +18,133 @@
 		if (ratio >= 0.7) return 'bg-yellow-500';
 		return 'bg-green-500';
 	}
+
+	function forgeBadge(forge?: Forge): string {
+		return forge === 'github' ? 'GH' : 'GL';
+	}
+
+	function forgeBadgeClass(forge?: Forge): string {
+		return forge === 'github' ? 'bg-gray-700 text-white' : 'bg-orange-600 text-white';
+	}
+
+	function scalingLabel(hpa: HPAStatus): string {
+		if (hpa.scaling_model === 'arc') {
+			return hpa.min_replicas === 0 ? 'ARC (scale-to-zero)' : 'ARC';
+		}
+		return 'HPA';
+	}
+
+	function conditionIcon(status: string): string {
+		return status === 'True' ? '✓' : '✗';
+	}
 </script>
 
-<div class="card p-4 bg-surface-100-800 rounded-lg border border-surface-300-600">
-	<div class="flex items-center justify-between mb-3">
-		<h4 class="font-medium">{hpa.name}</h4>
-		<span class="text-sm text-surface-500">
-			{hpa.current_replicas}/{hpa.max_replicas} replicas
-		</span>
-	</div>
-
-	<div class="space-y-2">
-		<!-- CPU bar -->
-		<div>
-			<div class="flex justify-between text-xs text-surface-500 mb-0.5">
-				<span>CPU</span>
-				<span>{cpuPercent}% / {cpuTarget}%</span>
+<Popover positioning={{ placement: 'bottom' }} portalled>
+	<Popover.Trigger class="w-full text-left cursor-pointer card p-4 bg-surface-100-800 rounded-lg border border-surface-300-600 hover:border-primary-500/50 transition-colors">
+		<div class="flex items-center justify-between mb-3">
+			<div class="flex items-center gap-2">
+				<span class="font-medium">{hpa.name}</span>
+				<span class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded {forgeBadgeClass(hpa.forge)}">
+					{forgeBadge(hpa.forge)}
+				</span>
+				<span class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded bg-surface-300-600 text-surface-700-200">
+					{scalingLabel(hpa)}
+				</span>
 			</div>
-			<div class="w-full h-2 bg-surface-300-600 rounded-full overflow-hidden">
-				<div
-					class="h-full rounded-full transition-all {barColor(cpuPercent, cpuTarget)}"
-					style:width="{Math.min(cpuPercent, 100)}%"
-				></div>
-			</div>
+			<span class="text-sm text-surface-500">
+				{hpa.current_replicas}/{hpa.max_replicas} replicas
+			</span>
 		</div>
 
-		<!-- Memory bar -->
-		<div>
-			<div class="flex justify-between text-xs text-surface-500 mb-0.5">
-				<span>Memory</span>
-				<span>{memPercent}% / {memTarget}%</span>
+		<div class="space-y-2">
+			<div>
+				<div class="flex justify-between text-xs text-surface-500 mb-0.5">
+					<span>CPU</span>
+					<span>{cpuPercent}% / {cpuTarget}%</span>
+				</div>
+				<div class="w-full h-2 bg-surface-300-600 rounded-full overflow-hidden">
+					<div
+						class="h-full rounded-full transition-all {barColor(cpuPercent, cpuTarget)}"
+						style:width="{Math.min(cpuPercent, 100)}%"
+					></div>
+				</div>
 			</div>
-			<div class="w-full h-2 bg-surface-300-600 rounded-full overflow-hidden">
-				<div
-					class="h-full rounded-full transition-all {barColor(memPercent, memTarget)}"
-					style:width="{Math.min(memPercent, 100)}%"
-				></div>
-			</div>
-		</div>
 
-		<!-- Replica bar -->
-		<div>
-			<div class="flex justify-between text-xs text-surface-500 mb-0.5">
-				<span>Scale</span>
-				<span>{hpa.current_replicas} ({hpa.min_replicas}-{hpa.max_replicas})</span>
+			<div>
+				<div class="flex justify-between text-xs text-surface-500 mb-0.5">
+					<span>Memory</span>
+					<span>{memPercent}% / {memTarget}%</span>
+				</div>
+				<div class="w-full h-2 bg-surface-300-600 rounded-full overflow-hidden">
+					<div
+						class="h-full rounded-full transition-all {barColor(memPercent, memTarget)}"
+						style:width="{Math.min(memPercent, 100)}%"
+					></div>
+				</div>
 			</div>
-			<div class="w-full h-2 bg-surface-300-600 rounded-full overflow-hidden">
-				<div
-					class="h-full rounded-full transition-all bg-primary-500"
-					style:width="{Math.min(replicaPercent, 100)}%"
-				></div>
+
+			<div>
+				<div class="flex justify-between text-xs text-surface-500 mb-0.5">
+					<span>Scale</span>
+					<span>{hpa.current_replicas} ({hpa.min_replicas}-{hpa.max_replicas})</span>
+				</div>
+				<div class="w-full h-2 bg-surface-300-600 rounded-full overflow-hidden">
+					<div
+						class="h-full rounded-full transition-all bg-primary-500"
+						style:width="{Math.min(replicaPercent, 100)}%"
+					></div>
+				</div>
 			</div>
 		</div>
-	</div>
-</div>
+	</Popover.Trigger>
+	<Popover.Positioner>
+		<Popover.Content class="card p-4 bg-surface-100-800 border border-surface-300-600 rounded-lg shadow-xl w-80 z-50">
+			<Popover.Arrow>
+				<Popover.ArrowTip />
+			</Popover.Arrow>
+			<Popover.Title class="text-sm font-semibold mb-2">{hpa.name}</Popover.Title>
+			<Popover.Description>
+				<div class="space-y-3 text-xs">
+					<div class="grid grid-cols-2 gap-x-4 gap-y-1">
+						<span class="text-surface-500">Scaling</span>
+						<span>{scalingLabel(hpa)}</span>
+						<span class="text-surface-500">Current</span>
+						<span>{hpa.current_replicas} replicas</span>
+						<span class="text-surface-500">Desired</span>
+						<span>{hpa.desired_replicas} replicas</span>
+						<span class="text-surface-500">Range</span>
+						<span>{hpa.min_replicas}–{hpa.max_replicas}</span>
+						{#if hpa.cpu_current != null}
+							<span class="text-surface-500">CPU</span>
+							<span>{cpuPercent}% of {cpuTarget}% target</span>
+						{/if}
+						{#if hpa.memory_current != null}
+							<span class="text-surface-500">Memory</span>
+							<span>{memPercent}% of {memTarget}% target</span>
+						{/if}
+					</div>
+					{#if hpa.conditions.length > 0}
+						<div class="border-t border-surface-300-600 pt-2">
+							<span class="text-surface-500 font-medium">Conditions</span>
+							<ul class="mt-1 space-y-0.5">
+								{#each hpa.conditions as cond}
+									<li class="flex items-start gap-1.5">
+										<span class={cond.status === 'True' ? 'text-green-500' : 'text-red-500'}>
+											{conditionIcon(cond.status)}
+										</span>
+										<span>
+											<span class="font-medium">{cond.type}</span>
+											{#if cond.message}
+												— {cond.message}
+											{/if}
+										</span>
+									</li>
+								{/each}
+							</ul>
+						</div>
+					{/if}
+				</div>
+			</Popover.Description>
+		</Popover.Content>
+	</Popover.Positioner>
+</Popover>

--- a/app/src/lib/server/prometheus/client.ts
+++ b/app/src/lib/server/prometheus/client.ts
@@ -33,13 +33,20 @@ interface PrometheusResponse<T> {
 export class PrometheusClient {
   private baseUrl: string;
   private available: boolean | null = null;
+  private availableCheckedAt = 0;
+  private readonly AVAILABILITY_TTL = 60_000;
 
   constructor(baseUrl?: string) {
     this.baseUrl = baseUrl ?? env.PROMETHEUS_URL ?? "http://prometheus:9090";
   }
 
   async isAvailable(): Promise<boolean> {
-    if (this.available !== null) return this.available;
+    if (
+      this.available !== null &&
+      Date.now() - this.availableCheckedAt < this.AVAILABILITY_TTL
+    ) {
+      return this.available;
+    }
     try {
       const response = await fetch(`${this.baseUrl}/-/healthy`, {
         signal: AbortSignal.timeout(3000),
@@ -48,11 +55,13 @@ export class PrometheusClient {
     } catch {
       this.available = false;
     }
+    this.availableCheckedAt = Date.now();
     return this.available;
   }
 
   resetAvailability() {
     this.available = null;
+    this.availableCheckedAt = 0;
   }
 
   async instantQuery(query: string, time?: number): Promise<InstantResult[]> {

--- a/app/src/routes/monitoring/+page.svelte
+++ b/app/src/routes/monitoring/+page.svelte
@@ -21,20 +21,11 @@
 	);
 
 	function forgeBadge(forge?: Forge): string {
-		if (forge === 'github') return 'GH';
-		return 'GL';
+		return forge === 'github' ? 'GH' : 'GL';
 	}
 
 	function forgeBadgeClass(forge?: Forge): string {
-		if (forge === 'github') return 'bg-gray-700 text-white';
-		return 'bg-orange-600 text-white';
-	}
-
-	function scalingLabel(hpa: HPAStatus): string {
-		if (hpa.scaling_model === 'arc') {
-			return hpa.min_replicas === 0 ? 'ARC (scale-to-zero)' : 'ARC';
-		}
-		return 'HPA';
+		return forge === 'github' ? 'bg-gray-700 text-white' : 'bg-orange-600 text-white';
 	}
 </script>
 
@@ -85,23 +76,7 @@
 		<h3 class="text-lg font-semibold mb-3">Autoscaling</h3>
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 			{#each filteredHpas as hpa}
-				<div class="relative">
-					<div class="absolute top-2 right-2 flex gap-1 z-10">
-						<span
-							class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded {forgeBadgeClass(
-								hpa.forge
-							)}"
-						>
-							{forgeBadge(hpa.forge)}
-						</span>
-						<span
-							class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded bg-surface-300-600 text-surface-700-200"
-						>
-							{scalingLabel(hpa)}
-						</span>
-					</div>
-					<HPAGauge {hpa} />
-				</div>
+				<HPAGauge {hpa} />
 			{/each}
 		</div>
 	</div>


### PR DESCRIPTION
- HPA cards use Skeleton Popover for detail overlay (replicas, conditions, utilization)
- Badges moved into card header from absolute-positioned overlay
- PrometheusClient retries availability every 60s instead of caching permanently

-Jess