### PR TITLE
fix: correct Attic service DNS name

### DIFF
--- a/.github/actions/setup-flywheel/action.yml
+++ b/.github/actions/setup-flywheel/action.yml
@@ -21,7 +21,7 @@ runs:
         if [ "${{ runner.environment }}" != "github-hosted" ]; then
           # Self-hosted ARC runners have cluster DNS access
           ATTIC="${{ inputs.attic-server }}"
-          ATTIC_URL="${ATTIC:-${ATTIC_SERVER:-http://attic-api.nix-cache.svc.cluster.local:8080}}"
+          ATTIC_URL="${ATTIC:-${ATTIC_SERVER:-http://attic.nix-cache.svc.cluster.local:8080}}"
 
           # Verify Attic DNS is reachable before setting (avoids hard failures downstream)
           ATTIC_HOST=$(echo "$ATTIC_URL" | sed 's|https\?://||;s|:.*||')

--- a/.github/workflows/test-arc-runners.yml
+++ b/.github/workflows/test-arc-runners.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Test cache connectivity
         run: |
           echo "=== Attic cache ==="
-          curl -sf http://attic-api.nix-cache.svc.cluster.local:8080 && echo "OK" || echo "UNREACHABLE"
+          curl -sf http://attic.nix-cache.svc.cluster.local:8080 && echo "OK" || echo "UNREACHABLE"
           echo ""
           echo "=== Bazel cache ==="
           curl -sf grpc://bazel-cache.nix-cache.svc.cluster.local:9092 2>/dev/null && echo "OK" || echo "(expected: grpc is not curl-able, but DNS resolves)"


### PR DESCRIPTION
## Summary
- Fix service DNS: `attic-api.nix-cache.svc.cluster.local` → `attic.nix-cache.svc.cluster.local`
- Affects `setup-flywheel` action and `test-arc-runners` workflow
- The K8s service has always been named `attic`, not `attic-api`

## Context
Every self-hosted CI build has been running without Nix cache because `getent hosts attic-api...` returned NXDOMAIN. This fix restores cache connectivity now that the Attic fleet is back online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)