### PR TITLE
fix(arc-runner): set containerMode.type for kubernetes mode

### DIFF
--- a/tofu/modules/arc-runner/main.tf
+++ b/tofu/modules/arc-runner/main.tf
@@ -68,12 +68,14 @@ resource "helm_release" "arc_runner" {
     value = var.controller_service_account_name
   }
 
-  # Container mode (dind for privileged Docker builds)
+  # Container mode: kubernetes (supports `container:` in workflows) or dind (privileged Docker)
+  # Without this, the ARC Helm chart defaults to no container mode and the
+  # workflow `container:` directive silently fails looking for a Docker daemon.
   dynamic "set" {
-    for_each = local.container_mode == "dind" ? [1] : []
+    for_each = local.container_mode != "" ? [1] : []
     content {
       name  = "containerMode.type"
-      value = "dind"
+      value = local.container_mode
     }
   }
 

--- a/tofu/stacks/arc-runners/main.tf
+++ b/tofu/stacks/arc-runners/main.tf
@@ -164,6 +164,8 @@ module "extra_runners" {
   runner_name          = each.key
   runner_label         = each.value.runner_label
   runner_type          = each.value.runner_type
+  container_mode       = each.value.container_mode
+  runner_image         = each.value.runner_image
   namespace            = var.runner_namespace
   controller_namespace = var.controller_namespace
   github_config_url    = each.value.github_config_url

--- a/tofu/stacks/arc-runners/terraform.tfvars.example
+++ b/tofu/stacks/arc-runners/terraform.tfvars.example
@@ -18,6 +18,7 @@ docker_memory_limit  = "4Gi"
 # Extra runner scale sets for external repos
 extra_runner_sets = {
   # linux-xr kernel build — needs high memory for kernel compilation + linking
+  # Uses container: rockylinux/rockylinux:10 in workflows for toolchain compat
   linux-xr-docker = {
     github_config_url = "https://github.com/Jesssullivan/linux-xr"
     runner_label      = "linux-xr-docker"

--- a/tofu/stacks/arc-runners/variables.tf
+++ b/tofu/stacks/arc-runners/variables.tf
@@ -269,6 +269,8 @@ variable "extra_runner_sets" {
     github_config_secret = optional(string, "github-app-secret")
     runner_label         = string
     runner_type          = optional(string, "nix")
+    container_mode       = optional(string, "")
+    runner_image         = optional(string, "")
     min_runners          = optional(number, 0)
     max_runners          = optional(number, 5)
     cpu_request          = optional(string, "500m")


### PR DESCRIPTION
## Summary

- The `containerMode.type` Helm value was only set for `dind` runners, leaving `docker`/`nix` runners (which use `kubernetes` mode per `locals.tf`) without it
- Without `containerMode.type=kubernetes`, the ARC chart defaults to no container mode, and the workflow `container:` directive fails with `docker.sock: no such file or directory`
- This blocks `container: rockylinux/rockylinux:10` on the `linux-xr-docker` runner, which is needed to build kernels with Rocky's native toolchain

## Changes

1. **`tofu/modules/arc-runner/main.tf`**: Set `containerMode.type` for ALL non-empty container modes, not just `dind`
2. **`tofu/stacks/arc-runners/variables.tf`**: Add `container_mode` and `runner_image` to `extra_runner_sets` object type
3. **`tofu/stacks/arc-runners/main.tf`**: Pass `container_mode` and `runner_image` through to the module

## Impact

After applying this change and running `tofu apply`:
- `linux-xr-docker` runner will support `container: rockylinux/rockylinux:10` in workflows
- `tinyland-docker` and `tinyland-nix` runners will also get proper `containerMode.type=kubernetes`
- No change to `tinyland-dind` (already correctly set)

## Test plan

- [ ] `tofu plan` shows `containerMode.type = "kubernetes"` added to docker/nix runner Helm values
- [ ] `tofu apply` succeeds
- [ ] `gh workflow run build-kernel.yml -R Jesssullivan/linux-xr -f variant=generic` with `container: rockylinux/rockylinux:10` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)